### PR TITLE
Add issue-driven-development skill (GitHub 版、イベント分割設計)

### DIFF
--- a/skills/issue-driven-development/SKILL.md
+++ b/skills/issue-driven-development/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: issue-driven-development
+description: |
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
+  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
+  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
+  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
+  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
+  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
+
+  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
+  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
+  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
+  `claude-loop:N` ラベルで PR に永続化する。
+
+  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
+  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
+  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
+  いずれでも必ず起動すること。
+
+  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
+  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
+  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
+  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  素の `git` / `gh` だけで動くこと。
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+---
+
+# issue-driven-development
+
+GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。**PR 作成が終端** — CI 緑化
+とレビュー対応はイベント駆動の別反応に委ね、本スキルは長い実装セッション 1 回分だけを持つ。
+
+> **Iron Law 1**: acceptance criteria が無い issue は実装しない。`ambiguous-issue` で止まるのが正解。
+> **Iron Law 2**: CI を watch しない。PR を作ったら終わる (待ちはイベントに置き換える)。
+> **Iron Law 3**: テストと CI 設定を弱める変更 (削除・skip・閾値緩和) は書かない。
+
+## 前提となる secret / env
+
+| 変数 | 用途 | 必須 |
+|---|---|---|
+| `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
+| `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+
+## 入力契約
+
+いずれかで issue を特定する:
+
+- **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
+- **B. 手動**: `owner/repo#123` 形式の識別子
+- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+  `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+
+Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
+
+## 排他制御 (二重起動防止)
+
+ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+
+0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
+1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
+2. `claude:ready` を外し `claude:in-progress` を付ける
+3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
+   - 自分が最古 → 続行
+   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+
+ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
+`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+
+Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
+([references/actions-wiring.md](references/actions-wiring.md))。
+
+## 入口ゲート — acceptance criteria 検証
+
+issue 本文に以下が読み取れるか確認する:
+
+- **Acceptance Criteria**: 機械または人間が判定可能な完了条件 (「いい感じ」「今風」は不可)
+- **検証方法**: どのコマンド / テスト / 操作で満たしたと判定するか (明示が無くても AC から
+  自明に導けるなら可)
+
+読み取れない場合は**実装に入らず**エスカレーション (reason: `ambiguous-issue`) する。
+これは失敗ではなく、issue の入口品質の問題を上流に返す正常動作。**推測でスコープを
+埋めて実装を始めることを禁じる** — 未指定の細部は実行毎に揺れ、レビュー不能な PR を生む。
+
+## 主要ステップ
+
+### 1. リポジトリ取得と branch
+
+```bash
+gh repo clone "$OWNER/$REPO" repo && cd repo   # Actions 上で checkout 済みならスキップ
+BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+git switch -c "claude/issue-${NUMBER}-<slug>" "origin/$BASE"
+```
+
+slug は issue タイトルから生成 (小文字・ハイフン・40 字以内)。
+
+### 2. 実装方針
+
+- リポジトリの `CLAUDE.md` / `AGENTS.md` / `README.md` を読み、規約・テスト/lint コマンドを確認
+- AC を満たす**最小変更**を設計する。機能を勝手に広げない
+- 解釈の余地があった点は PR description に書く (issue に質問コメントは投げない —
+  ヘッドレスなので返答を待てない。判断できないほど曖昧なら入口ゲートに戻って escalate)
+
+### 3. 実装 + テスト
+
+- behavioral change は `tdd` の規律 (先に失敗するテスト)、structural は `tidy-first` に従う
+- リポジトリにテストがあれば必ずローカル実行し、green を確認してから commit
+- テストが無ければビルド・型チェック・lint を通す
+- **既存テストの削除・skip 化・アサーション緩和・CI 設定の弱体化はしない** (Iron Law 3)。
+  テストが間違っていると判断した場合はその根拠を PR に書き、テスト修正だけの commit に分離する
+
+### 4. commit / push / PR
+
+```bash
+git add <変更ファイルを明示>   # git add -A は使わない
+git commit -m "<repo 規約に従う subject>
+
+<why を説明する body>
+
+Refs: #${NUMBER}"
+git push -u origin "claude/issue-${NUMBER}-<slug>"
+gh pr create --title "<subject> (#${NUMBER})" --body "$(printf '## Summary\n- ...\n\nCloses #%s\n\n## 解釈と判断\n- <AC の解釈で自分が決めた点>\n\n## Test plan\n- [x] <実行したテスト/検証>\n' "$NUMBER")"
+```
+
+- PR body の `Closes #N` は必須 (issue 自動クローズ + 計測の issue 紐付けの両方に使われる)
+- issue ラベルに `claude:draft` があれば `--draft`
+
+### 5. 終端処理 — ここで終了する
+
+- PR URL を issue にコメントし、`claude:in-progress` → `claude:done` に張り替える
+  (done = 「PR 作成まで完了」の意。merge ではない)
+- **CI を watch しない。レビューを待たない。** 以降は次の反応が引き継ぐ:
+
+| イベント | 反応 (別トリガで起動) | 上限 |
+|---|---|---|
+| CI 失敗 (`workflow_run`) | `ci-self-heal` — 修正 push ごとに `claude-loop:N` を進める | N=3 で escalate |
+| レビューコメント | `pr-review-respond` | 5 周で escalate |
+| conflict | `pr-conflict-resolver` | — |
+
+- 反応側の no-progress 検出: 直前の自分の修正と同一ファイル・同一失敗なら反復せず escalate
+
+## エスカレーション
+
+どの段階でも継続不能になったら:
+
+1. `needs-human` ラベルを付け、`claude:in-progress` を外し `claude:failed` を付ける
+2. issue (PR があれば PR) に構造化コメントを投稿する:
+
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか>
+
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "<enum>", "detail": "<1-2 文>", "attempts": <n>, "session_id": "<取れれば>", "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+reason は次の enum から: `budget-exceeded / max-turns / ci-3-fail / review-5-rounds /
+no-progress / ambiguous-issue / repo-unresolvable / conflict / security-block / other`。
+`LOOP_OPS_TOKEN` があれば `escalated` イベントも送信する (無ければコメントのみで良い —
+PR クローズ時の収集がフォールバックで拾う)。
+
+## ガードレール
+
+- **destructive git 禁止**: `reset --hard` / `push --force*` / `rebase` を使わない。修正は常に追加 commit
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類
+- **PR を merge しない**: merge は常に人間ゲート
+- **`.github/workflows/` を変更しない**: CI の変更が必要なら escalate (security-block)
+- **予算上限は起動側が持つ**: runner は `--max-turns` / `--max-budget-usd` を必ず設定する
+  (超過時の subtype がそのまま escalation reason になる)。設定方法は references 参照
+- **他人の branch に触らない**: 常に新規 `claude/issue-*` branch
+
+## リファレンス
+
+- [references/actions-wiring.md](references/actions-wiring.md) — トリガ配線 (claude-code-action ラベル起動 / Routines)、concurrency・自己発火ガード・SHA ピン留め・最小権限、`claude-loop:N` の進め方、`agent_run` 計測イベントの送信。**配線作業をする時だけ読む**

--- a/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
+++ b/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動識別子モードを明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/skills/issue-driven-development/evals/issue-driven-development-trigger.json
+++ b/skills/issue-driven-development/evals/issue-driven-development-trigger.json
@@ -1,0 +1,97 @@
+{
+  "target_skill": "issue-driven-development",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "claude:ready ラベルの issue を処理して PR まで作って",
+      "should_trigger": true,
+      "rationale": "ラベル駆動の主経路そのもの",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "kanade0404/skills#11 をやって PR 作成まで自走して",
+      "should_trigger": true,
+      "rationale": "手動識別子モード",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "GitHub issue から実装して PR 出すところまでヘッドレスでやって",
+      "should_trigger": true,
+      "rationale": "issue→PR の自走要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "この issue やっておいて",
+      "should_trigger": true,
+      "rationale": "issue 対応の委譲 (口語)",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t05",
+      "prompt": "issue #42 の対応、離席中に終わらせておいて",
+      "should_trigger": true,
+      "rationale": "無人完遂の要請",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t06",
+      "prompt": "毎時の Routine から: claude:ready の issue を 1 件選んで処理",
+      "should_trigger": true,
+      "rationale": "Routine 主経路",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "f01",
+      "prompt": "Linear の ENG-123 を処理して",
+      "should_trigger": false,
+      "rationale": "Linear issue は linear-issue-driven-development",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f02",
+      "prompt": "実装できたから ship して。CI もレビューも全部通して",
+      "should_trigger": false,
+      "rationale": "ローカル実装後の出荷は shipping",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f03",
+      "prompt": "PR の CI が落ちてるから直して",
+      "should_trigger": false,
+      "rationale": "CI 修正単体は ci-self-heal (イベント分割の後半)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f04",
+      "prompt": "CodeRabbit のコメントに対応して",
+      "should_trigger": false,
+      "rationale": "レビュー対応単体は pr-review-respond",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f05",
+      "prompt": "この PR を merge して",
+      "should_trigger": false,
+      "rationale": "merge は人間ゲート (本スキルは merge しない)",
+      "tags": ["adjacent", "edge"]
+    },
+    {
+      "id": "f06",
+      "prompt": "issue のテンプレートを作って",
+      "should_trigger": false,
+      "rationale": "issue という語を含むが issue 処理ではない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "f07",
+      "prompt": "今週の open issue を一覧して優先度を付けて",
+      "should_trigger": false,
+      "rationale": "トリアージであって実装自走ではない",
+      "tags": ["distractor"]
+    }
+  ]
+}

--- a/skills/issue-driven-development/references/actions-wiring.md
+++ b/skills/issue-driven-development/references/actions-wiring.md
@@ -1,0 +1,108 @@
+# Actions / Routines 配線
+
+issue-driven-development を無人で回すためのトリガ配線。**配線作業をする時だけ読む。**
+セキュリティ既定 (SHA ピン留め・最小権限・外部コントリビュータ除外) は省略せず全て適用する。
+
+## 方式の選択
+
+| 方式 | 即時性 | 予算の持ち方 | 向き |
+|---|---|---|---|
+| **A. claude-code-action (ラベルトリガ)** | 即時 | workflow 内で `--max-turns` / budget | 単一 repo で完結させたい時 |
+| **B. Routines (GitHub イベント / 毎時)** | イベント or 毎時 | Routine プロンプトで指示 | subscription 枠で回したい時・複数 repo |
+
+どちらも本スキル (SKILL.md) を実行させる点は同じ。トリガと実行環境だけが違う。
+
+## A. claude-code-action ラベルトリガ
+
+```yaml
+# .github/workflows/claude-issue.yml (対象 repo)
+name: claude-issue
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: claude-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    # ラベルゲート = セキュリティゲート: ラベルは write 権限者しか付けられない。
+    # 自己発火ガード: Claude App 自身のイベントでは起動しない
+    if: >
+      github.event.label.name == 'claude:ready' &&
+      !endsWith(github.actor, '[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@<SHA をピン留め> # vX.Y.Z
+      - uses: anthropics/claude-code-action@<SHA をピン留め> # vX.Y.Z
+        with:
+          claude_args: "--max-turns 80"
+          prompt: |
+            issue-driven-development skill に従い、この repo の issue #${{ github.event.issue.number }} を処理して PR 作成まで完遂すること。
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+注意:
+
+- action の参照は**必ずコミット SHA でピン留め** (floating tag は供給網リスク)
+- `pull_request_target` は使わない。fork からの issue/PR で secrets が要る workflow を起動しない
+- issue 本文はプロンプトに直接埋め込まない ( injection 面)。番号だけ渡し、skill 側が gh で読む
+
+## B. Routines
+
+```
+毎時 (または GitHub issues イベント):
+  対象 repo で claude:ready ラベルの open issue を作成日昇順で 1 件選び、
+  issue-driven-development skill に従って PR 作成まで完遂する。
+  0 件なら何もせず終了する。
+```
+
+- Routine の secrets に `GH_TOKEN` (repo スコープ PAT)、任意で `LOOP_OPS_TOKEN`
+- 排他はスキル本体の lock コメント protocol が守る (毎時 cron と手動の併走を想定済み)
+
+## CI 修正・レビュー対応の反応 (イベント分割の後半)
+
+```yaml
+# CI 失敗への有界な反応の例 (概形)
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+jobs:
+  fix:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
+    # → claude-code-action で ci-self-heal 相当を 1 反応だけ実行
+```
+
+反応側の必須ルール:
+
+- **`claude-loop:N` を進める**: 修正 push の前に PR の現在値を読み、N>=3 なら修正せず
+  escalate (`ci-3-fail`)。ラベル更新と judge は反応の冒頭で行う
+- **no-progress**: 直前の自分の commit と同一ファイル・同一失敗なら反復せず escalate
+- **自己発火ガード**: 反応が push した commit で自分自身が再起動しない条件を必ず入れる
+
+## 計測 (agent_run) の送信
+
+実行の終端で ResultMessage 相当 (`claude -p --output-format json` の出力、または
+Action の実行結果) から 1 イベントを送る。loop-ops を使う環境のみ:
+
+```bash
+jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "$OWNER/$REPO" --argjson issue "$NUMBER" --arg phase "implement" \
+  --arg subtype "$SUBTYPE" --argjson turns "$TURNS" --argjson cost "$COST" \
+  --arg session "$SESSION_ID" \
+  '{v:1, ts:$ts, event:"agent_run", repo:$repo, issue:$issue, phase:$phase,
+    result_subtype:$subtype, num_turns:$turns, total_cost_usd:$cost, session_id:$session}' \
+  | bash emit-event.sh   # loop-ops/scripts/emit-event.sh (要 LOOP_OPS_TOKEN)
+```
+
+phase は反応の種類に合わせる: `implement` (本スキル) / `ci-fix` / `review-respond`。
+PR クローズ時の `pr_closed` は loop-ops の collect-metrics.yml (loop-metrics 配線) が拾う。


### PR DESCRIPTION
## Summary
- `linear-issue-driven-development` の **GitHub 移植版**。自走ループの中核部品
- 主要な設計差分 (loop engineering 調査での合意事項を反映):
  1. **イベント分割** — 本スキルは PR 作成で終了し、CI を watch しない。CI 修正 / レビュー対応は Actions イベントによる有界な反応 (`ci-self-heal` / `pr-review-respond`) が引き継ぐ。ループは while 文でなくイベント連鎖として現れる (runner 分数と 6h 上限の回避、fresh context の担保)
  2. **入口ゲート** — acceptance criteria の無い issue は実装せず `ambiguous-issue` でエスカレート。推測実装の禁止 (自走の成否は issue の入口品質で決まる)
  3. **ループ制御** — `claude-loop:N` ラベルカウンタ (3 で escalate)、no-progress 検出、予算は起動側の `--max-turns` / `--max-budget-usd`
  4. **エスカレーション** — `needs-human` + `loop-escalation:v1` 構造化コメント (loop-ops taxonomy 準拠。loop-metrics 収集がパース可能)
  5. **ガードレール** — テスト/CI 弱体化の禁止 (reward hacking 対策)、`.github/workflows/` 変更禁止、merge しない (人間ゲート)、destructive git 禁止
- Linear 版から簡素化: 対象 repo の解決が不要 (issue の属する repo が対象)、branchName 生成は `claude/issue-N-slug`
- 配線 (claude-code-action ラベル起動の workflow 例 / Routines / concurrency / SHA ピン留め / 自己発火ガード / agent_run 計測送信) は references/actions-wiring.md に分離

## 構成
- SKILL.md (183 行) / references/actions-wiring.md (108 行)
- trigger eval 13 ケース (explicit 4 / ambiguous 2 / adjacent 5 / distractor 2) + 初回ベースライン (自己測定 13/13)

## Self-review (skill-builder Mode A)
- [x] 500 行以内 / 三人称 description / ディレクトリ名 = name
- [x] 境界の名指し: linear-issue-driven-development / shipping / ci-self-heal / pr-review-respond / pr-conflict-resolver / merge=人間ゲート
- [x] Iron Law 3 件 (AC 無しは実装しない / CI を watch しない / テストを弱めない)
- [ ] マルチモデル trigger 検証 (未)

## Test plan
- [ ] merge + タグ後、skills repo 自身の issue #11 (trigger eval CI 化) を第一号として手動モードで流す
- [ ] その結果を session-retro にかけて skill を改訂する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcnmrjKiVvAYmDbCcixzX3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for a new issue-to-PR automation workflow that handles labeled issues end-to-end and stops after creating a pull request.
  * Expanded automation support with clearer handling for issue selection, locking, and escalation when requirements are unclear.

* **Documentation**
  * Added setup and operation notes for running the workflow safely with GitHub Actions.

* **Tests**
  * Added evaluation cases to validate trigger behavior for the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->