### PR TITLE
Add product-discovery skill; generalize catalog for APM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 └── assets/*            # テンプレ等
 ```
 
-収録 skill: `skill-builder`, `test-review`, `empirical-prompt-tuning`, `research-practices`（いずれも自作・日本語 description・Anthropic skill best-practices 準拠）。
+収録 skill: `skill-builder`, `test-review`, `empirical-prompt-tuning`, `research-practices`, `product-discovery`（いずれも自作・日本語 description・Anthropic skill best-practices 準拠）。
 
 ## SKILL.md 編集時の規約
 
@@ -50,5 +50,5 @@ uv run python skill-builder/scripts/score_triggers.py \
 ## 新しい skill を足すとき
 
 1. `<name>/SKILL.md` を作る。雛形と self-review チェックリストは `skill-builder/SKILL.md` Mode A。
-2. `README.md` の「出所」表に 1 行追加する。
+2. `README.md` の「概要」表に 1 行追加する。
 3. APM 配布対象なので、`<name>/` のディレクトリ名 = `name` frontmatter にする。

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ upstream を直接依存に書く方針（重複と更新追従の手間を避�
 ├── skill-builder/SKILL.md
 ├── test-review/SKILL.md
 ├── empirical-prompt-tuning/SKILL.md
-└── research-practices/SKILL.md
+├── research-practices/SKILL.md
+└── product-discovery/SKILL.md
 ```
 
 ## 収録 skill
 
-| Skill | 出所 |
+いずれも自作。プロジェクト固有 doctrine への依存を外し、APM (`microsoft/apm`) で `kanade0404/skills/<name>` として project-agnostic に配布する。
+
+| Skill | 概要 |
 | --- | --- |
-| `skill-builder` | 自作（`agegis` で運用していたもの） |
-| `test-review` | 自作（`agegis` で運用していたもの） |
-| `empirical-prompt-tuning` | 自作（`agegis` で運用していたもの） |
-| `research-practices` | 自作（`agegis` で運用していたもの） |
+| `skill-builder` | Claude Code skill のスキャフォールド + trigger / quality eval ループを回すメタスキル |
+| `test-review` | テストコードを Khorikov 4 属性 / Meszaros 17 smells / AI 生成アンチパターンで一貫レビュー（言語・スタック非依存） |
+| `empirical-prompt-tuning` | プロンプトをバイアス排除した実行者で評価し反復改善する手法 |
+| `research-practices` | ライブラリ / 学術 / 業界実践の構造化リサーチワークフロー（CRAAP / SIFT / S0-S5 信頼度タグ） |
+| `product-discovery` | 要求定義（要件定義の前段）。Outcome > Output で PRD を起こし、`prd-review` → `requirements` に渡す |
 
 ## プロジェクトでの利用 (apm.yml)
 

--- a/product-discovery/SKILL.md
+++ b/product-discovery/SKILL.md
@@ -68,7 +68,7 @@ PRD 出力先は **常に `docs/prd/<slug>.md`**（Linear など外部ツール�
 
 ## ワークフロー
 
-```
+```text
 [Phase A: triage]          ── 顧客 / 起動可否 / 既存 PRD diff か新規か
    ↓
 [Phase B: outcome framing] ── 動かしたい outcome を 1 つに絞る (Build Trap 防御)

--- a/product-discovery/SKILL.md
+++ b/product-discovery/SKILL.md
@@ -255,4 +255,4 @@ CLAUDE.md に従い、ユーザとのやり取りおよび PRD 本文は **日�
 - `references/triage-decision.md` — Phase A 判定木と別 skill への振り分け
 - `references/handoff-protocol.md` — prd-review / requirements への引き継ぎ仕様
 - `assets/prd-lean.md.tpl` — Lean PRD テンプレート
-- `evals/trigger.json` — trigger eval 雛形（skill-builder Mode B で利用）
+- `evals/product-discovery-trigger.json` — trigger eval 雛形（skill-builder Mode B で利用）

--- a/product-discovery/SKILL.md
+++ b/product-discovery/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: product-discovery
+description: 要求定義 (PM フェーズ) を進め、ユーザの「やりたい / 困っている」を Outcome > Output で言語化して Lean PRD を docs/prd/<slug>.md に書き出す skill。INSPIRED の 4 リスク (value / usability / feasibility / viability)、Continuous Discovery Habits の Opportunity Solution Tree と Riskiest Assumption Test、Escape the Build Trap の outcome 重視・feature factory 回避を doctrine とする。顧客が自分自身であるパターンも一級扱いし、自己ヒアリングのバイアス除去プロトコルを内蔵する。発火例 — 「〜を作りたい」「〜が欲しい」「アイデアがある」「〜って作るべき?」「PM 視点で整理して」「要求まとめて」「PRD 書いて」「PRD ドラフト」「discovery 回したい」「opportunity 整理」「outcome 何にする?」「riskiest assumption は?」「自分用ツール作りたい」。要件定義 (spec / 要件) を直接書く依頼、実装方針の検討、UI 仕様の確定、コード生成、API 設計、データモデル詳細は本スキル範囲外で、それぞれ requirements skill / design / data-modeling skill 等に委ねる。ドラフト後は別 agent の prd-review skill にレビューを渡し、合意済み PRD を入力に requirements skill を起動する想定。アドホックに要求整理するより本スキルを優先する理由は、build trap を防ぎ outcome / opportunity / assumption の三層を欠落なく PRD に揃え、下流レビュー・要件定義への引き継ぎ品質を担保するため。
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebFetch
+  - WebSearch
+  - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - Agent
+---
+
+# product-discovery
+
+要求定義（要件定義の前段、PM フェーズ）を進める skill。ユーザの発話を起点に Outcome → Opportunity → Assumption の三層に整理し、最終的に **Lean PRD** を `docs/prd/<slug>.md` として書き出す。下流の `prd-review` skill（別 agent）でレビューを受けて revise し、合意後に `requirements` skill（要件定義）を起動するハンドオフを前提にする。
+
+なぜこの skill が必要か: 開発の失敗のほとんどは「要件 (spec) の精度不足」ではなく「**要求 (request) の段階で outcome と opportunity を捉え損ねたこと**」に起因する。INSPIRED / Continuous Discovery Habits / Escape the Build Trap の 3 書はいずれも、build trap（output 中心の量産）を抜けるには discovery を独立した工程として持てと説く。本 skill はその discovery を 1 セッション内で再現する PM 補助線である。
+
+詳細レイヤ:
+- `references/inspired-cdh-build-trap.md` — 3 書を本 skill 用に蒸留した doctrine
+- `references/customer-is-self.md` — 顧客が自分自身のパターンの bias 除去プロトコル
+- `references/triage-decision.md` — 起動 / 別 skill へ振る判定木
+- `references/handoff-protocol.md` — prd-review / requirements への引き渡し仕様
+- `assets/prd-lean.md.tpl` — PRD テンプレート
+
+---
+
+## いつ使うか
+
+以下を強くトリガとする:
+
+- 「〜を作りたい / 欲しい / 試したい」「アイデアがある」「ぼんやり構想中」
+- 「これって作るべき?」「やる価値ある?」「PMF ありそう?」
+- 「PM 視点で整理して」「要求 / requirement をまとめて」「PRD 書いて / ドラフト」
+- 「discovery 回したい」「opportunity 整理」「outcome 何にする?」
+- 「riskiest assumption は?」「value risk チェックして」
+- 「自分用ツール作りたい」「自分が困ってるから」（顧客=自分自身）
+- slash command `/product-discovery` または明示で本 skill 名を呼ばれた時
+
+**使わない場面**:
+
+- 既に PRD / 要求が固まっており、**仕様 (spec / 要件)** を書きたい — `requirements` skill
+- PRD を書き終え、**レビュー**にかけたい — `prd-review` skill
+- 単なる**実装着手の段取り** — feature-dev / design 系
+- 単純な**事実調査・ライブラリ比較** — `research-practices` skill
+- **テスト・コード品質**の話 — `test-review` / `simplify` 等
+
+迷う境界は §Phase A の triage で振り分ける。
+
+---
+
+## 入力
+
+- ユーザの自然文発話（「〜したい」「〜で困っている」「〜って作るべき?」など断片で可）
+- 任意: 既存 PRD, ノート, Linear issue リンク, 音声書き起こし などの素材
+- 任意: 顧客タイプ指定（外部 / 自分自身 / 混在）。未指定なら Phase A で確認
+
+PRD 出力先は **常に `docs/prd/<slug>.md`**（Linear など外部ツールへの転記はユーザが手動 or 将来の Linear MCP 連携拡張で行う想定。本 skill は file-based に閉じる）。
+
+---
+
+## ワークフロー
+
+```
+[Phase A: triage]          ── 顧客 / 起動可否 / 既存 PRD diff か新規か
+   ↓
+[Phase B: outcome framing] ── 動かしたい outcome を 1 つに絞る (Build Trap 防御)
+   ↓
+[Phase C: opportunity]     ── OST 軽量版で 2〜4 の opportunity を立てる
+   ↓
+[Phase D: assumption]      ── 4 リスク + riskiest assumption + 直近で打つテスト
+   ↓
+[Phase E: synthesis]       ── assets/prd-lean.md.tpl に流し込み docs/prd/<slug>.md に書く
+   ↓
+[Phase F: handoff]         ── prd-review skill 起動を提案、合意後 requirements 案内
+```
+
+### Phase A: triage（ユーザ対話 1 回）
+
+`AskUserQuestion` を **冒頭で 1 回だけ** 使い、以降は本文に `[ASSUMED: ...]` `[TO_VALIDATE: ...]` を埋めて完走する（discovery の勢いを切らさない）。
+
+冒頭 1 回で揃えるべき情報は以下。複数の問いを 1 ターンに束ねる:
+
+1. **change_type 相当**: 新規プロダクト / 新規機能 / 既存機能の改善 / 既存 PRD の改訂 のいずれか
+2. **顧客タイプ**: 外部ユーザ / 自分自身 / 混在
+3. **不可逆性 / blast radius**: 本人のサンドボックス / 個人公開ツール / 業務影響あり
+4. **既存素材の有無**: ノート, 音声, 過去 PRD, 競合プロダクトのリンクなど
+
+判定の詳細は `references/triage-decision.md`。triage 結果が「本 skill 範囲外」なら（例: 仕様レベルの要件を書きたい、テストレビューをしたい）速やかに該当 skill を案内して終了する。
+
+triage 結果は PRD §Meta に記録する。
+
+### Phase B: outcome framing（Build Trap 防御）
+
+「何を作るか」を聞く前に「**何を動かしたいか**」を聞く。これを飛ばすと build trap に直行する。
+
+確認する観点:
+
+- 動かしたい指標 / 状態変化（「自分が週 3 回やっていた手作業を 0 にする」「家族が翌日にも料理を再現できる」など、観測可能な行動 or 数値）
+- 現状値 / 直近の悲しさ
+- 戦略・大方針との接続（個人プロジェクトなら「自分の今の生活で何を優先しているか」でも可）
+- **もし何もしなかったら 3 ヶ月後どうなるか**（do-nothing baseline）
+
+「outcome が thin」（output を言い換えただけ）と検出したら **Phase B で停滞させて深掘りする**。代表アンチパターン:
+
+- 「Slack bot を作りたい」→ 動かしたい outcome は? 何を Slack 経由で速くしたいのか
+- 「ダッシュボードが欲しい」→ どの意思決定を速くしたいのか
+- 「LLM agent を組みたい」→ 結果として何を 5 分から 30 秒にしたいのか
+
+詳細な doctrine は `references/inspired-cdh-build-trap.md` の §Build Trap 節。
+
+### Phase C: opportunity shaping（OST 軽量）
+
+Continuous Discovery Habits の Opportunity Solution Tree を **軽量版** で適用する。書き出すのは PRD ではなく**頭の中の枝分かれ**。
+
+- desired outcome（Phase B 結果）の下に **opportunity を最大 4 件** 並べる（多すぎたら統合 / 落とす）
+- 各 opportunity に対し **solution candidate を 1〜3 件** ずつ持つ
+- 「このソリューションがダメなら次に何を試すか」が言える状態にする（早期固定の回避）
+
+opportunity の良し悪しの目安:
+
+- **specific instance** から導かれている（「家族が前にこう困った」のような **具体痛点** が起点）
+- 動かしたい outcome に明確に紐づく
+- 顧客が**今すでにやっている代替行動**が観察できている（CDH の「customer は今何をして埋め合わせているか」）
+
+アンチパターン:
+
+- opportunity が「機能名」になっている（それは solution）
+- opportunity が複数 outcome を兼ねている（細分化しろ）
+
+### Phase D: assumption + riskiest test
+
+INSPIRED の 4 リスクで未検証前提を棚卸しする:
+
+| リスク | 問い |
+|---|---|
+| **value** | 顧客はそもそも欲しがるか / 使ってくれるか |
+| **usability** | 使いこなせるか / 認知負荷は越えられているか |
+| **feasibility** | 技術的に作れるか / 期間内に出せるか |
+| **viability** | プロダクト全体・ビジネス・自分の生活で成立するか（個人なら維持コスト含む） |
+
+各リスクで「現時点で **検証されていない** 一番痛い前提」を 1 つずつ書く。さらに:
+
+- **riskiest assumption**: 上記から「これがウソなら全体が崩れる」を 1 つ選ぶ
+- **直近で打つテスト**: その前提を 1 週間以内に falsify するなら何をするか（簡易プロトタイプ / 自己観察ログ / 紙芝居 / インタビュー 1 人）
+
+CDH の Assumption Mapping を圧縮した形。詳細は `references/inspired-cdh-build-trap.md` §Assumption Mapping。
+
+顧客=自分自身の場合、ここで bias check を必ず通す（次節 + `references/customer-is-self.md`）。
+
+### Phase E: synthesis（PRD 起こし）
+
+`assets/prd-lean.md.tpl` を読み込み、Phase A〜D の内容を埋めて `docs/prd/<slug>.md` に書き出す。
+
+- `<slug>` は input から `kebab-case` で 2〜4 語の識別子を AI が生成（例: `weekly-recipe-bot`）
+- 既存ファイルがある場合は **改訂モード**: 既存内容を読んで diff として書き、§Decision log にエントリを追加
+- **抽象度を要求レベルに保つ**: 関数シグネチャ, API 仕様, データスキーマ, 画面遷移詳細などの **spec / 設計詳細** を本文に書かない（要件定義 / 設計フェーズの仕事）
+- 不明点は `[TO_VALIDATE: 具体的な質問]` で本文に残す（要件定義へ持ち越す）
+- §Anti-goals（「これが見えたら逆効果」）を必ず 1 件以上書く（success metric の hack 防止）
+
+### Phase F: handoff
+
+完了報告でユーザに以下を渡す:
+
+1. 生成 / 更新した artifact path（`docs/prd/<slug>.md`）
+2. 要約 3 点（outcome / 上位 opportunity / riskiest assumption）
+3. **次の動き**:
+   - `prd-review` skill にレビューを依頼する案内（別 agent で起動する想定。本 skill からは自動起動しない）
+   - レビュー指摘で revise が必要なら本 skill を再起動 → §Decision log に追記
+   - PRD が approved になったら `requirements` skill を起動して要件定義へ
+4. 残った `[TO_VALIDATE]` の数（あれば内容）
+
+ハンドオフ仕様の詳細は `references/handoff-protocol.md`。
+
+---
+
+## ユーザターン最小化の原則
+
+- ユーザに尋ねるのは **Phase A の triage 1 回のみ** が既定
+- 例外: triage 結果が本 skill 範囲外（→ 別 skill 案内のための確認）/ 既存 PRD と矛盾する入力 / 上限超過の `[TO_VALIDATE]`
+- それ以外は **Phase A→B→C→D→E→F を 1 ターンで完走** して完了報告
+- 不明点は `[ASSUMED: ...]` `[TO_VALIDATE: ...]` を本文に埋め、上限内（Lean PRD なら `[TO_VALIDATE]` 上限 5 件）なら自動進行
+
+---
+
+## 顧客=自分自身モード
+
+個人プロダクト・社内ツール・実験コードなど、顧客が自分自身（または家族・身近な少人数）であるケースは**むしろ多数派**として扱う。「customer interview しろ」式の杓子定規を持ち込まず、自己観察のままで rigor を担保する。
+
+最低限の bias check（詳細プロトコルは `references/customer-is-self.md`）:
+
+- **specific instance**: 直近 2 週間で「実際に起きた瞬間」を最低 1 つ書ける
+- **inversion**: 「自分でない別の人だったらこの outcome を欲しがるか」を仮定で答え、答えが no ならスコープを「自分専用」と Meta に明記
+- **alternative observed**: 今すでにやっている代替行動を 1 つ以上挙げる
+- **viability self-check**: 維持コスト（自分が運用できるか / 半年後も触るか）を 1 行で書く
+
+これらが埋まらない PRD は §Self-check を `weak` とマーキングして prd-review に渡す。
+
+---
+
+## 出力
+
+| パス | 条件 | 内容 |
+|---|---|---|
+| `docs/prd/<slug>.md` | 常時 | Lean PRD（`assets/prd-lean.md.tpl` 由来） |
+| ユーザへの完了報告 | 常時 | artifact path / 3 点要約 / handoff 案内 |
+
+PRD 自体に self-check ブロックを内蔵する（prd-review が読む契約）。
+
+---
+
+## このスキルがやらないこと
+
+negative space は **動詞ではなく成果物** で書く（`skill-builder` の `dual-meaning-verb-by-action` 原則）:
+
+- **要件 (spec) ファイル `z/{task}/requirements.md` 相当** を生成しない（→ `requirements` skill）
+- **設計ドキュメント / 関数シグネチャ / API 定義 / Prisma schema** を本文に書かない（→ design / data-modeling）
+- **コード / テスト / config** を生成しない
+- **`prd-review` skill を自動呼び出ししない**（別 agent で明示起動する設計; 自動チェーンは討論の独立性を壊す）
+- **Linear / Notion / Jira への直接書き込みを行わない**（本 skill は file-based。MCP 連携が必要なら拡張で）
+- **discovery を打ち切る判断（「やめる」）を skill 単独で出さない** — riskiest assumption が崩れた時の判断はユーザに委ねる
+
+---
+
+## 連携 skill
+
+| skill | 役割 | 起動タイミング |
+|---|---|---|
+| `prd-review`（別 agent / 別 skill） | PRD のレビュー（must / imo） | 本 skill 完了後ユーザが明示起動 |
+| `requirements` | 要件定義（spec, EARS, 影響範囲） | PRD approved 後にユーザ起動 |
+| `research-practices` | 競合 / 先行事例 / ライブラリ調査 | Phase B/C/D で外部根拠が必要なときのみ |
+| `skill-builder` | 本 skill の trigger / quality 改善 | 本 skill の改修時 |
+
+`prd-review` / `requirements` は本 skill から自動起動しない（auto mode 親和とレビュー独立性のため）。
+
+---
+
+## 言語
+
+CLAUDE.md に従い、ユーザとのやり取りおよび PRD 本文は **日本語**。slug と frontmatter / メタキーは英小文字 + ハイフン。
+
+---
+
+## リファレンス
+
+- `references/inspired-cdh-build-trap.md` — 3 書の doctrine 蒸留
+- `references/customer-is-self.md` — 顧客=自分自身パターンの bias 除去
+- `references/triage-decision.md` — Phase A 判定木と別 skill への振り分け
+- `references/handoff-protocol.md` — prd-review / requirements への引き継ぎ仕様
+- `assets/prd-lean.md.tpl` — Lean PRD テンプレート
+- `evals/trigger.json` — trigger eval 雛形（skill-builder Mode B で利用）

--- a/product-discovery/assets/prd-lean.md.tpl
+++ b/product-discovery/assets/prd-lean.md.tpl
@@ -1,0 +1,190 @@
+# PRD: {{title}}
+
+## Meta
+
+```yaml
+slug: {{slug}}
+created: {{ISO8601}}
+updated: {{ISO8601}}
+author: {{author}}
+status: draft           # draft | reviewing | revising | approved | archived
+change_type: {{change_type}}      # new_product | new_feature | enhancement | prd_revision
+customer_type: {{customer_type}}  # external | self | self-and-close-circle | mix
+self_only: {{self_only}}          # true | false
+blast_radius: {{blast_radius}}    # sandbox | personal-public | business | irreversible
+handoff_to: requirements
+review_skill: prd-review          # 別 agent で起動する想定
+related:
+  prior_prd: {{prior_prd_path|null}}
+  notes: []
+  competitor_links: []
+  linear_urls: []
+```
+
+---
+
+## 1. Why now / Outcome
+
+### きっかけ
+
+{{trigger_narrative}}
+
+<!-- 1〜3 段落。「なぜ今これを問うているか」。直近で起きた具体的な出来事を必ず 1 つ以上含める -->
+
+### 動かしたい outcome（1 つに絞る）
+
+- **outcome**: {{outcome_statement}}
+- **観測方法 / 指標**: {{outcome_metric}}
+- **現状値**: {{baseline}}
+- **目標値**（任意）: {{target}}
+
+### Do-nothing baseline
+
+3 ヶ月何もしなかった場合、何が起きるか:
+{{do_nothing_baseline}}
+
+### 戦略 / 大方針との接続
+
+{{strategic_fit}}
+
+<!-- 個人プロジェクトなら「自分の今期の優先テーマとどう紐づくか」でも可 -->
+
+---
+
+## 2. Customer
+
+### 一次顧客
+
+- 顧客タイプ: {{customer_type}}
+- 具体像（誰が / どんな状況で）: {{persona}}
+
+### Jobs to be done
+
+- ジョブ: {{jobs_statement}}
+- 状況・トリガ: {{job_context}}
+
+### Specific instance（直近 2 週間で実際に起きた瞬間）
+
+{{specific_instance}}
+
+<!-- 日時 / 場所 / 何が起きたか / 何を感じたか。1 件以上、外部顧客なら 2 件以上推奨 -->
+
+### Alternative observed（今やっている代替行動）
+
+- {{alternative_1}}
+- {{alternative_2|optional}}
+
+### 顧客=自分自身モード Self-check（customer_type が self / self-and-close-circle / mix のとき必須）
+
+```yaml
+specific_instance_recorded: pass | fail
+inversion_check: pass | fail | self_only_declared
+alternative_observed: pass | fail
+viability_self_check: pass | fail
+overall: ok | weak
+```
+
+詳細は `references/customer-is-self.md` 参照。`overall: weak` のまま prd-review に渡してよいが、レビュー側はここを起点に bias 指摘を行う。
+
+---
+
+## 3. Opportunities（最大 4 件、顧客痛点で書く / feature 名で書かない）
+
+### O1. {{opportunity_title}}
+
+- 痛点: {{pain_description}}
+- outcome への接続: {{link_to_outcome}}
+- 候補ソリューション:
+  - S1a: {{solution_candidate}}
+  - S1b: {{solution_candidate|optional}}
+
+### O2. ...
+
+### 落としたもの / 統合したもの
+
+- {{rejected_opportunity}} — 理由: {{rejection_reason}}
+
+---
+
+## 4. Solution direction（spec ではない）
+
+### 大きな方針
+
+{{solution_direction}}
+
+<!-- 段落 1〜2 つ。具体的な機能名を出して良いが、関数 / API / schema / 画面遷移詳細は書かない -->
+
+### 検討した代替と却下理由
+
+| 代替 | 却下理由 |
+|---|---|
+| {{alt_1}} | {{reason_1}} |
+| {{alt_2}} | {{reason_2}} |
+
+### スコープ外（won't）
+
+- {{out_of_scope_1}}
+- {{out_of_scope_2}}
+
+---
+
+## 5. Assumptions & Riskiest test
+
+### 4 リスク（INSPIRED）
+
+| リスク | 未検証の一番痛い前提 |
+|---|---|
+| value | {{value_assumption}} |
+| usability | {{usability_assumption}} |
+| feasibility | {{feasibility_assumption}} |
+| viability | {{viability_assumption}} |
+
+### Riskiest assumption
+
+> {{riskiest_assumption}}
+
+理由（なぜ他より riskiest か）: {{why_riskiest}}
+
+### 直近で打つ falsification test
+
+- 実験名: {{test_name}}
+- 期間: {{duration}}（1 週間以内推奨）
+- 方法: {{method}}
+- 「これが見えたら前提は false」: {{falsification_signal}}
+- 期待コスト: {{cost}}
+
+---
+
+## 6. Success / Anti-goals
+
+### Leading indicator（早く動く / 行動レベル）
+
+- {{leading_1}}
+- {{leading_2|optional}}
+
+### Lagging indicator（遅く動く / 結果レベル）
+
+- {{lagging_1}}
+
+### Anti-goals（これが見えたら逆効果）
+
+- {{anti_goal_1}}
+- {{anti_goal_2|optional}}
+
+<!-- ethical / 依存助長 / プライバシー悪化 / 自分の生活負荷増 などをここに混ぜる -->
+
+---
+
+## 7. Open questions（要件定義へ持ち越し / `[TO_VALIDATE]` 上限 5）
+
+- [TO_VALIDATE: {{question_1}}]
+- [TO_VALIDATE: {{question_2|optional}}]
+
+---
+
+## 8. Decision log
+
+| 日付 | 変更 | 理由 / 学び |
+|---|---|---|
+| {{ISO_DATE}} | initial draft | — |
+<!-- revise 時は新しい行を追加 -->

--- a/product-discovery/evals/product-discovery-trigger.json
+++ b/product-discovery/evals/product-discovery-trigger.json
@@ -1,7 +1,7 @@
 {
   "target_skill": "product-discovery",
   "version": "1",
-  "notes": "skill-builder Mode B 用の trigger eval 雛形。should-trigger / should-skip 計 20 件。explicit / ambiguous / adjacent / distractor の混合。Mode B で計測する際は別途 evals/trigger-results-<YYYY-MM-DD>.jsonl を生成する。",
+  "notes": "skill-builder Mode B 用の trigger eval 雛形。should-trigger / should-skip 計 20 件。explicit / ambiguous / adjacent / distractor の混合。Mode B で計測する際は別途 evals/product-discovery-trigger-results-<YYYY-MM-DD>.jsonl を生成する。",
   "cases": [
     {
       "id": "t01",

--- a/product-discovery/evals/trigger.json
+++ b/product-discovery/evals/trigger.json
@@ -1,0 +1,147 @@
+{
+  "target_skill": "product-discovery",
+  "version": "1",
+  "notes": "skill-builder Mode B 用の trigger eval 雛形。should-trigger / should-skip 計 20 件。explicit / ambiguous / adjacent / distractor の混合。Mode B で計測する際は別途 evals/trigger-results-<YYYY-MM-DD>.jsonl を生成する。",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "新しいプロダクトを作りたい。PRDをドラフトしてほしい。",
+      "should_trigger": true,
+      "rationale": "明示的な PRD ドラフト依頼 + 新規プロダクト",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "/product-discovery",
+      "should_trigger": true,
+      "rationale": "slash command 直接指定",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "PM視点で要求を整理してほしい。outcomeとopportunityまで降ろしたい。",
+      "should_trigger": true,
+      "rationale": "PM視点 + outcome/opportunity の語が明示",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "discovery セッションを回したい。riskiest assumption を出したい。",
+      "should_trigger": true,
+      "rationale": "discovery / riskiest assumption は CDH/INSPIRED の中核語",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t05",
+      "prompt": "PRD書いて。Lean PRDでいい。",
+      "should_trigger": true,
+      "rationale": "成果物名で直接指定",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t06",
+      "prompt": "Slack bot 作りたいなって思ってるんだけど、何から考えればいい?",
+      "should_trigger": true,
+      "rationale": "アイデア整理段階。build trap を疑う必要あり、本 skill が outcome を確認する",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t07",
+      "prompt": "これって作る価値ある?",
+      "should_trigger": true,
+      "rationale": "value risk の問い。本 skill の Phase B/D が答える領域",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t08",
+      "prompt": "アイデアがあるんだけど、整理したい。",
+      "should_trigger": true,
+      "rationale": "PM 整理依頼の口語パターン",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t09",
+      "prompt": "自分用の bot 欲しいなと思ってる。週次でレシピ提案するやつ。",
+      "should_trigger": true,
+      "rationale": "顧客=自分自身パターン。本 skill の Self-check 領域",
+      "tags": ["ambiguous", "self-customer"]
+    },
+    {
+      "id": "t10",
+      "prompt": "家族で使うレシピ管理アプリ作りたい。",
+      "should_trigger": true,
+      "rationale": "self-and-close-circle パターン",
+      "tags": ["ambiguous", "self-customer"]
+    },
+    {
+      "id": "t11",
+      "prompt": "なんとなく週次レポート機能があったらいいなと思ってる。",
+      "should_trigger": true,
+      "rationale": "outcome 不明瞭な機能依頼。Phase B で深掘る対象",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t12",
+      "prompt": "z/{task}/requirements.md を書いてほしい。EARS 記法で。",
+      "should_trigger": false,
+      "rationale": "spec 段階 → requirements skill。本 skill の範囲外",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t13",
+      "prompt": "docs/prd/foo.md をレビューして。must / imo を出して。",
+      "should_trigger": false,
+      "rationale": "PRD のレビュー → prd-review skill",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t14",
+      "prompt": "API のエンドポイント設計を相談したい。RESTful にすべきかGraphQL か。",
+      "should_trigger": false,
+      "rationale": "設計フェーズ → design / feature-dev",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t15",
+      "prompt": "Prisma schema に新しいテーブルを足したい。設計を相談したい。",
+      "should_trigger": false,
+      "rationale": "データモデル設計 → data-modeling skill",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t16",
+      "prompt": "テストファイルをレビューして。AI 生成の smell をチェックして。",
+      "should_trigger": false,
+      "rationale": "テストレビュー → test-review skill",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t17",
+      "prompt": "実装したい。コードを書いて。",
+      "should_trigger": false,
+      "rationale": "実装フェーズ。要求段階を超えている",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t18",
+      "prompt": "Tanstack Query と SWR どっちが良い? 比較して。",
+      "should_trigger": false,
+      "rationale": "ライブラリ比較 → research-practices skill",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t19",
+      "prompt": "PostgreSQL の slow query を最適化したい。",
+      "should_trigger": false,
+      "rationale": "DB パフォーマンス → postgres skill。PRD の語感はないが「最適化したい」が単発で来た場合に誤起動しないか確認",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t20",
+      "prompt": "PRD は書いた。次の段取りどうする?",
+      "should_trigger": false,
+      "rationale": "本 skill 完了後の handoff 案内段階。本 skill を再度起動する必要なし（completion 報告で済む）。誤起動の検知用 distractor",
+      "tags": ["distractor", "edge"]
+    }
+  ]
+}

--- a/product-discovery/references/customer-is-self.md
+++ b/product-discovery/references/customer-is-self.md
@@ -1,0 +1,114 @@
+# 顧客=自分自身パターンの bias 除去プロトコル
+
+個人プロダクト・社内ツール・実験的ボット・自分用 CLI など、**顧客が自分自身（or 家族・身近な少人数）** であるケースのために置く参照。
+
+本 skill のスタンス: 顧客=自分自身パターンは「劣化版 discovery」ではなく、**discovery の正規パターン**として扱う。N=1 でも rigor は確保できる。ただし以下のバイアスが構造的に強く出るので明示的に防御する。
+
+---
+
+## このパターンで出るバイアス
+
+| バイアス | 症状 |
+|---|---|
+| **confirmation bias** | 自分が欲しい結論に合う観察だけ集めて、合わない観察を忘れる |
+| **planning fallacy** | 自作だから維持できると過信し、半年後に放置 |
+| **endowment effect** | 既に書いたコード / アイデアに引きずられて outcome を曲げる |
+| **availability bias** | 直近の苛立ちだけが outcome を支配する（実は週 1 回しか起きない問題かも） |
+| **social desirability の不在** | 顧客インタビューでは抑圧される「面倒だから使わない」が、自分相手だと逆に過小評価される |
+
+これらに対する反証手順を Phase C/D の前に通す。
+
+---
+
+## 4 つの bias check（必須）
+
+PRD 本文の `§Self-check` セクションに各項目を埋める。書けない項目があれば**その時点では PRD を完成させず Phase B/C に戻る**。
+
+### 1. Specific Instance — 「直近の実例を 1 つ」
+
+直近 2 週間で「実際にその痛みが起きた瞬間」を時系列で 1 つ書ける必要がある。
+
+良い例:
+> 4/29 19:30、夕食の献立を考えるのに 23 分かかり、結局昨日と同じになった。冷蔵庫の中身を見るたびに思い出さなくてはいけないのが嫌だった。
+
+悪い例（generic complaint）:
+> いつも献立決めに困っている。
+
+書けないなら **availability bias** の疑いあり。outcome を retain するなら頻度を計測する 1 週間の log を取ることを Phase D の test にする。
+
+### 2. Inversion — 「自分でなかったら欲しいか」
+
+「**もし自分以外の同じ状況の人**（家族 / 同僚 / 似た嗜好の友人）がこれを使うとしたら、欲しがるか」を仮定で答える。
+
+- 答えが **明確に yes**（具体的に思い浮かぶ人がいる）→ scope は「自分 + 周囲数名」
+- 答えが **微妙 / no** → scope を「自分専用」と Meta に明記する。これは悪いことではない。**自分専用**だと明示することで、PRD の品質基準が変わる（汎用性 / 一般化を諦めて、自己観察を信頼する）
+
+inversion で「全人類が欲しいはず」と答えたくなったら **confirmation bias の警報**。Phase C に戻る。
+
+### 3. Alternative Observed — 「今やってる代替行動」
+
+CDH の核心: 「customer が今すでにやっている代替行動 / workaround」を 1 つ以上挙げる。
+
+書けないなら、その痛みは**そもそも痛みでない**可能性が高い（人は痛ければ何かしら代替してる）。
+
+例:
+- 献立決め → 「クックパッドの履歴を見る / 妻に丸投げする」
+- メール整理 → 「未読を放置して土曜日にまとめて見る」
+- ノート整理 → 「Slack の自分宛 DM に投げて検索で探す」
+
+代替行動が「**実用的に成立している**」なら、新しい解の value risk は高い（既に解けてる）。代替行動が**苦痛で持続できない**なら value がある。
+
+### 4. Viability Self-check — 「半年後も触るか」
+
+INSPIRED の viability を **個人プロダクトに翻訳**したもの。
+
+- 自分が運用 / メンテできる技術スタックか
+- 半年後に「使い続けるモチベーション」があるか（hobby vs tool の見極め）
+- 月額コスト / API rate limit / インフラ管理の負荷が自分の許容範囲か
+- **やめる時の出口**は確保できているか（データのエクスポート / 依存解除）
+
+書けないなら viability risk が riskiest assumption になりがち。Phase D で必ず取り上げる。
+
+---
+
+## scope の宣言
+
+bias check の結果、PRD の §Meta に以下を明記する:
+
+```yaml
+customer_type: self          # self | self-and-close-circle | external | mix
+self_only: true              # inversion の結果（自分専用なら true）
+sample_size: 1               # N=1 を隠さない
+generalization_claimed: false # 一般化主張があるか
+```
+
+`self_only: true` の PRD は、prd-review で「外部顧客向けの validation 不足」を must 指摘から除外する契約にする（過剰な客観性要求は意味がない）。
+
+---
+
+## 「家族 + 自分」「友人 5 人」などの近接コミュニティ
+
+最も誤読されやすいゾーン。N が小さい外部ユーザに見えるが、実態は**自分自身 + わずかな観測対象**。
+
+ルール:
+
+- 観測対象（家族 / 友人）には **specific instance を本人由来で 1 件**確保する（推測ではなく実観察）
+- 観測対象が 5 人以上なら external 寄り、4 人以下なら self-and-close-circle 扱いで bias check は self と同様に厳しく
+- 観測対象が嫌がる UX を **過小評価しない**（家族が「面倒」と一言言ったら value risk として扱う）
+
+---
+
+## このプロトコルで判定が変わる典型例
+
+| 入力 | bias check 後の判定 |
+|---|---|
+| 「献立 bot 作りたい。みんな困ってるはず」 | inversion で具体名が出ない → self_only: true、scope を縮める |
+| 「ToDo app を作りたい」 | alternative observed が「Reminders.app で十分機能してる」→ value risk 高、Phase B 再検討 |
+| 「読書管理 SaaS」 | viability で「半年後も触るか」が no → hobby project として明示し scale 想定を捨てる |
+| 「家族で使うレシピ共有」 | 家族 1 人が「面倒」と言った → usability risk を riskiest に格上げ |
+
+---
+
+## prd-review への引き渡し
+
+`§Self-check` ブロックに上記 4 項目の結果と scope 宣言を埋めた PRD を `prd-review` に渡す。レビュー側はこのブロックを読んで、レビュー観点を **self_only スコープ用** に絞る運用とする（詳細は `handoff-protocol.md`）。

--- a/product-discovery/references/handoff-protocol.md
+++ b/product-discovery/references/handoff-protocol.md
@@ -8,7 +8,7 @@
 
 ## ステージ全体図
 
-```
+```text
 [product-discovery]      ── 本 skill。docs/prd/<slug>.md を生成 / 更新
         ↓ ユーザ起動
 [prd-review]             ── 別 agent / 別 skill。must / imo を出す
@@ -49,7 +49,7 @@ PRD には以下のセクションを **必ず** 埋める。prd-review はこ�
 
 ### 完了報告でユーザに渡す文面（テンプレ）
 
-```
+```text
 PRD ドラフトを docs/prd/<slug>.md に書きました。
 
 要約:

--- a/product-discovery/references/handoff-protocol.md
+++ b/product-discovery/references/handoff-protocol.md
@@ -1,0 +1,155 @@
+# Handoff protocol — prd-review / requirements への引き継ぎ
+
+本 skill が `docs/prd/<slug>.md` を書き終えた後、下流の **`prd-review` skill（別 agent）** と **`requirements` skill（要件定義）** にどう繋ぐかを定義する。
+
+設計原則: **本 skill は何も自動起動しない**。チェーン化はレビューの独立性を壊し、auto mode 親和も損なう。ユーザが意識的に次のフェーズに進む。
+
+---
+
+## ステージ全体図
+
+```
+[product-discovery]      ── 本 skill。docs/prd/<slug>.md を生成 / 更新
+        ↓ ユーザ起動
+[prd-review]             ── 別 agent / 別 skill。must / imo を出す
+        ↓ revise が必要なら
+[product-discovery (再)] ── §Decision log にエントリを追加
+        ↓ approved
+[requirements]           ── 要件定義 (spec / EARS / 影響範囲)
+        ↓
+[design / implement / ...]
+```
+
+---
+
+## prd-review への引き継ぎ仕様
+
+### 入力（prd-review が読むもの）
+
+- 必須: `docs/prd/<slug>.md`
+- 任意: `docs/prd/<slug>.md` の前バージョン（git で取れるなら diff）
+- 任意: `references/customer-is-self.md` の bias check 結果（PRD §Self-check に埋まっている）
+
+### 本 skill が PRD に埋める「review が読む契約」のブロック
+
+PRD には以下のセクションを **必ず** 埋める。prd-review はこれらを点検対象にする:
+
+| PRD セクション | review が見るポイント |
+|---|---|
+| §Meta | change_type, customer_type, self_only, blast_radius |
+| §1 Why now / Outcome | outcome が output の言い換えになっていないか, do-nothing baseline がある |
+| §2 Customer | specific instance, alternative observed, scope 宣言 |
+| §3 Opportunities | feature 名でなく顧客痛点で書かれている, 上限 4 |
+| §4 Solution direction | spec / 設計詳細が混入していない, 却下した代替の理由 |
+| §5 Assumptions & Riskiest test | 4 リスクすべて記載, riskiest 1 件選択, falsification test |
+| §6 Success / Anti-goals | leading + lagging + anti-signal がある |
+| §7 Open questions | `[TO_VALIDATE]` 上限 5 以下 |
+| §8 Decision log | 改訂時にエントリ追加 |
+| §Self-check (顧客=自分自身モード時) | 4 項目埋まっている |
+
+### 完了報告でユーザに渡す文面（テンプレ）
+
+```
+PRD ドラフトを docs/prd/<slug>.md に書きました。
+
+要約:
+- Outcome: ...
+- 上位 opportunity: ...
+- Riskiest assumption: ...
+
+次のステップ:
+1. 別 agent で `prd-review` skill を起動してレビューを依頼してください
+   （本 skill からは自動起動しません）。
+2. レビューの must 指摘があれば本 skill を再起動 → revise します
+   （§Decision log に履歴が残ります）。
+3. PRD が approved になったら `requirements` skill を起動して要件定義に進んでください。
+
+残った [TO_VALIDATE]: N 件（あれば内容）
+```
+
+### prd-review が must を返したとき
+
+ユーザは以下のいずれかを選ぶ:
+
+1. **revise**: 本 skill を再起動。`prd_revision` モードで起動し、指摘部分の Phase（B / C / D / E）に戻ってリファインしてから PRD を上書き。§Decision log にエントリを追加
+2. **drop**: PRD を破棄して再企画。本 skill を `new_product` モードで再起動
+3. **defer**: 指摘を `[TO_VALIDATE]` に降格させて先に進める（要件定義フェーズで決着させる）
+
+`defer` を選んだ際は §Decision log に **defer の理由** を残す（後で「なぜ無視したか」がわかるように）。
+
+---
+
+## requirements への引き継ぎ仕様
+
+`requirements` skill は本 skill とは別 skill（speee/sengoku の `requirements` パターンを参考にする想定）。本 skill から自動起動しない。
+
+### 引き渡すもの
+
+- PRD パス: `docs/prd/<slug>.md`
+- approved ステータス（PRD §Meta `status: approved`）
+- prd-review の最終 verdict（`docs/prd/<slug>-review.md` 等が別 skill 側で生成される想定）
+
+### requirements 側で行うこと（本 skill の責務外）
+
+- PRD を Read して **要件 (spec)** に展開（EARS, FR / NFR, 影響範囲, AC）
+- DB 修正必要性判定 → data-modeling skill delegate
+- self-review で PASS / FAIL_SELF / FAIL_UPSTREAM 判定
+- `z/{task}/requirements.md` を生成
+
+### PRD と requirements の責務境界
+
+| 軸 | PRD（本 skill） | requirements |
+|---|---|---|
+| 抽象度 | What / Why（要求） | What の詳細 + 観測可能な振る舞い（要件） |
+| 顧客視点 | jobs / outcome / pain | use case / actor / 制約 |
+| 検証対象 | 動かす指標 / anti-goal | 受入条件 (AC), Vitest テスト名対応 |
+| 書かないもの | spec, シグネチャ, schema | アーキ図, クラス, 実装方針 |
+
+PRD で書きすぎると要件が矛盾する。**本 skill は spec を書かない契約を厳守**。
+
+---
+
+## ユーザが本 skill / prd-review / requirements を行き来する典型パターン
+
+### パターン 1: 順調
+
+1. product-discovery → PRD draft
+2. prd-review → must 0, imo 2 → PASS
+3. ユーザ判断で imo を反映 or defer
+4. requirements 起動
+
+### パターン 2: revise loop
+
+1. product-discovery → PRD draft (v1)
+2. prd-review → must 2 → FAIL_SELF
+3. product-discovery 再起動（`prd_revision`）→ PRD v2、§Decision log にエントリ
+4. prd-review → PASS
+5. requirements 起動
+
+### パターン 3: 上流問題（PRD の前提が崩れる）
+
+1. product-discovery → PRD draft
+2. prd-review → FAIL_UPSTREAM（「outcome 自体が筋違い」）
+3. ユーザは PRD を破棄
+4. product-discovery を **`new_product` または `new_feature`** で再起動。前 PRD は §Decision log に「破棄理由」を書いて archive 扱い
+
+### パターン 4: requirements で要求側の問題が発覚
+
+1. product-discovery → PRD approved
+2. requirements 起動 → `[NEEDS CLARIFICATION]` で「outcome に対する制約が不明」
+3. ユーザ判断で本 skill を再起動して PRD を補強 → requirements 再起動
+
+このサイクルを許容する設計にしておく。**PRD は不変文書ではなく、§Decision log を伴う 進化文書** として運用する。
+
+---
+
+## Linear / Notion / Jira への外部書き出し
+
+本 skill は file-based に閉じる（`docs/prd/<slug>.md` のみ）。
+
+外部ツールへの転記が必要な場合:
+
+- **手動**: ユーザが `docs/prd/<slug>.md` を開いてコピー
+- **将来拡張**: Linear MCP サーバが接続されている前提で、本 skill とは別の連携 skill（例: `prd-to-linear`）を作る。本 skill 自体には混ぜ込まない（責務分離）
+
+外部ツール上に書き戻す PRD は **本 skill が書いた `docs/prd/<slug>.md` をソース・オブ・トゥルース** とする運用を推奨。

--- a/product-discovery/references/inspired-cdh-build-trap.md
+++ b/product-discovery/references/inspired-cdh-build-trap.md
@@ -74,7 +74,7 @@ Cagan の主張: 製品開発の失敗のほとんどは以下 4 種に集約さ
 
 ### Opportunity Solution Tree (OST)
 
-```
+```text
 Outcome
  ├── Opportunity 1
  │    ├── Solution candidate 1a

--- a/product-discovery/references/inspired-cdh-build-trap.md
+++ b/product-discovery/references/inspired-cdh-build-trap.md
@@ -1,0 +1,135 @@
+# INSPIRED / Continuous Discovery Habits / Escape the Build Trap — doctrine
+
+本 skill が依拠する 3 書のエッセンスを **discovery セッションで実際に問える形** に蒸留したもの。元書の網羅的解説ではなく、PRD ドラフト中に「次に何を聞くか」を即決するための短い参照。
+
+3 書の関係:
+
+- **Escape the Build Trap (Melissa Perri)** — 「なぜ output 中心が失敗するのか」のフレーミング。組織論寄り。
+- **INSPIRED (Marty Cagan)** — discovery と delivery を分ける思想 + 4 リスク分類。
+- **Continuous Discovery Habits (Teresa Torres)** — 上記を実務に落とすための **習慣** と **OST**。
+
+本 skill では **Build Trap → INSPIRED の 4 リスク → CDH の OST + Riskiest Assumption Test** の順で適用する。
+
+---
+
+## §Build Trap（Escape the Build Trap）
+
+### 定義
+
+「機能をたくさん出すこと」自体を成果と勘違いし、outcome（顧客の状態変化 / ビジネス指標）から切り離されて output（リリース数 / 機能数）を量産する状態。
+
+### 検出シグナル（Phase B で疑え）
+
+- 入力が**動詞 + 目的語の機能名**で来る（「Slack bot を作る」「ダッシュボード」「LLM agent」）
+- 「いつまでに」「何を」だけが議論されており、「**それで何が良くなるのか**」が空白
+- 既存機能を量産しても顧客の行動が変わらない実例がある（社内・前職経験・本人観察）
+- 「他社が作っているから」「最近流行っているから」が動機
+
+### 防御の問い
+
+1. これを作らなかったら 3 ヶ月後どうなる? どこが具体的に困る?
+2. 動かしたい outcome を 1 つに絞ると何? 観測可能か?
+3. 同じ outcome を別の解で動かせないか? 安いほうから試したか?
+
+「**outcome のない feature は spec 化しない**」を Phase B で守る。outcome が thin な状態で Phase C に進ませない。
+
+### Product Kata（Perri）
+
+「`現在地 → 目標 → 障害 → 次のステップ → 学び`」のループ。本 skill では:
+
+- 現在地 = Phase A の triage 結果
+- 目標 = Phase B の outcome
+- 障害 = Phase C の opportunity
+- 次のステップ = Phase D の riskiest test
+- 学び = revise 時に PRD の §Decision log に書く
+
+---
+
+## §INSPIRED の 4 リスク
+
+Cagan の主張: 製品開発の失敗のほとんどは以下 4 種に集約される。**discovery とはこれらを並行で潰す活動**である。
+
+| リスク | 問い | discovery 手段の例 |
+|---|---|---|
+| **value risk** | 顧客はそもそも欲しがるか / 使うか / 金 or 時間を払うか | プロトタイプ反応, 価格提示, アナログ実験 |
+| **usability risk** | 使いこなせるか / 認知負荷を越えられるか | クリック可能 prototype, タスク観察, 紙芝居 |
+| **feasibility risk** | 期間 / 技術 / インフラで作れるか | spike, tracer bullet, 外部 API 検証 |
+| **viability risk** | プロダクト全体・ビジネス・運用で成立するか（個人なら維持コスト） | コスト試算, 法務 / ポリシー確認, 運用負荷見積 |
+
+### 本 skill での扱い（Phase D）
+
+- 各リスクで「**現時点で未検証の一番痛い前提**」を 1 つずつ書かせる
+- 4 つのうち **riskiest assumption** を 1 つ選ぶ（複数選ばない — 集中が崩れる）
+- 1 週間以内で打てる falsification test を 1 つ書く
+
+### 落とし穴
+
+- value だけを論じて feasibility / viability を書き忘れる（個人プロダクトで多い: 「自分が欲しい」止まり）
+- usability を「UI が綺麗か」と誤読しない。**学習コスト + 認知負荷** の話
+- viability に「**自分が半年後も触るか**」を含めるのを忘れない（顧客=自分自身モード）
+
+---
+
+## §Continuous Discovery Habits
+
+### Opportunity Solution Tree (OST)
+
+```
+Outcome
+ ├── Opportunity 1
+ │    ├── Solution candidate 1a
+ │    └── Solution candidate 1b
+ ├── Opportunity 2
+ │    └── Solution candidate 2a
+ └── Opportunity 3
+      └── ...
+```
+
+ルール:
+
+- **outcome は 1 つ**。複数 outcome を 1 PRD に詰めない
+- opportunity は **顧客の言葉 / 痛点 / jobs to be done** で書く（機能名で書かない）
+- solution は **opportunity ごとに複数候補** を持つ（早期固定の回避）
+- assumption test は solution ごとに付ける（CDH 原書では assumption 層が下にある）
+
+本 skill は Phase C で軽量化し、最大 4 opportunity × 各 1〜3 solution まで。
+
+### Continuous の意味
+
+CDH の核心は **「週 1 回顧客に触れる」習慣**。本 skill は **1 PRD を書く瞬間** にしか動かないので continuous 性は担保できない。代わりに以下を埋め込む:
+
+- §Open questions に「次の touchpoint で確認したいこと」を残す
+- §Decision log で revise 時に「この回で何を学んだか」を書く
+- 顧客=自分自身モードでは「自己観察ログを継続するか」を viability の一部として書く
+
+つまり本 skill は **continuous の 1 点** を切り取る役割。連続性はユーザの運用側に委ねる。
+
+### Assumption Mapping
+
+CDH 原書では desirability / viability / feasibility / usability / **ethical** の 5 軸（INSPIRED の 4 + ethical）。本 skill では:
+
+- 4 リスクは Phase D で必ず書く
+- ethical は **§Anti-goals** として「これが見えたら逆効果」のスロットに混ぜる（差別 / 依存助長 / プライバシー悪化など、出力前に毎回点検）
+
+### Riskiest Assumption Test (RAT)
+
+「assumption を 1 つだけ選び、それを最も安く falsify する 1 実験」。本 skill では Phase D で 1 件強制書き出し。書けないなら opportunity / solution が抽象すぎる証拠 → Phase C に戻る。
+
+---
+
+## §3 書を Phase に対応づけた早見表
+
+| Phase | 主な doctrine | 落ちやすい罠 |
+|---|---|---|
+| A triage | — | 仕様レベルの依頼を本 skill で受け取って、要件定義の skill に渡しそびれる |
+| B outcome | Build Trap, Product Kata | outcome に output を流し込む（言い換え） |
+| C opportunity | OST, jobs-to-be-done | opportunity が feature 名になる |
+| D assumption | INSPIRED 4 risk + RAT, Assumption Mapping | viability / 維持コストの欠落 |
+| E synthesis | — | spec / 設計詳細を PRD に書いてしまう |
+| F handoff | continuous の 1 点切り取り | 自動チェーン化してレビュー独立性を壊す |
+
+---
+
+## 参考
+
+3 書の原本に当たる必要があれば本 skill から **`research-practices`** を呼ぶ。本 skill 自体は 3 書の解釈に閉じる。

--- a/product-discovery/references/triage-decision.md
+++ b/product-discovery/references/triage-decision.md
@@ -1,0 +1,103 @@
+# Phase A: triage 決定木
+
+本 skill を起動するか / 別 skill に振るかの判定、および本 skill 内で扱う **change_type** と **顧客タイプ** を決める。
+
+冒頭の `AskUserQuestion` 1 回でユーザに揃えてもらい、以降は本文で完走する。
+
+---
+
+## Step 0: 本 skill 範囲外の検出
+
+ユーザ入力が以下のいずれかに該当するなら、本 skill を起動せず該当 skill を案内して終了する:
+
+| 検出キー | 振り先 |
+|---|---|
+| 「要件 / spec / 仕様 を書きたい / 確定したい」「EARS で書く」 | `requirements` skill |
+| 「PRD のレビュー」「PRD を見て指摘」「PRD のチェック」 | `prd-review` skill |
+| 「設計して」「アーキテクチャ」「クラス図」「シーケンス図」 | feature-dev / design 系 |
+| 「実装して」「コード書いて」「リファクタリング」 | 該当の実装系 skill / agent |
+| 「ライブラリ調べて」「比較して」「先行事例」 | `research-practices` skill |
+| 「テスト見て」「テストレビュー」 | `test-review` skill |
+| 「データモデル / Prisma schema / index 設計」 | data-modeling 系 skill |
+
+迷うなら「本 skill は **要求 (request)**、`requirements` は **要件 (spec)** を扱う」を物差しにする。
+
+---
+
+## Step 1: change_type の判定
+
+| change_type | 入力サイン | Phase 重点 |
+|---|---|---|
+| `new_product` | 「〜を作りたい（既存なし）」「ゼロから」「新しいプロダクト / サービス / bot」 | Phase B (outcome) を厚く。Phase D viability 必須 |
+| `new_feature` | 既存プロダクトに対する「機能を足したい」 | Phase B（既存 outcome との接続）+ Phase C |
+| `enhancement` | 「〜を変えたい」「挙動修正」「改善したい」 | Phase B（**直す価値があるか**）+ Phase D usability 重点 |
+| `prd_revision` | 「PRD を直したい」「前の PRD に追記」 | 既存 PRD を Read → diff モード（Phase E で revise） |
+
+`enhancement` か `new_feature` か微妙な場合は、対象機能が**既に動いていて顧客が使っているか**で分岐する（使っていれば enhancement）。
+
+---
+
+## Step 2: 顧客タイプの判定
+
+| customer_type | 入力サイン | doctrine |
+|---|---|---|
+| `external` | 「ユーザに使ってもらう」「販売 / 配布する」「会社のプロダクト」 | INSPIRED 通常運用。CDH の continuous touchpoint を §Open questions に残す |
+| `self` | 「自分用」「自分が困ってる」「個人プロジェクト」 | `customer-is-self.md` プロトコル必須 |
+| `self-and-close-circle` | 「家族 / パートナー / 友人 5 人以下で」 | self プロトコル + 近接コミュニティ補足 |
+| `mix` | 「最初は自分、いずれ外部」 | self プロトコル + scope 拡張時の前提を §Open questions に |
+
+**判定が曖昧なときは self に寄せて始める**（後で external に持ち上げるほうが安全）。
+
+---
+
+## Step 3: 不可逆性 / blast radius の判定
+
+下流の review / 要件定義の厳しさを変えるためのヒント。PRD §Meta に `blast_radius` として記録。
+
+| blast_radius | 例 | review 厳しさ |
+|---|---|---|
+| `sandbox` | 自分のローカルだけ。お金もデータも他人に触れない | 軽い。riskiest test も小さくて良い |
+| `personal-public` | 個人で web 公開。少数の他人が触る可能性 | 中。ethical anti-goals に依存助長 / 誤情報を混ぜる |
+| `business` | 会社・チームの業務に影響 | 厚い。viability + 法務 / セキュリティを書かせる |
+| `irreversible` | 課金 / 顧客データ / 法的責任 | 最厚。本 skill 単独で完結させない（要件定義 + 設計レビューを必ず回す） |
+
+`irreversible` の場合、本 skill 完了報告で「**要件定義 + 設計レビューを通すまで実装着手しないこと**」を明示する。
+
+---
+
+## Step 4: 既存素材の有無
+
+ユーザが「ノート / 音声 / 過去 PRD / 競合プロダクトリンク / Linear issue」などを持っているか。
+
+- 既存 **PRD** あり → revise モード（Phase E で diff 起こし）
+- ノート / 音声 → Phase B/C の入力として活用。長い場合は冒頭で要約させる
+- 競合プロダクトリンク → Phase C で alternative observed の参考に
+- Linear issue → 本 skill は file-based なので、内容を抜き出して `docs/prd/<slug>.md` に取り込む（Linear 自動同期はしない）
+
+---
+
+## triage の出力スキーマ
+
+Phase A の結果を内部で次の YAML として持つ（PRD §Meta に書き出す）:
+
+```yaml
+change_type: new_product | new_feature | enhancement | prd_revision
+customer_type: external | self | self-and-close-circle | mix
+self_only: bool
+blast_radius: sandbox | personal-public | business | irreversible
+existing_materials:
+  prd_path: docs/prd/<slug>.md | null
+  notes: bool
+  competitor_links: []
+  linear_urls: []
+```
+
+これを以後の Phase で参照する。
+
+---
+
+## triage で判定しない（後段に委ねる）
+
+- depth（Lean / Full） — 本 skill は **常に Lean PRD** で固定。Full PRD は将来追加検討
+- DB 修正必要性 — `requirements` skill 側の責務（PRD では §Open questions に「DB 影響ありそう」とだけ残す）
+- 実装工数見積 — PRD ではなく要件定義 / 設計フェーズ

--- a/product-discovery/references/triage-decision.md
+++ b/product-discovery/references/triage-decision.md
@@ -90,6 +90,12 @@ existing_materials:
   notes: bool
   competitor_links: []
   linear_urls: []
+
+# PRD §Meta への変換規則（Phase E で適用）:
+#   existing_materials.prd_path        → related.prior_prd (path or null)
+#   existing_materials.notes (bool)    → related.notes (array; bool は「素材が存在するか」フラグ。中身は Phase B/C 入力に展開)
+#   existing_materials.competitor_links → related.competitor_links (array)
+#   existing_materials.linear_urls     → related.linear_urls (array)
 ```
 
 これを以後の Phase で参照する。

--- a/skill-builder/SKILL.md
+++ b/skill-builder/SKILL.md
@@ -53,7 +53,7 @@ APM (`microsoft/apm`) で `kanade0404/skills/skill-builder` として配布さ�
 
 | モード | 入力 | 出力 |
 |---|---|---|
-| `create` | 何をする skill か（自然文） | `.claude/skills/<name>/SKILL.md` + `evals/trigger.json` 雛形 |
+| `create` | 何をする skill か（自然文） | `.claude/skills/<name>/SKILL.md` + `evals/<name>-trigger.json` 雛形 |
 | `tune-trigger` | 既存 skill 名 | `evals/<skill>-trigger-results-<date>.json` + description 改訂案 |
 | `tune-quality` | 既存 skill 名 + シナリオ | subagent 品質レポート + SKILL.md 改訂案 |
 
@@ -138,7 +138,7 @@ consumer プロジェクト固有の確認：
 - 詳細レイヤは `references/<topic>.md` に切り出し、本文からは「対象が X のときだけ参照する」と書く
 - 出力フォーマットは固定する。スキャンしやすさ優先
 
-### Step 4 — `evals/trigger.json` 雛形を置く
+### Step 4 — `evals/<name>-trigger.json` 雛形を置く
 
 Mode B の入力になる。詳細は後段。
 
@@ -270,7 +270,7 @@ description を直したら **同じ eval セット**で再測定。F1 が上が
 
 ## Files
 - .claude/skills/<name>/SKILL.md
-- .claude/skills/<name>/evals/trigger.json (雛形)
+- .claude/skills/<name>/evals/<name>-trigger.json (雛形)
 
 ## Self-review
 - [✓/✗] 500 行以内

--- a/skill-builder/SKILL.md
+++ b/skill-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-builder
-description: agegis プロジェクト内で Claude Code skill を新規作成・既存 skill のトリガ精度を測定/改善するためのメタスキル。新しい skill を `.claude/skills/<name>/SKILL.md` に scaffold したい時、既存 skill が適切なときに発火しない / 余計な時に発火するのを直したい時、skill description を eval ベースで最適化したい時、skill の trigger 性能をベースライン測定したい時に必ず使う。「skill 作って」「このスキルなんで起動しない」「スキルが暴発する」「skill description 最適化」「skill の eval 作って」「メタスキル」のような要請に該当する。プロジェクト規約（CLAUDE.md / rules/）への整合チェックも兼ねる。
+description: Claude Code skill を新規作成・既存 skill のトリガ精度を測定/改善するためのメタスキル。新しい skill を `.claude/skills/<name>/SKILL.md` に scaffold したい時、既存 skill が適切なときに発火しない / 余計な時に発火するのを直したい時、skill description を eval ベースで最適化したい時、skill の trigger 性能をベースライン測定したい時、Mode C で起動後の本文品質を subagent dispatch で測りたい時に必ず使う。発火例: 「skill 作って」「このスキルなんで起動しない」「スキルが暴発する」「skill description 最適化」「skill の eval 作って」「メタスキル」「skill の trigger 精度測って」「skill の品質を測りたい」。consumer プロジェクトの CLAUDE.md / 規約ファイル（`rules/` `docs/` 等）への整合チェックも兼ねる。プラグインスキル（`plugins/<plugin>/skills/...`）の編集は範囲外で、plugin-dev 系 skill に委ねる。
 allowed-tools:
   - Read
   - Write
@@ -14,9 +14,11 @@ allowed-tools:
   - AskUserQuestion
 ---
 
-# Skill Builder (agegis)
+# Skill Builder
 
-公式 `skill-creator` の発想を踏襲しつつ、agegis プロジェクト内に閉じた軽量メタスキル。subagent や外部 LLM を立てずに、**1 セッション内で完結する eval ループ**を回す。
+公式 `skill-creator` の発想を踏襲しつつ、consumer プロジェクトの `.claude/skills/` 運用に閉じた軽量メタスキル。subagent や外部 LLM を立てずに、**1 セッション内で完結する eval ループ**を回す。
+
+APM (`microsoft/apm`) で `kanade0404/skills/skill-builder` として配布される前提で project-agnostic に書く。consumer プロジェクトの CLAUDE.md / 規約ファイル（`rules/`, `docs/`, `AGENTS.md` 等）への整合は consumer 側の規約として参照する。
 
 主参照：
 - [Anthropic Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)（公式の規範）
@@ -25,7 +27,7 @@ allowed-tools:
 外部 skill-creator との位置付け：
 
 - 公式 skill-creator は汎用かつ重装備（並列 subagent、blind A/B comparator、HTML viewer）。新規プラグイン公開を想定。
-- 本スキルは **agegis のローカル `.claude/skills/` 配下を運用するための最小ループ**。CLAUDE.md と `rules/` への整合、日本語 description、Onion / FP / TDD ドクトリンへの寄り添いを担保する。
+- 本スキルは **consumer プロジェクト内 `.claude/skills/` を運用するための最小ループ**。日本語 description / 規約整合チェック / 1 セッション内 eval を担保する。
 
 ---
 
@@ -69,10 +71,11 @@ allowed-tools:
 - **既存スキルとの分担境界** — 機能が重なる skill があれば名指しで線を引く
 - **依存ツール / MCP** — `allowed-tools` に何を入れるか
 
-agegis 固有の確認：
+consumer プロジェクト固有の確認：
 
-- `rules/architecture-style.md` / `rules/design-guide.md` のどの原則に直接関わるか
-- 取り扱う対象（テスト / RLS / プロンプト / インフラ）が既存 skill とどう違うか
+- consumer プロジェクトに `CLAUDE.md` / `rules/*.md` / `AGENTS.md` / `docs/` 等の規約があれば、新 skill が違反していないか確認する
+- 取り扱う対象（テスト / API / プロンプト / インフラ / プロダクト要求 etc.）が既存 skill とどう違うかを名指しで線引きする
+- consumer プロジェクトに同領域の既存 skill / agent / slash command があれば、責務境界を frontmatter description に明記する
 
 ### Step 2 — frontmatter を書く
 
@@ -102,12 +105,16 @@ agegis 固有の確認：
 
 判断基準は **「Claude が書ける/判断できることを書かない」**。`PDF を読み込み → 各ページのテキストを取得` は不要、`pdfplumber を使え` だけで十分（公式の "concise is key" 原則）。
 
-#### 参考構造（`test-review` を雛形にする）：
+#### 参考構造（同カタログ内の `test-review` / `research-practices` / `product-discovery` を雛形にできる）：
 
 ```
-# <skill name> (agegis)
+# <skill name>
 
 <なぜ必要か。1 段落>
+
+## いつ使うか / 使わない場面
+- 発火すべき状況（口語含む）
+- 発火しない場面 → 該当 skill 名を明示
 
 ## ワークフロー
 ### Step 1 — ...
@@ -118,7 +125,10 @@ agegis 固有の確認：
 <固定テンプレ>
 
 ## このスキルがやらないこと
-- ...
+- 成果物名で除外（動詞ではなく）
+
+## リファレンス
+- references/<topic>.md
 ```
 
 **書き方の原則**：
@@ -134,7 +144,7 @@ Mode B の入力になる。詳細は後段。
 
 ### Step 5 — レビュー観点（Anthropic 公式チェックリスト準拠）
 
-書き終えたら以下を自己点検する。`[A]` は公式 best-practices の checklist 項目、`[L]` は agegis ローカル追加：
+書き終えたら以下を自己点検する。`[A]` は公式 best-practices の checklist 項目、`[L]` は本カタログのローカル追加：
 
 **Core quality**
 - [A] description が具体的で key terms を含む
@@ -151,7 +161,7 @@ Mode B の入力になる。詳細は後段。
 **Triggering / boundary**
 - [A] description に should-use の典型表現が複数列挙されている
 - [L] negative space（やらないこと）が **動詞ではなく成果物** で定義されている（参照: failure-patterns.md `dual-meaning-verb-by-action`）
-- [L] CLAUDE.md / `rules/` と矛盾しない
+- [L] consumer プロジェクトの CLAUDE.md / 規約ファイル（`rules/`, `AGENTS.md`, `docs/` 等）と矛盾しない
 
 **Code / scripts（同梱する場合のみ）**
 - [A] スクリプトは「Claude に投げない」(solve, don't punt)。エラー処理を内側で持つ

--- a/test-review/SKILL.md
+++ b/test-review/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: test-review
-description: テストコード（pytest / pgTAP / n8n workflows）をレビューする際に使うスキル。test smells、AI 生成テストのアンチパターン、seam / mock 境界の違反、LLM・エージェント eval の抜け、Supabase RLS / AuthZ のカバー、flakiness、agegis の Safety / Order / Reinforcement 原則との整合をまとめて点検する。テストファイル（`**/tests/**`, `*_test.py`, `supabase/tests/**`）を含む PR / diff のレビュー時、新規テストファイルの監査時、テストスイートの品質チェック時、flaky テストの原因追跡時、LLM / エージェント eval の厳密性評価時、RLS / 認可テストの存在確認時、いずれでも必ず起動すること。ユーザーの言い方が曖昧でも — 「テスト見て」「このテストいい?」「テストスイート大丈夫?」「このテストなんで壊れる?」「認可のテスト足りてる?」「eval レビューして」「このプロンプトテストでカバーできてる?」— どれも該当する。ただし以下の成果物を生む依頼はこのスキルの範囲外：テスト追加・テスト修正・テスト基盤の移行・テスト並列化・パフォーマンス改善・lint 違反修正。本スキルは「読んで指摘する」レビュー専用で、コードを書き換える依頼には起動しない。アドホックなレビューより本スキルを優先する理由は、プロジェクトのチェックリストを適用して構造化された findings を出すためである。
+description: テストコード（pytest / vitest / jest / rspec / go test / pgTAP / ワークフロー定義 等の任意フレームワーク）をレビューする際に使うスキル。test smells（Meszaros 17 種）、Khorikov の 4 属性 (Protection / Resistance to refactoring / Fast feedback / Maintainability)、AI 生成テストのアンチパターン、seam / mock 境界の違反、LLM・エージェント eval の抜け、DB / RLS / 認可テストのカバー、flakiness の原因分類をまとめて点検する。テストファイル（`**/tests/**`, `*_test.*`, `*.test.*`, `*.spec.*`, `supabase/tests/**` など）を含む PR / diff のレビュー時、新規テストファイルの監査時、テストスイートの品質チェック時、flaky テストの原因追跡時、LLM / エージェント eval の厳密性評価時、RLS / 認可テストの存在確認時、いずれでも必ず起動すること。ユーザーの言い方が曖昧でも — 「テスト見て」「このテストいい?」「テストスイート大丈夫?」「このテストなんで壊れる?」「認可のテスト足りてる?」「eval レビューして」「このプロンプトテストでカバーできてる?」— どれも該当する。ただし以下の成果物を生む依頼はこのスキルの範囲外：テスト追加・テスト修正・テスト基盤の移行・テスト並列化・パフォーマンス改善・lint 違反修正。本スキルは「読んで指摘する」レビュー専用で、コードを書き換える依頼には起動しない。アドホックなレビューより本スキルを優先する理由は、構造化されたチェックリスト（Meszaros / Khorikov / AI antipatterns）を一貫適用して findings を出すためである。
 tools: Read, Glob, Grep, Bash, LSP, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs, mcp__plugin_serena_serena__find_symbol, mcp__plugin_serena_serena__find_referencing_symbols, mcp__plugin_serena_serena__get_symbols_overview, mcp__plugin_serena_serena__search_for_pattern, mcp__plugin_serena_serena__list_dir, mcp__plugin_serena_serena__find_file, mcp__plugin_serena_serena__read_file, mcp__plugin_serena_serena__check_onboarding_performed
 ---
 
-# Test Review (agegis)
+# Test Review
 
 テストを書くのが速く、レビューするのが安いままであるようにテストコードをレビューするためのスキル。テスト品質は予測可能な形で劣化するので、その劣化を一度・一貫して捕まえることで、以降の PR で時間を節約できる。
 
-レビューは 2 つのレンズを常に併用する：
+APM (`microsoft/apm`) で `kanade0404/skills/test-review` として配布される前提で project-agnostic に書く。consumer プロジェクトに固有の doctrine (例: Safety / Order / Reinforcement のような独自原則) があれば §Step 7 で取り込む拡張点を持たせている。
+
+レビューの主レンズ:
 
 - **Khorikov の 4 属性** — Protection against regressions · Resistance to refactoring · Fast feedback · Maintainability。掛け算的に効く。どれか 1 軸でもゼロに近づくとテストの価値のほとんどが失われる。
-- **agegis の 3 原則** — Safety · Order · Reinforcement。エージェント回り / データ回りの非自明なテストは少なくとも 1 つにマップできるべき。
+- **Meszaros の 17 smells** — `references/smells.md` の完全カタログを §Step 3 で当てる。
+- **AI 生成テストのアンチパターン** — `references/ai-generated.md` に詳細。LLM が書いたテストに偏った 6 種を §Step 5 で常時チェック。
+- **consumer プロジェクトの doctrine マッピング**（任意）— §Step 7。プロジェクトに独自の原則（Safety / Order / Reinforcement, Reliability / Observability / Idempotence 等）があれば、非自明なテストをそれに対応付ける。
 
 ---
 
@@ -21,24 +25,25 @@ tools: Read, Glob, Grep, Bash, LSP, mcp__plugin_context7_context7__resolve-libra
 
 ### Step 1 — スコープ分類
 
-変更されたテストを読み、ファイルごとに分類する。
+変更されたテストを読み、ファイルごとに分類する。下表は consumer プロジェクトで頻出するレイヤの**例**。consumer の技術スタックに応じて読み替える。
 
-| 信号 | レイヤ | 主要な関心事 |
+| 信号（例） | レイヤ | 主要な関心事 |
 |---|---|---|
-| `pytest`, `hypothesis`、ネットワーク呼出なし | Python unit | §3, §4, §5 |
-| `respx`, `testcontainers`, `asyncpg`, `supabase-py` | Python integration | §3, §4, §5, §8 |
-| `anthropic`, `strands`, agent loop, tool use | LLM / agent | §3, §4, §5, §7, §8 |
-| `pgTAP`, `supabase/test_helpers` | DB / RLS | §8 |
-| `workflow.json`, `n8n-nodes-base` | n8n | §8 |
+| `pytest`, `vitest`, `jest`, `rspec`, `go test` などの単体テスト | unit | §3, §4, §5 |
+| `respx`, `msw`, `testcontainers`, `supertest`, `httptest` 等 + DB / 外部 API | integration | §3, §4, §5, §8 |
+| `anthropic` / `openai` SDK, agent loop, tool use, prompt eval | LLM / agent | §3, §4, §5, §7, §8 |
+| `pgTAP`, RLS テスト, supabase test helpers | DB / 認可 | §8 |
+| ワークフロー定義 (`workflow.json`, n8n, Temporal 等) | workflow | §8 |
+| ブラウザ E2E (Playwright, Cypress) | E2E | §9 |
 
-レイヤ固有の詳細は **必要になったときのみ** 参照する：
+レイヤ固有の詳細は **必要になったときのみ** 参照する。本カタログは以下の汎用 reference を同梱する。consumer プロジェクトは独自の `references/<stack>.md` を追加して拡張できる:
 
-- `references/patterns.md` — xUnit Test Patterns の正のパターン（Four-Phase Test, Test Double タクソノミ, Fixture 戦略, テストデータ構築, 結果検証, Humble Object 等）
-- `references/smells.md` — Meszaros 17 smells の完全版、修正例つき
-- `references/ai-generated.md` — AI 生成テスト特有のアンチパターンと検出ヒューリスティック
-- `references/python.md` — pytest / Hypothesis / async / fixture の具体
-- `references/llm-eval.md` — LLM / エージェント eval の具体
-- `references/data-stack.md` — Supabase / RLS / pgvector / n8n の具体
+- `references/patterns.md` — xUnit Test Patterns の正のパターン（Four-Phase Test, Test Double タクソノミ, Fixture 戦略, テストデータ構築, 結果検証, Humble Object 等。言語非依存）
+- `references/smells.md` — Meszaros 17 smells の完全版、修正例つき（言語非依存）
+- `references/ai-generated.md` — AI 生成テスト特有のアンチパターンと検出ヒューリスティック（言語非依存）
+- `references/python.md` — pytest / Hypothesis / async / fixture の具体（**Python 例**。他言語の consumer は無視）
+- `references/llm-eval.md` — LLM / エージェント eval の具体（汎用）
+- `references/data-stack.md` — Supabase / RLS / pgvector / n8n の具体（**特定スタック例**。consumer のスタックに応じて参照）
 
 これらは参考資料であり、事前に読む必要はない。対象ファイルが要求するときだけ読む。
 
@@ -51,8 +56,8 @@ tools: Read, Glob, Grep, Bash, LSP, mcp__plugin_context7_context7__resolve-libra
 - **Act は 1 行。** 複数行にわたるなら複数の振る舞いを検証している兆候 — 分割する。
 - **1 テスト 1 概念。** 同じ概念を確認する複数の物理 `assert` は OK（返り値の各フィールドなど）。
 - **Assertion は原則 State Verification。** 戻り値・保持された状態・外界の観測可能な出力（DB の行、OTel span の属性、webhook 受信記録）を直接比較する。呼び出し回数や呼び出し順の assertion は使わない — §4 で test double を使わない設計により、そもそも道具が存在しない。詳細は `references/patterns.md §5`。
-- **テスト本体に「どのアサートが走るか」を分岐させる制御構造を置かない。** `if`/`try`/`while`/`for` でアサートの実行可否が変わるものは却下し、`@pytest.mark.parametrize` に展開する。ただし **property-based テストの precondition フィルタ** は正当な例外 — `hypothesis.assume(cond)` が慣用形、`if cond: assert ...`（`cond` が入力分割の述語であり、全ケースで最終的に property を満たすもの）も許容。
-- **strict-markers 整合。** `@pytest.mark.<foo>` は `pyproject.toml` の `markers` リストに宣言されていること（リポジトリは `--strict-markers` で走るため、未宣言マーカーは即エラー）。新規マーカー追加時は同じ PR で `markers` リストに登録する。
+- **テスト本体に「どのアサートが走るか」を分岐させる制御構造を置かない。** `if`/`try`/`while`/`for` でアサートの実行可否が変わるものは却下し、parametrize 機能（`@pytest.mark.parametrize`, `it.each`, `describe.each`, `RSpec.shared_examples` 等）に展開する。ただし **property-based テストの precondition フィルタ** は正当な例外 — Hypothesis の `assume(cond)`、fast-check の `fc.pre(cond)` などが慣用形。
+- **マーカー / タグの整合。** `@pytest.mark.<foo>` / `describe.skip` / `RSpec.tag` 等を使う場合、フレームワークの設定（`pyproject.toml` `markers` リスト、jest config 等）に宣言されていること。`--strict-markers` 相当の検査が CI で動いているなら、未宣言マーカーは即エラーになる。新規マーカー追加時は同じ PR で設定に登録する。
 - **Reader test。** 実装を知らない読み手がテストだけを読んで契約を言えるか。言えないなら、書き手都合のテストになっている。
 
 ### Step 3 — Test smells スキャン
@@ -63,18 +68,18 @@ Eager test · Mystery guest · Fragile test · Obscure test · Assertion roulett
 
 ### Step 4 — seam / 外部 I/O 境界
 
-**大前提**: このプロジェクトでは **test double を使う必要が出ないように設計する**。test double が欲しくなる時点で、設計が正しくない可能性を先に疑う。立場は Classicist に Functional Core / Imperative Shell と Humble Object を強く適用したもの。詳細は `references/patterns.md §2` と `§6 Humble Object`。
+**立場**: **test double を使う必要が出ないように設計する**ことを優先するレビューを行う。test double が欲しくなる時点で、設計が正しくない可能性を先に疑う。Classicist に Functional Core / Imperative Shell と Humble Object を強く適用した立場。詳細は `references/patterns.md §2` と `§6 Humble Object`。
 
 レビューで当てる順序：
 
 - **「test double が必要」と主張するテストは設計を疑う。** 先に純関数として抽出できないかを問う。パース、バリデーション、プロンプト合成、ルーティング、判断ロジックはほぼ全て純関数に寄せられる — そうすれば test double なしで直接テストできる。
 - **本物優先。** 自分が所有するコードは test double にしない。内部クラスや内部関数を mock しているテストは、ほぼ必ず設計の問題のサインなので指摘する。
-- **DB は本物を使う。** Supabase / PostgreSQL は `testcontainers-python` や `supabase start` でローカル実行できるので、本物で検証する。`InMemoryRepo` 等の DB fake は作らない。RLS は SQL で記述されているため、SQL を実行しないテストは RLS を何も検証していない。
-- **外部 API (Claude / Gmail / X / Discord) の扱いも "まず Humble Object 化"**。I/O を薄い外殻に押し出し、周辺の Functional Core は本物のデータ（録画された JSON 等）で直接テストする。**残る薄い I/O 部分だけ** VCR 録画で統合テストする（`vcrpy` / `respx`、サニタイズ hook で PII / API キー除去）。録画が難しい場合のみ境界アダプタに薄い Fake を 1 枚、50 行以下で置く。
-- **Clock / UUID / 乱数** は Protocol で DI する（fake を書くのではなく、決定的な実装を本番 / テストで差し替える設計）。
-- **`patch` のターゲットは使用箇所、定義元ではない。** どうしても必要な数少ない場面での書き方: 良: `patch("<own_module>.<imported_name>")`、悪: `patch("<vendor_lib>.<name>")`。Functional Core と I/O 境界が分離しきれていないコードでは使用箇所 patch を暫定的に許容するが、境界が明確化されれば `patch` 自体が不要になる方向で設計を進める（外部 I/O は `LLMClient` / `HttpFetcher` Protocol 相当のアダプタを 1 枚挟むのが理想）。
+- **DB は本物を使う。** PostgreSQL / MySQL / SQLite などは Testcontainers (testcontainers-python / testcontainers-node / testcontainers-java など) や docker-compose, ローカル CLI (例: `supabase start`) でローカル実行できるので、本物で検証する。`InMemoryRepo` 等の DB fake は作らない。RLS や stored procedure のように SQL に書かれた制約は、SQL を実行しないテストでは何も検証されない。
+- **外部 API（LLM 提供者 / 通知先 / メーラー / OAuth プロバイダ等）の扱いも "まず Humble Object 化"**。I/O を薄い外殻に押し出し、周辺の Functional Core は本物のデータ（録画された JSON 等）で直接テストする。**残る薄い I/O 部分だけ** VCR 録画系ツール（vcrpy / nock / WireMock / Polly.JS / respx / msw など、言語に応じて）で統合テストする。録画時は **サニタイズ hook で PII / API キー除去** を必須にする。録画が難しい場合のみ境界アダプタに薄い Fake を 1 枚、50 行以下で置く。
+- **Clock / UUID / 乱数** はインタフェース（Python Protocol / TypeScript interface / Go interface 等）で DI する（fake を書くのではなく、決定的な実装を本番 / テストで差し替える設計）。
+- **monkey-patch のターゲットは使用箇所、定義元ではない。** Python `unittest.mock.patch` / Jest `jest.mock` / Sinon stub 等、どの言語でも同じ原則。良: `patch("<own_module>.<imported_name>")`、悪: `patch("<vendor_lib>.<name>")`。Functional Core と I/O 境界が分離しきれていないコードでは使用箇所 patch を暫定的に許容するが、境界が明確化されれば patch 自体が不要になる方向で設計を進める（外部 I/O は `LLMClient` / `HttpFetcher` 相当のアダプタを 1 枚挟むのが理想）。
 - **純関数は直接テストする。** parser / validator / prompt composer / routing は test double 不要。
-- **`pytest-rerunfailures` で flaky を隠さない。** flaky が現れたら §6 で分類する。
+- **flaky retry プラグインで flaky を隠さない。** `pytest-rerunfailures`, `jest --retry`, `mocha --retries` 等。flaky が現れたら §6 で分類する。
 
 ### Step 5 — AI 生成テストのアンチパターン
 
@@ -91,46 +96,58 @@ LLM が書いたテストは特定の失敗パターンに偏る。完全な一�
 
 ### Step 6 — flakiness の原因分類
 
-「たまに落ちる」や `pytest-rerunfailures` が diff に出たら、原因分類を要求する。retry-to-green は認めない。
+「たまに落ちる」や retry プラグイン（`pytest-rerunfailures` / `jest --retry` / `mocha --retries` 等）が diff に出たら、原因分類を要求する。retry-to-green は認めない。
 
-| 原因 | 対策 |
+| 原因 | 対策（言語に応じた具体ツール） |
 |---|---|
-| 非同期レース | `async with asyncio.timeout(...)` + 決定的スケジューリング |
-| ネットワーク | MSW / respx / VCR / testcontainers |
-| 順序依存 | 共有可変状態を排除。`pytest-randomly` 導入（現状は未依存）を検討 |
-| Clock | `time-machine`（`freezegun` ではなく）または `Clock` を注入 |
-| 乱数 | `random.Random(seed)` を注入 |
-| 環境変数 | `monkeypatch.setenv` のみ |
-| リソースリーク | autouse な `asyncio.all_tasks()` 検出 fixture |
+| 非同期レース | timeout 明示 + 決定的スケジューリング (Python `asyncio.timeout`, JS `Promise.race + AbortController`, Go `context.WithTimeout`) |
+| ネットワーク | MSW / nock / VCR / vcrpy / WireMock / Testcontainers で固定化 |
+| 順序依存 | 共有可変状態を排除。テスト順序ランダム化（`pytest-randomly`, `jest --randomize`）で検出 |
+| Clock | 注入可能な Clock インタフェース。`time-machine` / `@sinonjs/fake-timers` / `clock-mock` などで決定化（`freezegun` の monkey-patch 系より DI 推奨） |
+| 乱数 | seed 注入（`random.Random(seed)` / `seedrandom` / Go `rand.New(rand.NewSource(seed))`） |
+| 環境変数 | テスト用の差し替え API のみ使用（Python `monkeypatch.setenv`, Node `process.env` を fixture で復元、Go `t.Setenv`） |
+| リソースリーク | リーク検出 fixture / hook（Python `asyncio.all_tasks()`, Jest `--detectOpenHandles`, Node `--detect-leaks`） |
 
-調査中の隔離は OK。リトライで誤魔化すのは NG。
+調査中の隔離（`@pytest.mark.skip` / `it.skip` 等で issue 番号付き）は OK。リトライで誤魔化すのは NG。
 
-### Step 7 — プロジェクト原則へのマッピング
+### Step 7 — consumer プロジェクトの doctrine マッピング（任意）
 
-非自明なテストは以下のいずれかに明確に対応付ける：
+consumer プロジェクトに **テストが守るべき独自原則** が明文化されているなら、非自明なテストはそのいずれかに明確に対応付けることを要求する。
 
-- **Safety** — RLS 否定系、prompt injection red team、ツール出力の data exfil フィルタ、PII 編集、policy violation の refusal。
-- **Order** — 書き込みの冪等性、エージェントループの停止条件（iter / token / cost 上限）、OTel span 属性の assertion、単調な状態遷移。
-- **Reinforcement** — golden dataset への新規ケース追加、trace replay 回帰、prompt version bump と同時の eval 更新、dataset バージョニング。
+このセクションは **consumer 側に doctrine がある場合のみ有効**。無い場合はスキップしてよい。doctrine の典型例:
 
-些末なヘルパのテストに原則マッピングを要求する必要はない。だがエージェント回り / データ回りのテストはどれかには必ず対応するはず。対応しない場合は、テストが違う場所にあるか、そもそも検証対象がここで検証する価値を持たない。
+- **Safety / Order / Reinforcement** — エージェント・データ系のプロダクトでよく置かれる 3 原則
+  - Safety: RLS 否定系、prompt injection red team、ツール出力の data exfil フィルタ、PII 編集、policy violation の refusal
+  - Order: 書き込みの冪等性、エージェントループの停止条件（iter / token / cost 上限）、OTel span 属性の assertion、単調な状態遷移
+  - Reinforcement: golden dataset への新規ケース追加、trace replay 回帰、prompt version bump と同時の eval 更新、dataset バージョニング
+- **Reliability / Observability / Recoverability** — 分散システム・SaaS 寄りで置かれることが多い
+- **Correctness / Performance / Compatibility** — ライブラリ・SDK で置かれることが多い
+
+consumer プロジェクトは `references/project-doctrine.md` を追加してここに自分の doctrine を書ける（本スキルは無くても動く）。
+
+doctrine マッピングを **要求するレベル**:
+
+- 些末なヘルパのテスト → マッピング不要
+- ビジネスロジック / セキュリティ境界 / データ整合性 / エージェント挙動 → どれかに必ず対応するはず。対応しない場合は、テストが違う場所にあるか、そもそも検証対象がここで検証する価値を持たない疑い
 
 ### Step 8 — レイヤ固有の深掘り
 
 対象ファイルがそのレイヤにあるときだけ参照する：
 
-- LLM / エージェントコード → `references/llm-eval.md`
-- Supabase / RLS / pgvector / n8n → `references/data-stack.md`
-- Python 具体（fixture scope, asyncio 癖, Hypothesis チューニング）→ `references/python.md`
+- LLM / エージェントコード → `references/llm-eval.md`（汎用）
+- Supabase / RLS / pgvector / n8n のような特定スタック → `references/data-stack.md`（**特定スタック例**。consumer のスタックが異なる場合、独自の `references/<stack>.md` を追加して使う）
+- Python 具体（fixture scope, asyncio 癖, Hypothesis チューニング）→ `references/python.md`（**Python 例**）
+
+consumer プロジェクトが他言語・他スタック（TypeScript / Go / Ruby / Rust 等）であれば、本カタログの上記 references を参考に独自の `references/<lang>.md` / `references/<stack>.md` を追加できる。本スキルは追加 references を `references/` 配下に置けば自動的に Step 8 から参照される設計。
 
 ### Step 9 — E2E 予算の確認
 
-Playwright 相当の E2E（n8n + Supabase + agent フルスタック）テストを diff が追加している場合：
+E2E テスト（Playwright / Cypress / Selenium / 手動シナリオ自動化）を diff が追加している場合：
 
-- より安いレイヤ（unit / integration）で既にカバーされていないかを確認する。
-- 予算: CI 全体 10 分以下、flaky 率 < 1%。
-- できる限りピラミッドの下側に寄せる（unit → integration → E2E の順）。
-- E2E は golden path と critical safety path に限定する。
+- より安いレイヤ（unit / integration / contract test）で既にカバーされていないかを確認する。
+- 予算の目安（consumer プロジェクトの基準があればそれに従う）: CI 全体 10 分以下、flaky 率 < 1%。
+- できる限りテストピラミッドの下側に寄せる（unit → integration → E2E の順）。
+- E2E は golden path と critical safety path に限定する。E2E でしか検証できない振る舞いだけを残す。
 
 ---
 
@@ -162,7 +179,7 @@ Playwright 相当の E2E（n8n + Supabase + agent フルスタック）テスト
 - ...
 ```
 
-カテゴリタグ（必ず角括弧つきで明示）: `smell/<name>`, `seam`, `ai-pattern`, `safety`, `order`, `reinforcement`, `flaky`, `naming`, `coverage-gap`, `py-specific`, `eval`, `rls`, `e2e-budget`。
+カテゴリタグ（必ず角括弧つきで明示）: `smell/<name>`, `seam`, `ai-pattern`, `flaky`, `naming`, `coverage-gap`, `lang-specific`, `eval`, `e2e-budget`, `auth`, `rls`, `doctrine/<name>`。`doctrine/safety`, `doctrine/order`, `doctrine/reinforcement` のように consumer プロジェクトの doctrine 名を `/` で繋いで使う（doctrine マッピングを採用している場合）。
 
 各項目は「issue 1 行 + Fix 1 行」。長めの理由は末尾の **Notes** 付録に脚注番号で参照させ、本文はスキャンしやすく保つ。
 
@@ -172,14 +189,16 @@ Playwright 相当の E2E（n8n + Supabase + agent フルスタック）テスト
 
 ## このスキルがやらないこと
 
-- **テストを実行しない。** 著者がローカルで `uv run pytest -v`, `uv run ruff check`, `uv run pyright` を回している前提。レビューは読むだけ。
+- **テストを実行しない。** 著者がローカルでテスト・lint・型チェック（pytest / vitest / jest / rspec / go test, ruff / eslint / rubocop / golangci-lint, pyright / tsc 等）を回している前提。レビューは読むだけ。
 - **コードを書き換えない。** 提案はテキスト。編集は著者 or 別ステップ。
-- **ツールが強制しているスタイルは二度検証しない。** ruff / pyright がスタイルの権威 — 重複しない。テスト固有のスタイル（命名、smell）のみ指摘する。
+- **ツールが強制しているスタイルは二度検証しない。** lint / formatter / 型チェッカがスタイルの権威 — 重複しない。テスト固有のスタイル（命名、smell）のみ指摘する。
 - **CI と重複しない。** CI が enforce している項目は手動で再検証しない。
 
 ---
 
 ## 良いレビューの例
+
+以下は Python + Supabase + LLM スタックでの具体例。本スキルは任意の言語・スタックで同じ構造のレビューを出力する。
 
 ```markdown
 # Test Review


### PR DESCRIPTION
## Summary
- Add `product-discovery` skill: 要求定義 (PM phase) workflow that drafts a Lean PRD at `docs/prd/<slug>.md` based on INSPIRED 4 risks, CDH Opportunity Solution Tree, Escape the Build Trap. First-class self-as-customer mode. Hands off to `prd-review` then `requirements` skills downstream.
- Generalize `skill-builder` and `test-review` for APM distribution — drop agegis-specific assumptions (project doctrine, Python-only stack, Safety/Order/Reinforcement hardcoding). Doctrine mapping is now an optional extension point in test-review.
- Rewrite README catalog table from origin info to capability summary.
- **Fix Devin Review finding**: rename `product-discovery/evals/trigger.json` → `product-discovery/evals/product-discovery-trigger.json` to match the AGENTS.md `evals/<skill>-trigger.json` naming convention; update the `notes` field's results-file reference and the catalog entry in `product-discovery/SKILL.md` accordingly. Without the rename the documented `score_triggers.py --cases <skill>/evals/<skill>-trigger.json` command would fail with a file-not-found error.

## Review & Testing Checklist for Human
- [ ] Verify rename: `ls product-discovery/evals/` shows `product-discovery-trigger.json` (not `trigger.json`).
- [ ] Confirm there are no lingering bare `trigger.json` references inside `product-discovery/` (`grep -rn "evals/trigger.json" product-discovery/` should return nothing).
- [ ] Spot-check that `product-discovery/SKILL.md` still fits within the 500-line cap (`wc -l product-discovery/SKILL.md`).
- [ ] Once `product-discovery` is consumed in a project, run `skill-builder` Mode B against `product-discovery/evals/product-discovery-trigger.json` (20 cases) and review the score.
- [ ] Manual smoke test: invoke `product-discovery` from a consumer project and confirm it triages correctly and writes `docs/prd/<slug>.md`.

### Notes
- Pre-existing `evals/trigger.json` references in `skill-builder/SKILL.md:56,141,273` are out of scope; Devin Review's prompt classified them as a pre-existing inconsistency. They can be addressed in a follow-up.
- Devin Review badge on this PR mentions "View 4 additional findings in Devin Review" — those are gated behind the Devin Review web UI and were not posted inline here. If any of them is actionable, please share so I can address it in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Link to Devin session: https://app.devin.ai/sessions/7ee19d1f9a6044f1845cdf1fb6623374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new product-discovery skill with a lean PRD template, session workflow, risk/self-check guidance, and an activation trigger evaluation.

* **Documentation**
  * Added multiple reference guides for triage, handoff, bias checks, and discovery doctrines.
  * Updated skill-builder and test-review documentation and adjusted README/CLAUDE listings to include the new skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->