### PR TITLE
Add session-retro skill (rule/sensor/issue/eval-case の 4 分岐 retro)

### DIFF
--- a/skills/session-retro/SKILL.md
+++ b/skills/session-retro/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: session-retro
+description: |
+  作業セッション (issue 駆動の自走実行・実装・出荷・リリース) の終端で、transcript /
+  会話履歴から学びを抽出し、**rule (CLAUDE.md・skill 改訂 = feedforward) / sensor
+  (テスト・lint・CI チェック追加 = feedback) / issue (繰り越し作業、acceptance criteria
+  必須) / eval-case (golden set 候補)** の 4 分岐に振り分けて提案として出力する振り返り
+  専用スキル。シグナル源は「失敗した tool 呼び出し」「人間による訂正」「エスカレーション」
+  の 3 つに限定し、全ログの漫然とした要約はしない。同じ失敗が 2 回目なら issue でなく
+  rule/sensor に昇格させる。rule 提案は特定の失敗にトレースできるものだけに絞り、追加と
+  同時に既存ルールの剪定候補も提示する。
+
+  issue 対応・実装・出荷セッションの終端 (shipping / linear-issue-driven-development の
+  完了直後)、release 後、「振り返りして」「retro」「レトロして」「このセッションの学びを
+  まとめて」「教訓を残して」「二度と起きないようにして」「学びを CLAUDE.md に反映して」
+  「詰まったことを issue 化しておいて」のような要請、Stop hook からの自動起動、いずれ
+  でも必ず起動すること。
+
+  範囲外: セッションの単純要約 (4 分岐が不要な依頼)、CLAUDE.md 全体の監査・改善
+  (claude-md-improver 等)、いま起きているバグの根本原因分析 (systematic-debugging)、
+  skill 本文のチューニング (skill-builder)、コードレビュー (code-review)。出力は全て
+  **提案まで** — CLAUDE.md 書き換え・golden set 追加・issue 起票は人間の承認を経る。
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+---
+
+# session-retro
+
+> **規律 1**: 複利は issue の数ではなく rule/sensor の蓄積から生まれる。issue は「今やらない作業」の置き場であり、再発防止の置き場ではない。
+> **規律 2**: 同じ問題が 2 回起きたら、それはもう issue ではない。feedforward (rule) か feedback (sensor) を改善して再発確率を下げる。
+> **規律 3**: 特定の過去の失敗にトレースできない rule はノイズ。追加するたびに剪定候補を出す (具体的な 10 ルールは汎用的な 100 ルールに勝る)。
+
+セッションの終端で「このセッションが次のセッションを楽にするもの」を抽出して 4 分岐に振り分ける。振り返りを issue 化だけで終わらせると backlog は伸びるが同じ失敗は再発し続ける。防止は harness (rule/sensor) に、作業は issue に、検証材料は eval-case に、それぞれ正しい置き場へ送るのが本スキルの仕事。
+
+---
+
+## いつ使うか / 使わない場面
+
+**使う**:
+
+- issue 対応・実装・出荷セッションの終端 (shipping / linear-issue-driven-development の完了・エスカレーション直後)
+- release 後の振り返り
+- 「振り返りして」「retro」「学びをまとめて」「教訓を残して」「二度と起きないようにして」
+- 「この学びを CLAUDE.md に反映して」(今セッションの学び由来の最小差分提案として)
+- Stop hook / Routine からの自動起動
+
+**使わない** (成果物で判定):
+
+- セッションの**要約文**だけが欲しい依頼 → 通常の応答で足りる
+- **CLAUDE.md 全体の監査レポート** → claude-md-improver 等の専用系
+- **いま起きている失敗の原因特定** → systematic-debugging (retro は事後、debug は渦中)
+- **skill の description / 本文の改訂そのもの** → skill-builder (retro は「skill を直すべき」という提案までを出す)
+- **コードの findings** → code-review
+
+---
+
+## 入力の解決
+
+上から順に試し、最初に使えたものをシグナル源とする:
+
+1. **transcript JSONL**: `$CLAUDE_SESSION_ID` が定義されていれば `~/.claude/projects/<cwd の / を - に置換した slug>/<session-id>.jsonl` を探す
+2. **会話コンテキスト**: transcript が読めない環境 (cloud / headless / compaction 後) では、本セッションの記憶にある範囲で行う。compaction で古い履歴が失われている場合はその旨をレポートに明記する
+3. **外部証跡**: PR のコメント・CI ログ・エスカレーションコメント (対象がわかっている場合のみ)
+
+## ワークフロー
+
+### Step 1 — シグナル抽出 (3 源限定)
+
+全ログを均等に読まない。以下の 3 つだけを拾う:
+
+| シグナル | transcript での見つけ方 | なぜ高シグナルか |
+|---|---|---|
+| **失敗した tool 呼び出し** | `"is_error": true` の tool_result | 環境・手順・前提の欠陥が集中する |
+| **人間による訂正** | assistant の出力直後に方向修正・否定・やり直し指示をする user メッセージ | 「書き手には自明、agent には不明瞭」の証拠 |
+| **エスカレーション** | `needs-human` ラベル付与、`loop-escalation` コメント、打ち切り宣言 | ループの限界点そのもの |
+
+transcript がある場合の抽出例:
+
+```bash
+jq -r 'select(.type == "user") | .. | objects | select(.is_error == true) | .content' "$TRANSCRIPT" 2>/dev/null | head -30
+```
+
+シグナル 0 件なら「学びなし」で正常終了してよい (無理に絞り出さない。空振りの retro を量産すると形骸化する)。
+
+### Step 2 — 分岐判定
+
+各シグナルに以下を順に問う。1 シグナルが複数分岐に落ちてよい (例: 再発失敗 → rule + eval-case):
+
+1. **過去にも起きた failure か?** (CLAUDE.md・過去 retro・issue 履歴に痕跡があるか)
+   → yes なら **issue は禁止**。rule か sensor に必ず昇格させる
+2. **機械で検出できるか?** (テスト・lint・CI チェック・hook で捕まえられるか)
+   → yes なら **sensor**。人間や agent の注意力に頼る rule より優先する
+3. **事前の一文で防げたか?** (指示・制約・手順として書けるか)
+   → yes なら **rule**。ただし「特定の失敗にトレースできる具体文」で書けるときだけ
+4. **今やらない作業として切り出すべきか?**
+   → yes なら **issue**。acceptance criteria + 検証方法を必ず含める (下記フォーマット)
+5. **再現可能な失敗ケースとして残す価値があるか?** (skill / loop の改訂を検証できるか)
+   → yes なら **eval-case** (golden set 候補)
+
+### Step 3 — 剪定チェック (rule を 1 件でも提案する場合は必須)
+
+rule は足す一方だと context rot でループ全体を劣化させる。追加提案と同時に:
+
+- 対象 CLAUDE.md / skill の既存ルールを読み、**今回のセッションで一度も効いていない・現状と矛盾する・新 rule と重複する**ものを最低 1 件、削除/統合候補として挙げる
+- 候補が本当に無ければ「剪定候補なし」と明記する (省略しない)
+
+### Step 4 — 出力 (提案として)
+
+下記フォーマットで提示する。**この時点ではどこにも書き込まない。**
+
+### Step 5 — 承認後の handoff
+
+| 分岐 | 承認後のアクション | 実装の担当 |
+|---|---|---|
+| rule | 対象 CLAUDE.md / SKILL.md へ最小差分を Edit | 本スキル (差分適用のみ)。skill の構造改訂が要るなら skill-builder へ |
+| sensor | テスト/CI チェックの実装 | tdd (behavioral) / tidy-first (structural) へ handoff |
+| issue | `gh issue create` (下記ドラフトのまま) | 本スキル |
+| eval-case | loop-ops `golden/cases/` への PR 起票 | 本スキル (merge は人間) |
+
+計測イベント (`agent_run` 等) の送信は本スキルの仕事ではなく実行ラッパー / Stop hook の仕事。配線方法は [references/loop-ops-integration.md](references/loop-ops-integration.md) を参照する (loop-ops 連携がある環境でのみ)。
+
+---
+
+## 出力フォーマット
+
+```markdown
+# Session Retro: <セッションの一言要約>
+
+## シグナル
+| # | 種別 (tool失敗/訂正/エスカレーション) | 何が起きたか (1 行) | 再発? |
+|---|---|---|---|
+
+## 分岐
+### rule (feedforward)
+- 提案: <対象ファイル> に「<具体文>」を追加
+  - trace: シグナル #N
+  - 剪定候補: <既存ルールの削除/統合案、無ければ「なし」と明記>
+### sensor (feedback)
+- 提案: <テスト/lint/CI チェックの具体案> — trace: #N
+### issue (deferred work)
+- <下記ドラフト形式> — trace: #N
+### eval-case (golden set 候補)
+- <下記ドラフト形式> — trace: #N
+
+## 見送り
+- <シグナルだが分岐に値しないと判断したもの + 理由>
+
+## 承認待ちアクション
+- [ ] rule 適用 / [ ] sensor handoff / [ ] issue 起票 / [ ] eval-case PR
+```
+
+### issue ドラフト形式 (acceptance criteria 必須)
+
+自走ループの成否は issue の入口品質で決まる。以下を欠く issue は起票しない:
+
+```markdown
+title: <動詞で始まる 1 行>
+body:
+## 背景
+<なぜやるか。retro のどのシグナル由来か>
+## Acceptance Criteria
+- [ ] <機械 or 人間が判定可能な条件。「いい感じ」禁止>
+## 検証方法
+<どのコマンド / テスト / 操作で満たしたと判定するか>
+```
+
+### eval-case ドラフト形式
+
+loop-ops `golden/cases/<id>.md` の形式に合わせる:
+
+```markdown
+---
+id: <kebab-case>
+type: canary | should-escalate | regression
+source: <この retro の対象セッション / PR の URL>
+target_repo: <repo>
+expected_outcome: <merged | escalated:<reason> | ...>
+verifier: <合否の機械判定方法>
+runs: 3
+---
+<agent に渡す issue 本文>
+```
+
+---
+
+## このスキルがやらないこと
+
+- **CLAUDE.md の全体監査レポート** (今セッション由来の最小差分提案のみ)
+- **skill 本文の改訂そのもの** (「直すべき」という提案と根拠まで。実装は skill-builder)
+- **テスト / CI チェックの実装** (sensor の仕様提示まで。実装は tdd / tidy-first)
+- **golden set への直接コミット** (PR 提案まで。merge は人間 — 改善対象の agent が自分の合格基準を書ける状態にしないため)
+- **計測イベントの送信** (実行ラッパー / Stop hook の責務。references 参照)
+- **承認前のあらゆる書き込み**
+
+## リファレンス
+
+- [references/loop-ops-integration.md](references/loop-ops-integration.md) — loop-ops (計測データストア) 連携: Stop hook での agent_run 送信、eval-case PR の出し方、エスカレーション形式。loop-ops を使う環境でのみ参照する

