### PR TITLE
Slim CLAUDE.md to repo-specific invariants; document tag release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,67 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## What this repo is
-
-Skill のカタログ兼 **rulesync 配布元リポジトリ**。配布は
-[rulesync](https://github.com/dyoshikawa/rulesync) を用い、各プロジェクトで
+Skill カタログ兼 **rulesync 配布元**。consumer は
 `rulesync fetch kanade0404/skills@<tag> --features skills,...` → `rulesync generate`
-で Claude Code / Codex 等の設定を生成して使う（旧 APM 方式から移行済み）。
+で各エージェントの設定を生成して使う。
 
-このリポジトリ自体にビルド・テスト・lint パイプラインは無い。コードを書く場所ではなく
-**SKILL.md を編集する場所**。
-
-**サードパーティ製 skill は原則 vendor しない**。consumer 側で upstream を直接
-`rulesync fetch`（例: `planetscale/database-skills`）。明示的な copy-in 例外は
-該当 skill ディレクトリ内に出典とライセンスを残し、必要な upstream ライセンス表示を同梱する。
-
-## レイアウト
-
-rulesync の `fetch` はルート直下のトップレベル feature ディレクトリを読む。
-
-```text
-skills/<skill-name>/
-├── SKILL.md            # 必須。frontmatter (name, description, allowed-tools) + 本文
-├── references/*.md     # 詳細レイヤ（progressive disclosure 第3層）
-├── evals/*.{json,jsonl}# trigger 評価ケース・結果
-├── scripts/*.py        # スコアラー等の補助ツール
-└── assets/*            # テンプレ等
-
-subagents/  commands/  hooks/  rules/   # 配布 feature 枠（現状 placeholder）
-```
-
-収録 skill の source of truth は `skills/<name>/` と各 `SKILL.md` frontmatter。README や
-CLAUDE.md に個別 skill の一覧や件数を重複管理しない。
-
-## SKILL.md 編集時の規約
-
-`skills/skill-builder/SKILL.md` に詳細があり、ここで管理される全 skill の規範になる。要点:
-
-- **frontmatter** — `name` ≤ 64 char / 小文字+数字+ハイフンのみ / 予約語（`anthropic`, `claude`）禁止。`description` ≤ 1024 char、三人称、「何を」「いつ使うか」両方を含める。
-- **本文** — ≤ 500 行。越えるなら `references/<topic>.md` に切り出して本文は「いつ参照しに行くか」だけ書く。
-- **`if`/`while` で動作分岐させない**（読み手が動作を予測できなくなる）。
-- **negative space を成果物で定義** — 「やらないこと」を動詞ではなく成果物で書く（`skills/skill-builder/evals/failure-patterns.md` の `dual-meaning-verb-by-action` 参照）。
-
-## skill-builder の評価ループ
-
-`skills/skill-builder/scripts/score_triggers.py` で trigger eval をスコアリングする。
-
-```bash
-# skills/<skill>/evals/<skill>-trigger.json の cases と
-# skills/<skill>/evals/<skill>-trigger-results-<date>.jsonl の予測を突き合わせ
-uv run python skills/skill-builder/scripts/score_triggers.py \
-  --cases skills/<skill>/evals/<skill>-trigger.json \
-  --preds skills/<skill>/evals/<skill>-trigger-results-2026-04-29.jsonl
-```
-
-`run_harness.py` は `claude -p` を別プロセスで叩いて trigger を観測するハーネス（重量側）。
-
-スコア解釈と次手の処方は `skills/skill-builder/SKILL.md` の Mode B (`tune-trigger`) を参照。
-
-## 新しい skill を足すとき
-
-1. `skills/<name>/SKILL.md` を作る。雛形と self-review チェックリストは `skills/skill-builder/SKILL.md` Mode A。
-2. copy-in 例外は該当 skill ディレクトリ内に出典とライセンスを残す。
-3. 配布対象なので、`skills/<name>/` のディレクトリ名 = `name` frontmatter にする。
-4. リリースは git タグ。consumer は `kanade0404/skills@<tag>` で固定取得する。
+- **コードでなく `skills/<name>/SKILL.md` を編集する場所**。build/test/lint は無い。
+- **source of truth は `skills/<name>/`**。README / CLAUDE.md に skill 一覧・件数を重複させない。
+- **配布の不変条件**: ディレクトリ名 = frontmatter `name`。
+- **リリースは git タグ `vX.Y.Z`**（手順は [RELEASING.md](RELEASING.md)）。consumer は `@<tag>` で固定取得。
+- **skill 作成・編集・trigger 評価の規範は `skills/skill-builder/SKILL.md`**（frontmatter / 500行 / negative space / eval ループの一次情報）。
+- **サードパーティ skill は vendor しない**。copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,28 @@
+# RELEASING
+
+このリポジトリのリリースは **git タグ `vX.Y.Z`（semver）だけ**。ビルド成果物は無い。
+consumer は `rulesync fetch kanade0404/skills@vX.Y.Z --features skills,...` でそのタグの
+`skills/<name>/` を固定取得する。
+
+## バージョンの上げ方
+
+| 種別 | いつ上げるか |
+|---|---|
+| MAJOR | 互換が壊れる変更: skill の削除 / リネーム（ディレクトリ名 = `name` の変更）/ 既存 skill の挙動契約の変更 |
+| MINOR | 後方互換のある追加: 新規 skill、既存 skill の機能追加 |
+| PATCH | 挙動を変えない修正: description / trigger 調整、本文の言い回し、typo、references 追記 |
+
+## 手順
+
+1. `master` が clean で、リリースに含めたい変更が全て merge 済みであることを確認する。
+2. 次バージョンを決める（上表）。直近タグは `git tag -l --sort=-v:refname | head -1` で確認。
+3. 注釈付きタグを切る:
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z: <要約>"
+   git push origin vX.Y.Z
+   ```
+4. consumer に告知（pin 先を `@vX.Y.Z` に上げてもらう）。
+
+## まだやっていないこと
+
+- タグ push の自動化（GitHub Actions 等）は未対応。手動でタグを切る。

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -139,7 +139,7 @@ rulesync で `kanade0404/skills@<tag>` から `skills/skill-builder/` として�
 **書き方の原則**：
 
 - 「なぜそうするか」を先に書く。`ALWAYS X` ではなく「X しない場合に Y が壊れるから X する」
-- `if`/`while` 等の制御構造で動作を分岐させない（読み手が動作を予測できなくなる）
+- 曖昧・不可視な条件で黙って動作分岐させない（読み手・実行ごとに結果が割れる）。分岐するなら判定基準を**明示・観測可能**にする — Anthropic 公式の Conditional workflow pattern（`Creating?` → A / `Editing?` → B のように観測可能な決定点で分ける）に従う。検証→修正→再検証の feedback loop は推奨
 - 詳細レイヤは `references/<topic>.md` に切り出し、本文からは「対象が X のときだけ参照する」と書く
 - 出力フォーマットは固定する。スキャンしやすさ優先
 


### PR DESCRIPTION
## What

CLAUDE.md をスリム化（68→12行）し、git タグ release を文書化する。これは「skill ブラッシュアップ」プログラムのサブプロジェクト①（統治ドキュメント改訂）。

## Why

- CLAUDE.md が **skill-builder と重複**していた（frontmatter 規約 / 500行 / negative space / eval ループ / 新規 skill 手順）。一次情報は `skills/skill-builder/SKILL.md` なので CLAUDE.md からは削除しポインタ化。
- 「リリースは git タグ」と謳っていたが**タグ0個**で記述が実態と乖離していた。
- `if`/`while` 禁止が **Anthropic 公式ベストプラクティスより厳しすぎた**（公式は Conditional workflow pattern と feedback loop を推奨）。

## Changes

- **CLAUDE.md 68→12行**: 重複を全削除、repo 固有の不変条件のみ残す（配布機構 / dir==name / source-of-truth / no-vendor / release-by-tag）+ skill-builder へのポインタ。
- **skill-builder L142**: if/while 規約を「曖昧・不可視な分岐を禁止。明示的・観測可能な決定点なら可（公式 Conditional workflow pattern 準拠）」に緩和。
- **RELEASING.md 新規**: `vX.Y.Z` semver タグの手順を明文化。

## Follow-up（このPRには含めない）

- マージ後に最初のタグ `v0.1.0` を切る（既存カタログ + 本修正のスナップショット）。
- ②ハーネス本体（entry-orchestrator / pr-monitor / retro / ci-self-heal の Monitor 化 / simplify 挿入）と ③empirical-prompt-tuning の trigger 修正は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured repository documentation to emphasize operational essentials and clear policies
  * Introduced release process guide covering semver git tagging, consumer workflows, and version bump rules
  * Enhanced skill development guidelines with improved conditional logic practices and feedback loop recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->