--- a/skills/session-retro/evals/session-retro-trigger-results-2026-07-03.jsonl
+++ b/skills/session-retro/evals/session-retro-trigger-results-2026-07-03.jsonl
@@ -1,0 +1,16 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"description の「振り返りして」に直接マッチ"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「retro」を明示列挙"}
+{"id":"t03","predicted":true,"actual":true,"reason":"rule/sensor/issue の 4 分岐は本文の中核語彙"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「release 後」を発火条件に明示"}
+{"id":"t05","predicted":true,"actual":true,"reason":"eval-case / golden set 候補を description に明示"}
+{"id":"t06","predicted":true,"actual":true,"reason":"「二度と起きないようにして」を明示列挙"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「学びを CLAUDE.md に反映して」を明示列挙 (全体監査は negative space で除外済み)"}
+{"id":"t08","predicted":true,"actual":true,"reason":"「詰まったことを issue 化しておいて」を明示列挙"}
+{"id":"t09","predicted":true,"actual":true,"reason":"「教訓を残して」に近接、終端の学び抽出は主目的"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space に「CLAUDE.md 全体の監査 (claude-md-improver 等)」を明示"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space に systematic-debugging を明示 (retro は事後、debug は渦中)"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space に skill-builder を明示"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space に「セッションの単純要約」を明示"}
+{"id":"f05","predicted":false,"actual":false,"reason":"レビュー対応の語彙は description に無く、pr-review-respond が拾う領域"}
+{"id":"f06","predicted":false,"actual":false,"reason":"「レトロ」を含むが調査依頼。FP リスク最有力ケースとして継続監視"}
+{"id":"f07","predicted":false,"actual":false,"reason":"計測集計の語彙は retro の発火条件に含まれない"}

--- a/skills/session-retro/evals/session-retro-trigger.json
+++ b/skills/session-retro/evals/session-retro-trigger.json
@@ -1,0 +1,118 @@
+{
+  "target_skill": "session-retro",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "このセッションの振り返りをして",
+      "should_trigger": true,
+      "rationale": "明示的な振り返り要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "retro お願い",
+      "should_trigger": true,
+      "rationale": "retro は description に列挙した直接トリガ",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "今回の学びを rule / sensor / issue に振り分けて",
+      "should_trigger": true,
+      "rationale": "4 分岐そのものの要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "リリースまで終わったので、振り返って教訓をまとめておいて",
+      "should_trigger": true,
+      "rationale": "release 後の振り返りは主経路",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t05",
+      "prompt": "このセッションで失敗したやつ、golden set の eval ケースにしておいて",
+      "should_trigger": true,
+      "rationale": "eval-case 分岐の明示要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t06",
+      "prompt": "さっきのミス、二度と起きないようにしておいて",
+      "should_trigger": true,
+      "rationale": "再発防止 = rule/sensor 昇格の口語形",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t07",
+      "prompt": "今回わかったこと、CLAUDE.md に反映しといて",
+      "should_trigger": true,
+      "rationale": "今セッションの学び由来の rule 提案 (全体監査ではない)",
+      "tags": ["ambiguous", "edge"]
+    },
+    {
+      "id": "t08",
+      "prompt": "今日詰まったところ、あとでやる issue にしといて",
+      "should_trigger": true,
+      "rationale": "セッション由来の deferred work 切り出し = issue 分岐",
+      "tags": ["ambiguous", "edge"]
+    },
+    {
+      "id": "t09",
+      "prompt": "作業終わり。次に活かせることあったら残しておいて",
+      "should_trigger": true,
+      "rationale": "終端での学び抽出の口語形",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "f01",
+      "prompt": "CLAUDE.md 全体を監査して品質レポートを出して",
+      "should_trigger": false,
+      "rationale": "全体監査は claude-md-improver 系の領域",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f02",
+      "prompt": "このテストがなぜ落ちるのか根本原因を調べて",
+      "should_trigger": false,
+      "rationale": "渦中のデバッグは systematic-debugging (retro は事後)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f03",
+      "prompt": "session-retro skill が発火しないので description を直して",
+      "should_trigger": false,
+      "rationale": "skill のチューニングは skill-builder",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f04",
+      "prompt": "このセッションで何をやったか要約して",
+      "should_trigger": false,
+      "rationale": "要約文だけの依頼に 4 分岐は過剰 (成果物が違う)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f05",
+      "prompt": "PR に付いたレビューコメントに対応して",
+      "should_trigger": false,
+      "rationale": "pr-review-respond の領域",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f06",
+      "prompt": "チームでやるスプリントレトロスペクティブの進め方を調べて",
+      "should_trigger": false,
+      "rationale": "レトロという語を含むが調査依頼 (research-practices)",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "f07",
+      "prompt": "loop-ops のイベント JSONL を集計して今月の成功率を出して",
+      "should_trigger": false,
+      "rationale": "計測データの集計であって振り返りの 4 分岐ではない",
+      "tags": ["distractor"]
+    }
+  ]
+}

--- a/skills/session-retro/references/loop-ops-integration.md
+++ b/skills/session-retro/references/loop-ops-integration.md
@@ -1,0 +1,69 @@
+# loop-ops 連携
+
+session-retro を [loop-ops](https://github.com/kanade0404/loop-ops) (private な計測データストア) と
+組み合わせる環境での配線。loop-ops を使わない環境ではこのファイルは無視してよい。
+
+## 責務の分離
+
+| 何を | 誰が | いつ |
+|---|---|---|
+| `agent_run` イベント送信 (cost / turns / subtype) | **実行ラッパー / Stop hook** | agent 実行の終端で必ず |
+| `escalated` イベント送信 | エスカレーション処理 (実行側 skill) | needs-human 付与と同時 |
+| retro の 4 分岐出力 | session-retro (本体) | セッション終端 |
+| eval-case の PR 起票 | session-retro (承認後) | retro 承認後 |
+
+session-retro 自身はイベントを送らない。セッション内から自分の総コスト・ターン数は取れないため、
+`agent_run` は **セッションの外側** (ResultMessage / `claude -p --output-format json` の出力を持つ側)
+が送る。
+
+## Stop hook での agent_run 送信 (実行ラッパー側の設定例)
+
+`claude -p` をラップする実行スクリプトの終端で:
+
+```bash
+# result.json = claude -p --output-format json の出力
+jq -n \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "$OWNER/$REPO" --argjson issue "${ISSUE_NUMBER:-null}" \
+  --arg phase "implement" \
+  --arg subtype "$(jq -r '.subtype // "unknown"' result.json)" \
+  --argjson turns "$(jq '.num_turns // 0' result.json)" \
+  --argjson cost "$(jq '.total_cost_usd // 0' result.json)" \
+  --arg session "$(jq -r '.session_id // ""' result.json)" \
+  '{v: 1, ts: $ts, event: "agent_run", repo: $repo, issue: $issue, phase: $phase,
+    result_subtype: $subtype, num_turns: $turns, total_cost_usd: $cost, session_id: $session}' \
+  | bash emit-event.sh   # loop-ops/scripts/emit-event.sh (要 LOOP_OPS_TOKEN)
+```
+
+`phase` は `implement | ci-fix | review-respond | conflict-resolve | retro | meta` から。
+対話セッションで hook として仕込む場合は Stop hook から同スクリプトを叩く
+(transcript パスが hook 入力で渡るので、そこから session_id を拾える)。
+
+## eval-case の PR 起票
+
+retro が承認された eval-case は loop-ops に PR で送る:
+
+```bash
+# 1 ファイルなので contents API で branch + PR を作るのが最短
+gh api repos/<owner>/loop-ops/git/refs -f ref="refs/heads/eval/<id>" \
+  -f sha="$(gh api repos/<owner>/loop-ops/git/ref/heads/master --jq '.object.sha')"
+gh api -X PUT "repos/<owner>/loop-ops/contents/golden/cases/<id>.md" \
+  -f branch="eval/<id>" -f message="eval: add <id> (from session retro)" \
+  -f content="$(base64 < case.md | tr -d '\n')"
+gh pr create -R <owner>/loop-ops --head "eval/<id>" --title "eval: <id>" \
+  --body "source: <セッション/PR URL>. 承認後 merge (agent は self-merge しない)"
+```
+
+**merge は必ず人間**。改善対象の agent が自分の合格基準を書ける状態にしない、という
+golden set の不変条件 (loop-ops/golden/README.md) を守る。
+
+## エスカレーション形式との整合
+
+retro がエスカレーション由来のシグナルを扱うとき、reason は loop-ops の taxonomy
+(`docs/taxonomy.md`) の enum を使う: `budget-exceeded / max-turns / ci-3-fail /
+review-5-rounds / no-progress / ambiguous-issue / repo-unresolvable / conflict /
+security-block / other`。
+
+`ambiguous-issue` は失敗ではなく「issue の入口品質の問題を上流に返した正常動作」。
+retro ではこれを issue の書き方の rule (例: acceptance criteria テンプレの改善) に
+昇格させる候補として扱う。


### PR DESCRIPTION
## Summary
- セッション終端の振り返り skill を追加。学びを **rule (feedforward) / sensor (feedback) / issue (deferred work) / eval-case (golden set 候補)** の 4 分岐に振り分けて提案として出力する
- 設計根拠は loop engineering 調査 (compounding engineering / harness engineering) の合意事項:
  - 複利は issue の数ではなく rule/sensor の蓄積から生まれる
  - 同じ失敗の 2 回目は issue 禁止で rule/sensor 昇格
  - rule は特定の失敗にトレースできるものだけ + 追加時は剪定候補を必須提示 (context rot 対策)
  - シグナル源は「失敗 tool 呼び出し / 人間の訂正 / エスカレーション」の 3 つに限定 (漫然とした全ログ要約の禁止)
- 全出力は提案まで。CLAUDE.md 書き換え / issue 起票 / golden set PR は人間承認後 (agent が自分の合格基準を書けない構造)
- loop-ops 連携 (agent_run イベントは実行ラッパー / Stop hook の責務、eval-case の PR 手順) は references/ に分離し、loop-ops を使わない consumer では無視できる形

## 構成
- `skills/session-retro/SKILL.md` (202 行)
- `skills/session-retro/references/loop-ops-integration.md`
- `skills/session-retro/evals/session-retro-trigger.json` (16 ケース: explicit 5 / ambiguous 4 / adjacent 5 / distractor 2)
- 初回ベースライン結果 (1-rater 自己測定 F1=1.0 — 書き手バイアス込みの参考値)

## Self-review (skill-builder Mode A checklist)
- [x] 500 行以内 (202)
- [x] description に should-use 口語 8 種 + negative space 5 件 + 三人称 + 1024 字以内
- [x] ディレクトリ名 = frontmatter name (配布不変条件)
- [x] negative space は成果物で定義 (監査レポート / findings / 要約文 / description 改訂)
- [x] 既存 skill との境界を名指し (claude-md-improver / systematic-debugging / skill-builder / code-review / pr-review-respond / tdd / tidy-first)
- [ ] マルチモデル trigger 検証 (未 — skill-builder の既知の限界と同じ)

## Test plan
- [ ] merge 後、実セッション終端で 1 回起動して 4 分岐出力を確認
- [ ] f06 (「スプリントレトロの進め方を調べて」) が FP しないか実運用で監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcnmrjKiVvAYmDbCcixzX3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new session-retro skill for capturing end-of-session and post-release learnings, with guidance on routing signals into rules, feedback, issues, or evaluation cases.
  * Added evaluation cases and trigger scenarios to validate when the skill should run.
* **Documentation**
  * Added integration guidance for connecting session-retro with loop-ops, including event flow and approval steps for retro outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->