### PR TITLE
Add commit skill (guardrail-safe staging + file-based message)

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: commit
+description: >-
+  git commit を「観測 → ガード → 明示パス staging → ファイル経由メッセージ → 検証」の固定順で作る skill。`git add
+  -A` / `git add .` / heredoc を使わないため、permission / hook
+  で汎用コマンドが拒否される環境でもブロックされずに完走する。「commit して」「コミット作って」「この変更コミットしといて」「stage して
+  commit」「きりのいいところで commit 切って」「一区切りだから記録して」のような要請、および tdd / tidy-first /
+  shipping の各サイクル終端の commit 作成で必ず起動すること。commit までが責務 — push・PR 作成は
+  `shipping`(検証ループ付き)または `commit-commands:commit-push-pr` に、リリースタグは RELEASING.md
+  の手順に、structural / behavioral の分割判断は `tidy-first` に渡す。履歴書き換え (amend / rebase /
+  squash / reset / revert) と commit 取り消しは範囲外 — 新規 commit を作る要請だけを扱う。
+---
+# Commit
+
+コミット作成を、guardrail の強い環境 (permission / hook が `git add -A`・`cat`・heredoc 等を
+拒否する設定) でも**一発で通る手順に固定**する skill。拒否 → 言い換えリトライの往復は
+それ自体が時間と context の浪費であり、拒否されない形を最初から使えば往復は発生しない。
+個別の禁止コマンドは列挙しない — 設定が真実であり (`rules/bash-and-api-discipline.md`)、
+本 skill は**どの設定下でも拒否されにくい最小手順**だけを規定する。
+
+## いつ使うか / 使わない場面
+
+**使う**: コミット作成の要請すべて。「commit して」「コミットしといて」「この変更で commit
+作って」「stage して commit」「きりのいいところで commit 切って」。tdd の GREEN 直後、
+tidy-first の tidying 単位、shipping Phase 3 など上流 skill からの commit 局面も同じ。
+
+**使わない** (成果物で線を引く):
+
+| 要求される成果物 | 渡す先 |
+|---|---|
+| push 済みブランチ + PR | `shipping` (検証ループ付き) / `commit-commands:commit-push-pr` |
+| リリースタグ | RELEASING.md の手順 (存在するリポの場合) |
+| 書き換えられた履歴 (amend / rebase / squash / reset / revert) | 範囲外。明示要求されたら本 skill の外で直接対応 |
+| structural / behavioral の分割方針 | `tidy-first` (何をコミットに入れるかの判断は上流) |
+
+## ワークフロー (順序固定)
+
+### Step 1 — 観測
+
+```bash
+git status --short
+git diff --stat          # unstaged
+git diff --cached --stat # staged (残留がないか)
+git rev-parse --abbrev-ref HEAD
+```
+
+働きかけの前に必ず現状を見る。既に staged の変更が残っていたら、それが今回のコミットに
+属するかを判定してから進む (無言で巻き込まない)。
+
+### Step 2 — ガード
+
+- **default ブランチ (main / master) に居るなら**: 直コミットせず、先にブランチ作成を提案する
+  (`git switch -c <topic>`)。ユーザが「master に直接で良い」と明示したときだけ続行。
+- **無関係な変更が混在**: 1 コミット 1 関心事。混在していたら分割を提案し、今回分だけを
+  staging 対象にする。
+- **コミット対象が空**: 何も stage せず「コミット対象がない」と報告して終了。
+
+### Step 3 — 明示パス staging
+
+```bash
+git add <path1> <path2> <dir/>   # 対象を列挙する。ディレクトリ指定は可
+```
+
+`-A` / `.` / `-u` / `--all` は**使わない**。guardrail 環境で拒否される代表格であり、
+拒否されない環境でも「何が入ったか」を Step 1 の観測と突き合わせられる明示列挙の方が
+巻き込み事故を構造的に防ぐ。staging 後に `git status --short` で意図どおりかを確認する。
+
+### Step 4 — メッセージはファイル経由
+
+メッセージは Write ツールで一時ファイル (scratchpad があればそこ、無ければ
+`/tmp` 相当) に書き、`-F` で渡す:
+
+```bash
+git commit -F <scratch>/commit-msg.txt
+```
+
+`-m` + heredoc / `$(cat <<EOF ...)` は**使わない** — heredoc・`cat` は guardrail 環境で
+拒否される上、複数行・引用符・記号を含むメッセージのエスケープ事故源になる。
+ハーネスが trailer (Co-Authored-By 等) を要求している場合はファイル末尾に含める。
+
+メッセージ本文は conventional な形式に固定する:
+
+```
+<要約 1 行 (50-72 字目安、何を＋なぜ)>
+
+- <変更点 1>
+- <変更点 2>
+<必要なら trailer>
+```
+
+### Step 5 — 検証と報告
+
+```bash
+git log -1 --stat
+```
+
+SHA・ファイル数・行数を確認してから報告する。**pre-commit hook が失敗したら**:
+root cause を読み、直せるものは直して再実行する。`--no-verify` での回避は
+ユーザの明示指示なしには使わない。同型の失敗が 2 回続いたら止めて報告する
+(`rules/bash-and-api-discipline.md` の「同型再試行しない」に従う)。
+
+## このスキルがやらないこと (成果物で定義)
+
+- **push された commit / PR**: 作らない。commit 作成で停止し、続きは呼出側が判断する。
+- **書き換えられた履歴**: amend / rebase / squash / reset / force 系は既定で出力しない。
+- **`--no-verify` で hook を迂回した commit**: 明示指示なしには作らない。
+- **staging 全量 (`-A` / `.`) による commit**: どの環境でも作らない。
+- **コミット分割方針の決定**: structural / behavioral の判断は `tidy-first` の成果物。
+
+## リファレンス
+
+- `rules/bash-and-api-discipline.md` — ブロック時の復帰手順・専用ツール優先の一般規律

--- a/.agents/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
+++ b/.agents/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,18 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"description の「commit して」に直接マッチ"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「コミット作って」が verbatim で列挙されている"}
+{"id":"t03","predicted":true,"actual":true,"reason":"「stage して commit」が verbatim で列挙されている"}
+{"id":"t04","predicted":true,"actual":true,"reason":"メッセージ作成込みでも成果物は commit 作成"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「この変更コミットしといて」系の直接要請"}
+{"id":"t06","predicted":true,"actual":true,"reason":"「きりのいいところで commit 切って」verbatim"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「一区切りだから記録して」verbatim"}
+{"id":"t08","predicted":true,"actual":true,"reason":"弱マッチ: 「保存」は非掲載だがリポ文脈+リファクタ完了で commit 要請と解釈可能。FN リスク箇所として記録"}
+{"id":"t09","predicted":true,"actual":true,"reason":"弱マッチ: 「テスト通った」= tdd サイクル終端の commit 局面が description に明記"}
+{"id":"t10","predicted":false,"actual":false,"reason":"push・PR は shipping / commit-push-pr へ、と negative space に明記"}
+{"id":"t11","predicted":false,"actual":false,"reason":"リリースタグは RELEASING.md へ、と明記"}
+{"id":"t12","predicted":false,"actual":false,"reason":"履歴書き換え (amend) は範囲外と明記 (初稿の曖昧文を修正済み)"}
+{"id":"t13","predicted":false,"actual":false,"reason":"squash = 履歴書き換えで範囲外"}
+{"id":"t14","predicted":false,"actual":false,"reason":"成果物が調査結果であり commit でない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"hook 設定は範囲外 (commit という語のみ共通の distractor)"}
+{"id":"t16","predicted":false,"actual":false,"reason":"成果物が解説であり commit でない"}
+{"id":"t17","predicted":true,"actual":true,"reason":"部分 staging での commit 作成 — 明示パス staging の中核ケース"}
+{"id":"t18","predicted":false,"actual":false,"reason":"取り消し (revert / reset) は範囲外に明記"}

--- a/.agents/skills/commit/evals/commit-trigger.json
+++ b/.agents/skills/commit/evals/commit-trigger.json
@@ -1,0 +1,132 @@
+{
+  "target_skill": "commit",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "この変更をcommitして",
+      "should_trigger": true,
+      "rationale": "直接的な commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "コミット作っておいて",
+      "should_trigger": true,
+      "rationale": "口語のコミット作成要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "いま編集したファイルをstageしてcommitまでやって",
+      "should_trigger": true,
+      "rationale": "staging + commit の明示要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "commit message 考えてそのままコミットして",
+      "should_trigger": true,
+      "rationale": "メッセージ作成込みの commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t05",
+      "prompt": "現状の追加されているファイルをcommitして",
+      "should_trigger": true,
+      "rationale": "本セッション実発話。untracked を含む commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t06",
+      "prompt": "きりのいいところでcommit切っといて",
+      "should_trigger": true,
+      "rationale": "口語・タイミング委任だが成果物は commit",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t07",
+      "prompt": "ここまでの作業、一区切りだから記録しといて",
+      "should_trigger": true,
+      "rationale": "git 文脈での「記録」= commit の婉曲表現",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t08",
+      "prompt": "リファクタ終わったから一旦保存で",
+      "should_trigger": true,
+      "rationale": "作業リポ文脈の「保存」= commit の口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t09",
+      "prompt": "テスト通ったのでこの分を積んでおいて",
+      "should_trigger": true,
+      "rationale": "「積む」= commit を積む口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t10",
+      "prompt": "commitしてpushしてPRまで作って",
+      "should_trigger": false,
+      "rationale": "成果物が PR — shipping / commit-push-pr の担当",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t11",
+      "prompt": "リリースするからv1.2.0のタグ切って",
+      "should_trigger": false,
+      "rationale": "成果物がタグ — RELEASING.md の手順",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t12",
+      "prompt": "直前のcommitにこの修正をamendで足して",
+      "should_trigger": false,
+      "rationale": "履歴書き換えの明示要求 — 本 skill の既定範囲外 (明示要求として直接対応)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t13",
+      "prompt": "この3つのcommitをsquashしてまとめて",
+      "should_trigger": false,
+      "rationale": "履歴書き換え (rebase/squash) — 範囲外",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t14",
+      "prompt": "commit履歴を見て、どこでバグが入ったか調べて",
+      "should_trigger": false,
+      "rationale": "調査タスク — commit という語はあるが成果物はコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t15",
+      "prompt": "pre-commit hookでlintが走るように設定して",
+      "should_trigger": false,
+      "rationale": "hook 設定 — update-config / hook-development の領域",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t16",
+      "prompt": "gitのcommitオブジェクトの仕組みを教えて",
+      "should_trigger": false,
+      "rationale": "解説要請 — 成果物は説明であってコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t17",
+      "prompt": "変更した2ファイルだけコミットに入れて、他は残しといて",
+      "should_trigger": true,
+      "rationale": "明示パス staging の部分 commit — 本 skill の中核ケース",
+      "tags": ["explicit", "edge"]
+    },
+    {
+      "id": "t18",
+      "prompt": "間違えてcommitしちゃったから取り消して",
+      "should_trigger": false,
+      "rationale": "reset / revert — 履歴操作で範囲外",
+      "tags": ["adjacent"]
+    }
+  ]
+}

--- a/.agents/skills/issue-driven-development/SKILL.md
+++ b/.agents/skills/issue-driven-development/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: issue-driven-development
+description: |
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
+  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
+  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
+  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
+  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
+  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
+
+  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
+  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
+  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
+  `claude-loop:N` ラベルで PR に永続化する。
+
+  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
+  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
+  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
+  いずれでも必ず起動すること。
+
+  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
+  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
+  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
+  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  素の `git` / `gh` だけで動くこと。
+---
+# issue-driven-development
+
+GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。**PR 作成が終端** — CI 緑化
+とレビュー対応はイベント駆動の別反応に委ね、本スキルは長い実装セッション 1 回分だけを持つ。
+
+> **Iron Law 1**: acceptance criteria が無い issue は実装しない。`ambiguous-issue` で止まるのが正解。
+> **Iron Law 2**: CI を watch しない。PR を作ったら終わる (待ちはイベントに置き換える)。
+> **Iron Law 3**: テストと CI 設定を弱める変更 (削除・skip・閾値緩和) は書かない。
+
+## 前提となる secret / env
+
+| 変数 | 用途 | 必須 |
+|---|---|---|
+| `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
+| `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+
+## 入力契約
+
+いずれかで issue を特定する:
+
+- **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
+- **B. 手動**: `owner/repo#123` 形式の識別子
+- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+  `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+
+Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
+
+## 排他制御 (二重起動防止)
+
+ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+
+0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
+1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
+2. `claude:ready` を外し `claude:in-progress` を付ける
+3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
+   - 自分が最古 → 続行
+   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+
+ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
+`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+
+Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
+([references/actions-wiring.md](references/actions-wiring.md))。
+
+## 入口ゲート — acceptance criteria 検証
+
+issue 本文に以下が読み取れるか確認する:
+
+- **Acceptance Criteria**: 機械または人間が判定可能な完了条件 (「いい感じ」「今風」は不可)
+- **検証方法**: どのコマンド / テスト / 操作で満たしたと判定するか (明示が無くても AC から
+  自明に導けるなら可)
+
+読み取れない場合は**実装に入らず**エスカレーション (reason: `ambiguous-issue`) する。
+これは失敗ではなく、issue の入口品質の問題を上流に返す正常動作。**推測でスコープを
+埋めて実装を始めることを禁じる** — 未指定の細部は実行毎に揺れ、レビュー不能な PR を生む。
+
+## 主要ステップ
+
+### 1. リポジトリ取得と branch
+
+```bash
+gh repo clone "$OWNER/$REPO" repo && cd repo   # Actions 上で checkout 済みならスキップ
+BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+git switch -c "claude/issue-${NUMBER}-<slug>" "origin/$BASE"
+```
+
+slug は issue タイトルから生成 (小文字・ハイフン・40 字以内)。
+
+### 2. 実装方針
+
+- リポジトリの `CLAUDE.md` / `AGENTS.md` / `README.md` を読み、規約・テスト/lint コマンドを確認
+- AC を満たす**最小変更**を設計する。機能を勝手に広げない
+- 解釈の余地があった点は PR description に書く (issue に質問コメントは投げない —
+  ヘッドレスなので返答を待てない。判断できないほど曖昧なら入口ゲートに戻って escalate)
+
+### 3. 実装 + テスト
+
+- behavioral change は `tdd` の規律 (先に失敗するテスト)、structural は `tidy-first` に従う
+- リポジトリにテストがあれば必ずローカル実行し、green を確認してから commit
+- テストが無ければビルド・型チェック・lint を通す
+- **既存テストの削除・skip 化・アサーション緩和・CI 設定の弱体化はしない** (Iron Law 3)。
+  テストが間違っていると判断した場合はその根拠を PR に書き、テスト修正だけの commit に分離する
+
+### 4. commit / push / PR
+
+```bash
+git add <変更ファイルを明示>   # git add -A は使わない
+git commit -m "<repo 規約に従う subject>
+
+<why を説明する body>
+
+Refs: #${NUMBER}"
+git push -u origin "claude/issue-${NUMBER}-<slug>"
+gh pr create --title "<subject> (#${NUMBER})" --body "$(printf '## Summary\n- ...\n\nCloses #%s\n\n## 解釈と判断\n- <AC の解釈で自分が決めた点>\n\n## Test plan\n- [x] <実行したテスト/検証>\n' "$NUMBER")"
+```
+
+- PR body の `Closes #N` は必須 (issue 自動クローズ + 計測の issue 紐付けの両方に使われる)
+- issue ラベルに `claude:draft` があれば `--draft`
+
+### 5. 終端処理 — ここで終了する
+
+- PR URL を issue にコメントし、`claude:in-progress` → `claude:done` に張り替える
+  (done = 「PR 作成まで完了」の意。merge ではない)
+- **CI を watch しない。レビューを待たない。** 以降は次の反応が引き継ぐ:
+
+| イベント | 反応 (別トリガで起動) | 上限 |
+|---|---|---|
+| CI 失敗 (`workflow_run`) | `ci-self-heal` — 修正 push ごとに `claude-loop:N` を進める | N=3 で escalate |
+| レビューコメント | `pr-review-respond` | 5 周で escalate |
+| conflict | `pr-conflict-resolver` | — |
+
+- 反応側の no-progress 検出: 直前の自分の修正と同一ファイル・同一失敗なら反復せず escalate
+
+## エスカレーション
+
+どの段階でも継続不能になったら:
+
+1. `needs-human` ラベルを付け、`claude:in-progress` を外し `claude:failed` を付ける
+2. issue (PR があれば PR) に構造化コメントを投稿する:
+
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか>
+
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "<enum>", "detail": "<1-2 文>", "attempts": <n>, "session_id": "<取れれば>", "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+reason は次の enum から: `budget-exceeded / max-turns / ci-3-fail / review-5-rounds /
+no-progress / ambiguous-issue / repo-unresolvable / conflict / security-block / other`。
+`LOOP_OPS_TOKEN` があれば `escalated` イベントも送信する (無ければコメントのみで良い —
+PR クローズ時の収集がフォールバックで拾う)。
+
+## ガードレール
+
+- **destructive git 禁止**: `reset --hard` / `push --force*` / `rebase` を使わない。修正は常に追加 commit
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類
+- **PR を merge しない**: merge は常に人間ゲート
+- **`.github/workflows/` を変更しない**: CI の変更が必要なら escalate (security-block)
+- **予算上限は起動側が持つ**: runner は `--max-turns` / `--max-budget-usd` を必ず設定する
+  (超過時の subtype がそのまま escalation reason になる)。設定方法は references 参照
+- **他人の branch に触らない**: 常に新規 `claude/issue-*` branch
+
+## リファレンス
+
+- [references/actions-wiring.md](references/actions-wiring.md) — トリガ配線 (claude-code-action ラベル起動 / Routines)、concurrency・自己発火ガード・SHA ピン留め・最小権限、`claude-loop:N` の進め方、`agent_run` 計測イベントの送信。**配線作業をする時だけ読む**

--- a/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
+++ b/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動識別子モードを明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger.json
+++ b/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger.json
@@ -1,0 +1,97 @@
+{
+  "target_skill": "issue-driven-development",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "claude:ready ラベルの issue を処理して PR まで作って",
+      "should_trigger": true,
+      "rationale": "ラベル駆動の主経路そのもの",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "kanade0404/skills#11 をやって PR 作成まで自走して",
+      "should_trigger": true,
+      "rationale": "手動識別子モード",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "GitHub issue から実装して PR 出すところまでヘッドレスでやって",
+      "should_trigger": true,
+      "rationale": "issue→PR の自走要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "この issue やっておいて",
+      "should_trigger": true,
+      "rationale": "issue 対応の委譲 (口語)",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t05",
+      "prompt": "issue #42 の対応、離席中に終わらせておいて",
+      "should_trigger": true,
+      "rationale": "無人完遂の要請",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t06",
+      "prompt": "毎時の Routine から: claude:ready の issue を 1 件選んで処理",
+      "should_trigger": true,
+      "rationale": "Routine 主経路",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "f01",
+      "prompt": "Linear の ENG-123 を処理して",
+      "should_trigger": false,
+      "rationale": "Linear issue は linear-issue-driven-development",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f02",
+      "prompt": "実装できたから ship して。CI もレビューも全部通して",
+      "should_trigger": false,
+      "rationale": "ローカル実装後の出荷は shipping",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f03",
+      "prompt": "PR の CI が落ちてるから直して",
+      "should_trigger": false,
+      "rationale": "CI 修正単体は ci-self-heal (イベント分割の後半)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f04",
+      "prompt": "CodeRabbit のコメントに対応して",
+      "should_trigger": false,
+      "rationale": "レビュー対応単体は pr-review-respond",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f05",
+      "prompt": "この PR を merge して",
+      "should_trigger": false,
+      "rationale": "merge は人間ゲート (本スキルは merge しない)",
+      "tags": ["adjacent", "edge"]
+    },
+    {
+      "id": "f06",
+      "prompt": "issue のテンプレートを作って",
+      "should_trigger": false,
+      "rationale": "issue という語を含むが issue 処理ではない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "f07",
+      "prompt": "今週の open issue を一覧して優先度を付けて",
+      "should_trigger": false,
+      "rationale": "トリアージであって実装自走ではない",
+      "tags": ["distractor"]
+    }
+  ]
+}

--- a/.agents/skills/issue-driven-development/references/actions-wiring.md
+++ b/.agents/skills/issue-driven-development/references/actions-wiring.md
@@ -1,0 +1,108 @@
+# Actions / Routines 配線
+
+issue-driven-development を無人で回すためのトリガ配線。**配線作業をする時だけ読む。**
+セキュリティ既定 (SHA ピン留め・最小権限・外部コントリビュータ除外) は省略せず全て適用する。
+
+## 方式の選択
+
+| 方式 | 即時性 | 予算の持ち方 | 向き |
+|---|---|---|---|
+| **A. claude-code-action (ラベルトリガ)** | 即時 | workflow 内で `--max-turns` / budget | 単一 repo で完結させたい時 |
+| **B. Routines (GitHub イベント / 毎時)** | イベント or 毎時 | Routine プロンプトで指示 | subscription 枠で回したい時・複数 repo |
+
+どちらも本スキル (SKILL.md) を実行させる点は同じ。トリガと実行環境だけが違う。
+
+## A. claude-code-action ラベルトリガ
+
+```yaml
+# .github/workflows/claude-issue.yml (対象 repo)
+name: claude-issue
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: claude-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    # ラベルゲート = セキュリティゲート: ラベルは write 権限者しか付けられない。
+    # 自己発火ガード: Claude App 自身のイベントでは起動しない
+    if: >
+      github.event.label.name == 'claude:ready' &&
+      !endsWith(github.actor, '[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@<SHA をピン留め> # vX.Y.Z
+      - uses: anthropics/claude-code-action@<SHA をピン留め> # vX.Y.Z
+        with:
+          claude_args: "--max-turns 80"
+          prompt: |
+            issue-driven-development skill に従い、この repo の issue #${{ github.event.issue.number }} を処理して PR 作成まで完遂すること。
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+注意:
+
+- action の参照は**必ずコミット SHA でピン留め** (floating tag は供給網リスク)
+- `pull_request_target` は使わない。fork からの issue/PR で secrets が要る workflow を起動しない
+- issue 本文はプロンプトに直接埋め込まない ( injection 面)。番号だけ渡し、skill 側が gh で読む
+
+## B. Routines
+
+```
+毎時 (または GitHub issues イベント):
+  対象 repo で claude:ready ラベルの open issue を作成日昇順で 1 件選び、
+  issue-driven-development skill に従って PR 作成まで完遂する。
+  0 件なら何もせず終了する。
+```
+
+- Routine の secrets に `GH_TOKEN` (repo スコープ PAT)、任意で `LOOP_OPS_TOKEN`
+- 排他はスキル本体の lock コメント protocol が守る (毎時 cron と手動の併走を想定済み)
+
+## CI 修正・レビュー対応の反応 (イベント分割の後半)
+
+```yaml
+# CI 失敗への有界な反応の例 (概形)
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+jobs:
+  fix:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
+    # → claude-code-action で ci-self-heal 相当を 1 反応だけ実行
+```
+
+反応側の必須ルール:
+
+- **`claude-loop:N` を進める**: 修正 push の前に PR の現在値を読み、N>=3 なら修正せず
+  escalate (`ci-3-fail`)。ラベル更新と judge は反応の冒頭で行う
+- **no-progress**: 直前の自分の commit と同一ファイル・同一失敗なら反復せず escalate
+- **自己発火ガード**: 反応が push した commit で自分自身が再起動しない条件を必ず入れる
+
+## 計測 (agent_run) の送信
+
+実行の終端で ResultMessage 相当 (`claude -p --output-format json` の出力、または
+Action の実行結果) から 1 イベントを送る。loop-ops を使う環境のみ:
+
+```bash
+jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "$OWNER/$REPO" --argjson issue "$NUMBER" --arg phase "implement" \
+  --arg subtype "$SUBTYPE" --argjson turns "$TURNS" --argjson cost "$COST" \
+  --arg session "$SESSION_ID" \
+  '{v:1, ts:$ts, event:"agent_run", repo:$repo, issue:$issue, phase:$phase,
+    result_subtype:$subtype, num_turns:$turns, total_cost_usd:$cost, session_id:$session}' \
+  | bash emit-event.sh   # loop-ops/scripts/emit-event.sh (要 LOOP_OPS_TOKEN)
+```
+
+phase は反応の種類に合わせる: `implement` (本スキル) / `ci-fix` / `review-respond`。
+PR クローズ時の `pr_closed` は loop-ops の collect-metrics.yml (loop-metrics 配線) が拾う。

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: commit
+description: >-
+  git commit を「観測 → ガード → 明示パス staging → ファイル経由メッセージ → 検証」の固定順で作る skill。`git add
+  -A` / `git add .` / heredoc を使わないため、permission / hook
+  で汎用コマンドが拒否される環境でもブロックされずに完走する。「commit して」「コミット作って」「この変更コミットしといて」「stage して
+  commit」「きりのいいところで commit 切って」「一区切りだから記録して」のような要請、および tdd / tidy-first /
+  shipping の各サイクル終端の commit 作成で必ず起動すること。commit までが責務 — push・PR 作成は
+  `shipping`(検証ループ付き)または `commit-commands:commit-push-pr` に、リリースタグは RELEASING.md
+  の手順に、structural / behavioral の分割判断は `tidy-first` に渡す。履歴書き換え (amend / rebase /
+  squash / reset / revert) と commit 取り消しは範囲外 — 新規 commit を作る要請だけを扱う。
+---
+# Commit
+
+コミット作成を、guardrail の強い環境 (permission / hook が `git add -A`・`cat`・heredoc 等を
+拒否する設定) でも**一発で通る手順に固定**する skill。拒否 → 言い換えリトライの往復は
+それ自体が時間と context の浪費であり、拒否されない形を最初から使えば往復は発生しない。
+個別の禁止コマンドは列挙しない — 設定が真実であり (`rules/bash-and-api-discipline.md`)、
+本 skill は**どの設定下でも拒否されにくい最小手順**だけを規定する。
+
+## いつ使うか / 使わない場面
+
+**使う**: コミット作成の要請すべて。「commit して」「コミットしといて」「この変更で commit
+作って」「stage して commit」「きりのいいところで commit 切って」。tdd の GREEN 直後、
+tidy-first の tidying 単位、shipping Phase 3 など上流 skill からの commit 局面も同じ。
+
+**使わない** (成果物で線を引く):
+
+| 要求される成果物 | 渡す先 |
+|---|---|
+| push 済みブランチ + PR | `shipping` (検証ループ付き) / `commit-commands:commit-push-pr` |
+| リリースタグ | RELEASING.md の手順 (存在するリポの場合) |
+| 書き換えられた履歴 (amend / rebase / squash / reset / revert) | 範囲外。明示要求されたら本 skill の外で直接対応 |
+| structural / behavioral の分割方針 | `tidy-first` (何をコミットに入れるかの判断は上流) |
+
+## ワークフロー (順序固定)
+
+### Step 1 — 観測
+
+```bash
+git status --short
+git diff --stat          # unstaged
+git diff --cached --stat # staged (残留がないか)
+git rev-parse --abbrev-ref HEAD
+```
+
+働きかけの前に必ず現状を見る。既に staged の変更が残っていたら、それが今回のコミットに
+属するかを判定してから進む (無言で巻き込まない)。
+
+### Step 2 — ガード
+
+- **default ブランチ (main / master) に居るなら**: 直コミットせず、先にブランチ作成を提案する
+  (`git switch -c <topic>`)。ユーザが「master に直接で良い」と明示したときだけ続行。
+- **無関係な変更が混在**: 1 コミット 1 関心事。混在していたら分割を提案し、今回分だけを
+  staging 対象にする。
+- **コミット対象が空**: 何も stage せず「コミット対象がない」と報告して終了。
+
+### Step 3 — 明示パス staging
+
+```bash
+git add <path1> <path2> <dir/>   # 対象を列挙する。ディレクトリ指定は可
+```
+
+`-A` / `.` / `-u` / `--all` は**使わない**。guardrail 環境で拒否される代表格であり、
+拒否されない環境でも「何が入ったか」を Step 1 の観測と突き合わせられる明示列挙の方が
+巻き込み事故を構造的に防ぐ。staging 後に `git status --short` で意図どおりかを確認する。
+
+### Step 4 — メッセージはファイル経由
+
+メッセージは Write ツールで一時ファイル (scratchpad があればそこ、無ければ
+`/tmp` 相当) に書き、`-F` で渡す:
+
+```bash
+git commit -F <scratch>/commit-msg.txt
+```
+
+`-m` + heredoc / `$(cat <<EOF ...)` は**使わない** — heredoc・`cat` は guardrail 環境で
+拒否される上、複数行・引用符・記号を含むメッセージのエスケープ事故源になる。
+ハーネスが trailer (Co-Authored-By 等) を要求している場合はファイル末尾に含める。
+
+メッセージ本文は conventional な形式に固定する:
+
+```
+<要約 1 行 (50-72 字目安、何を＋なぜ)>
+
+- <変更点 1>
+- <変更点 2>
+<必要なら trailer>
+```
+
+### Step 5 — 検証と報告
+
+```bash
+git log -1 --stat
+```
+
+SHA・ファイル数・行数を確認してから報告する。**pre-commit hook が失敗したら**:
+root cause を読み、直せるものは直して再実行する。`--no-verify` での回避は
+ユーザの明示指示なしには使わない。同型の失敗が 2 回続いたら止めて報告する
+(`rules/bash-and-api-discipline.md` の「同型再試行しない」に従う)。
+
+## このスキルがやらないこと (成果物で定義)
+
+- **push された commit / PR**: 作らない。commit 作成で停止し、続きは呼出側が判断する。
+- **書き換えられた履歴**: amend / rebase / squash / reset / force 系は既定で出力しない。
+- **`--no-verify` で hook を迂回した commit**: 明示指示なしには作らない。
+- **staging 全量 (`-A` / `.`) による commit**: どの環境でも作らない。
+- **コミット分割方針の決定**: structural / behavioral の判断は `tidy-first` の成果物。
+
+## リファレンス
+
+- `rules/bash-and-api-discipline.md` — ブロック時の復帰手順・専用ツール優先の一般規律

--- a/.claude/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
+++ b/.claude/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,18 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"description の「commit して」に直接マッチ"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「コミット作って」が verbatim で列挙されている"}
+{"id":"t03","predicted":true,"actual":true,"reason":"「stage して commit」が verbatim で列挙されている"}
+{"id":"t04","predicted":true,"actual":true,"reason":"メッセージ作成込みでも成果物は commit 作成"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「この変更コミットしといて」系の直接要請"}
+{"id":"t06","predicted":true,"actual":true,"reason":"「きりのいいところで commit 切って」verbatim"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「一区切りだから記録して」verbatim"}
+{"id":"t08","predicted":true,"actual":true,"reason":"弱マッチ: 「保存」は非掲載だがリポ文脈+リファクタ完了で commit 要請と解釈可能。FN リスク箇所として記録"}
+{"id":"t09","predicted":true,"actual":true,"reason":"弱マッチ: 「テスト通った」= tdd サイクル終端の commit 局面が description に明記"}
+{"id":"t10","predicted":false,"actual":false,"reason":"push・PR は shipping / commit-push-pr へ、と negative space に明記"}
+{"id":"t11","predicted":false,"actual":false,"reason":"リリースタグは RELEASING.md へ、と明記"}
+{"id":"t12","predicted":false,"actual":false,"reason":"履歴書き換え (amend) は範囲外と明記 (初稿の曖昧文を修正済み)"}
+{"id":"t13","predicted":false,"actual":false,"reason":"squash = 履歴書き換えで範囲外"}
+{"id":"t14","predicted":false,"actual":false,"reason":"成果物が調査結果であり commit でない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"hook 設定は範囲外 (commit という語のみ共通の distractor)"}
+{"id":"t16","predicted":false,"actual":false,"reason":"成果物が解説であり commit でない"}
+{"id":"t17","predicted":true,"actual":true,"reason":"部分 staging での commit 作成 — 明示パス staging の中核ケース"}
+{"id":"t18","predicted":false,"actual":false,"reason":"取り消し (revert / reset) は範囲外に明記"}

--- a/.claude/skills/commit/evals/commit-trigger.json
+++ b/.claude/skills/commit/evals/commit-trigger.json
@@ -1,0 +1,132 @@
+{
+  "target_skill": "commit",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "この変更をcommitして",
+      "should_trigger": true,
+      "rationale": "直接的な commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "コミット作っておいて",
+      "should_trigger": true,
+      "rationale": "口語のコミット作成要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "いま編集したファイルをstageしてcommitまでやって",
+      "should_trigger": true,
+      "rationale": "staging + commit の明示要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "commit message 考えてそのままコミットして",
+      "should_trigger": true,
+      "rationale": "メッセージ作成込みの commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t05",
+      "prompt": "現状の追加されているファイルをcommitして",
+      "should_trigger": true,
+      "rationale": "本セッション実発話。untracked を含む commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t06",
+      "prompt": "きりのいいところでcommit切っといて",
+      "should_trigger": true,
+      "rationale": "口語・タイミング委任だが成果物は commit",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t07",
+      "prompt": "ここまでの作業、一区切りだから記録しといて",
+      "should_trigger": true,
+      "rationale": "git 文脈での「記録」= commit の婉曲表現",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t08",
+      "prompt": "リファクタ終わったから一旦保存で",
+      "should_trigger": true,
+      "rationale": "作業リポ文脈の「保存」= commit の口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t09",
+      "prompt": "テスト通ったのでこの分を積んでおいて",
+      "should_trigger": true,
+      "rationale": "「積む」= commit を積む口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t10",
+      "prompt": "commitしてpushしてPRまで作って",
+      "should_trigger": false,
+      "rationale": "成果物が PR — shipping / commit-push-pr の担当",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t11",
+      "prompt": "リリースするからv1.2.0のタグ切って",
+      "should_trigger": false,
+      "rationale": "成果物がタグ — RELEASING.md の手順",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t12",
+      "prompt": "直前のcommitにこの修正をamendで足して",
+      "should_trigger": false,
+      "rationale": "履歴書き換えの明示要求 — 本 skill の既定範囲外 (明示要求として直接対応)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t13",
+      "prompt": "この3つのcommitをsquashしてまとめて",
+      "should_trigger": false,
+      "rationale": "履歴書き換え (rebase/squash) — 範囲外",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t14",
+      "prompt": "commit履歴を見て、どこでバグが入ったか調べて",
+      "should_trigger": false,
+      "rationale": "調査タスク — commit という語はあるが成果物はコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t15",
+      "prompt": "pre-commit hookでlintが走るように設定して",
+      "should_trigger": false,
+      "rationale": "hook 設定 — update-config / hook-development の領域",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t16",
+      "prompt": "gitのcommitオブジェクトの仕組みを教えて",
+      "should_trigger": false,
+      "rationale": "解説要請 — 成果物は説明であってコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t17",
+      "prompt": "変更した2ファイルだけコミットに入れて、他は残しといて",
+      "should_trigger": true,
+      "rationale": "明示パス staging の部分 commit — 本 skill の中核ケース",
+      "tags": ["explicit", "edge"]
+    },
+    {
+      "id": "t18",
+      "prompt": "間違えてcommitしちゃったから取り消して",
+      "should_trigger": false,
+      "rationale": "reset / revert — 履歴操作で範囲外",
+      "tags": ["adjacent"]
+    }
+  ]
+}

--- a/.claude/skills/issue-driven-development/SKILL.md
+++ b/.claude/skills/issue-driven-development/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: issue-driven-development
+description: |
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
+  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
+  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
+  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
+  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
+  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
+
+  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
+  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
+  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
+  `claude-loop:N` ラベルで PR に永続化する。
+
+  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
+  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
+  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
+  いずれでも必ず起動すること。
+
+  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
+  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
+  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
+  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  素の `git` / `gh` だけで動くこと。
+---
+# issue-driven-development
+
+GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。**PR 作成が終端** — CI 緑化
+とレビュー対応はイベント駆動の別反応に委ね、本スキルは長い実装セッション 1 回分だけを持つ。
+
+> **Iron Law 1**: acceptance criteria が無い issue は実装しない。`ambiguous-issue` で止まるのが正解。
+> **Iron Law 2**: CI を watch しない。PR を作ったら終わる (待ちはイベントに置き換える)。
+> **Iron Law 3**: テストと CI 設定を弱める変更 (削除・skip・閾値緩和) は書かない。
+
+## 前提となる secret / env
+
+| 変数 | 用途 | 必須 |
+|---|---|---|
+| `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
+| `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+
+## 入力契約
+
+いずれかで issue を特定する:
+
+- **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
+- **B. 手動**: `owner/repo#123` 形式の識別子
+- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+  `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+
+Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
+
+## 排他制御 (二重起動防止)
+
+ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+
+0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
+1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
+2. `claude:ready` を外し `claude:in-progress` を付ける
+3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
+   - 自分が最古 → 続行
+   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+
+ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
+`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+
+Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
+([references/actions-wiring.md](references/actions-wiring.md))。
+
+## 入口ゲート — acceptance criteria 検証
+
+issue 本文に以下が読み取れるか確認する:
+
+- **Acceptance Criteria**: 機械または人間が判定可能な完了条件 (「いい感じ」「今風」は不可)
+- **検証方法**: どのコマンド / テスト / 操作で満たしたと判定するか (明示が無くても AC から
+  自明に導けるなら可)
+
+読み取れない場合は**実装に入らず**エスカレーション (reason: `ambiguous-issue`) する。
+これは失敗ではなく、issue の入口品質の問題を上流に返す正常動作。**推測でスコープを
+埋めて実装を始めることを禁じる** — 未指定の細部は実行毎に揺れ、レビュー不能な PR を生む。
+
+## 主要ステップ
+
+### 1. リポジトリ取得と branch
+
+```bash
+gh repo clone "$OWNER/$REPO" repo && cd repo   # Actions 上で checkout 済みならスキップ
+BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+git switch -c "claude/issue-${NUMBER}-<slug>" "origin/$BASE"
+```
+
+slug は issue タイトルから生成 (小文字・ハイフン・40 字以内)。
+
+### 2. 実装方針
+
+- リポジトリの `CLAUDE.md` / `AGENTS.md` / `README.md` を読み、規約・テスト/lint コマンドを確認
+- AC を満たす**最小変更**を設計する。機能を勝手に広げない
+- 解釈の余地があった点は PR description に書く (issue に質問コメントは投げない —
+  ヘッドレスなので返答を待てない。判断できないほど曖昧なら入口ゲートに戻って escalate)
+
+### 3. 実装 + テスト
+
+- behavioral change は `tdd` の規律 (先に失敗するテスト)、structural は `tidy-first` に従う
+- リポジトリにテストがあれば必ずローカル実行し、green を確認してから commit
+- テストが無ければビルド・型チェック・lint を通す
+- **既存テストの削除・skip 化・アサーション緩和・CI 設定の弱体化はしない** (Iron Law 3)。
+  テストが間違っていると判断した場合はその根拠を PR に書き、テスト修正だけの commit に分離する
+
+### 4. commit / push / PR
+
+```bash
+git add <変更ファイルを明示>   # git add -A は使わない
+git commit -m "<repo 規約に従う subject>
+
+<why を説明する body>
+
+Refs: #${NUMBER}"
+git push -u origin "claude/issue-${NUMBER}-<slug>"
+gh pr create --title "<subject> (#${NUMBER})" --body "$(printf '## Summary\n- ...\n\nCloses #%s\n\n## 解釈と判断\n- <AC の解釈で自分が決めた点>\n\n## Test plan\n- [x] <実行したテスト/検証>\n' "$NUMBER")"
+```
+
+- PR body の `Closes #N` は必須 (issue 自動クローズ + 計測の issue 紐付けの両方に使われる)
+- issue ラベルに `claude:draft` があれば `--draft`
+
+### 5. 終端処理 — ここで終了する
+
+- PR URL を issue にコメントし、`claude:in-progress` → `claude:done` に張り替える
+  (done = 「PR 作成まで完了」の意。merge ではない)
+- **CI を watch しない。レビューを待たない。** 以降は次の反応が引き継ぐ:
+
+| イベント | 反応 (別トリガで起動) | 上限 |
+|---|---|---|
+| CI 失敗 (`workflow_run`) | `ci-self-heal` — 修正 push ごとに `claude-loop:N` を進める | N=3 で escalate |
+| レビューコメント | `pr-review-respond` | 5 周で escalate |
+| conflict | `pr-conflict-resolver` | — |
+
+- 反応側の no-progress 検出: 直前の自分の修正と同一ファイル・同一失敗なら反復せず escalate
+
+## エスカレーション
+
+どの段階でも継続不能になったら:
+
+1. `needs-human` ラベルを付け、`claude:in-progress` を外し `claude:failed` を付ける
+2. issue (PR があれば PR) に構造化コメントを投稿する:
+
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか>
+
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "<enum>", "detail": "<1-2 文>", "attempts": <n>, "session_id": "<取れれば>", "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+reason は次の enum から: `budget-exceeded / max-turns / ci-3-fail / review-5-rounds /
+no-progress / ambiguous-issue / repo-unresolvable / conflict / security-block / other`。
+`LOOP_OPS_TOKEN` があれば `escalated` イベントも送信する (無ければコメントのみで良い —
+PR クローズ時の収集がフォールバックで拾う)。
+
+## ガードレール
+
+- **destructive git 禁止**: `reset --hard` / `push --force*` / `rebase` を使わない。修正は常に追加 commit
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類
+- **PR を merge しない**: merge は常に人間ゲート
+- **`.github/workflows/` を変更しない**: CI の変更が必要なら escalate (security-block)
+- **予算上限は起動側が持つ**: runner は `--max-turns` / `--max-budget-usd` を必ず設定する
+  (超過時の subtype がそのまま escalation reason になる)。設定方法は references 参照
+- **他人の branch に触らない**: 常に新規 `claude/issue-*` branch
+
+## リファレンス
+
+- [references/actions-wiring.md](references/actions-wiring.md) — トリガ配線 (claude-code-action ラベル起動 / Routines)、concurrency・自己発火ガード・SHA ピン留め・最小権限、`claude-loop:N` の進め方、`agent_run` 計測イベントの送信。**配線作業をする時だけ読む**

--- a/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
+++ b/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動識別子モードを明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger.json
+++ b/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger.json
@@ -1,0 +1,97 @@
+{
+  "target_skill": "issue-driven-development",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "claude:ready ラベルの issue を処理して PR まで作って",
+      "should_trigger": true,
+      "rationale": "ラベル駆動の主経路そのもの",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "kanade0404/skills#11 をやって PR 作成まで自走して",
+      "should_trigger": true,
+      "rationale": "手動識別子モード",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "GitHub issue から実装して PR 出すところまでヘッドレスでやって",
+      "should_trigger": true,
+      "rationale": "issue→PR の自走要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "この issue やっておいて",
+      "should_trigger": true,
+      "rationale": "issue 対応の委譲 (口語)",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t05",
+      "prompt": "issue #42 の対応、離席中に終わらせておいて",
+      "should_trigger": true,
+      "rationale": "無人完遂の要請",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t06",
+      "prompt": "毎時の Routine から: claude:ready の issue を 1 件選んで処理",
+      "should_trigger": true,
+      "rationale": "Routine 主経路",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "f01",
+      "prompt": "Linear の ENG-123 を処理して",
+      "should_trigger": false,
+      "rationale": "Linear issue は linear-issue-driven-development",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f02",
+      "prompt": "実装できたから ship して。CI もレビューも全部通して",
+      "should_trigger": false,
+      "rationale": "ローカル実装後の出荷は shipping",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f03",
+      "prompt": "PR の CI が落ちてるから直して",
+      "should_trigger": false,
+      "rationale": "CI 修正単体は ci-self-heal (イベント分割の後半)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f04",
+      "prompt": "CodeRabbit のコメントに対応して",
+      "should_trigger": false,
+      "rationale": "レビュー対応単体は pr-review-respond",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "f05",
+      "prompt": "この PR を merge して",
+      "should_trigger": false,
+      "rationale": "merge は人間ゲート (本スキルは merge しない)",
+      "tags": ["adjacent", "edge"]
+    },
+    {
+      "id": "f06",
+      "prompt": "issue のテンプレートを作って",
+      "should_trigger": false,
+      "rationale": "issue という語を含むが issue 処理ではない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "f07",
+      "prompt": "今週の open issue を一覧して優先度を付けて",
+      "should_trigger": false,
+      "rationale": "トリアージであって実装自走ではない",
+      "tags": ["distractor"]
+    }
+  ]
+}

--- a/.claude/skills/issue-driven-development/references/actions-wiring.md
+++ b/.claude/skills/issue-driven-development/references/actions-wiring.md
@@ -1,0 +1,108 @@
+# Actions / Routines 配線
+
+issue-driven-development を無人で回すためのトリガ配線。**配線作業をする時だけ読む。**
+セキュリティ既定 (SHA ピン留め・最小権限・外部コントリビュータ除外) は省略せず全て適用する。
+
+## 方式の選択
+
+| 方式 | 即時性 | 予算の持ち方 | 向き |
+|---|---|---|---|
+| **A. claude-code-action (ラベルトリガ)** | 即時 | workflow 内で `--max-turns` / budget | 単一 repo で完結させたい時 |
+| **B. Routines (GitHub イベント / 毎時)** | イベント or 毎時 | Routine プロンプトで指示 | subscription 枠で回したい時・複数 repo |
+
+どちらも本スキル (SKILL.md) を実行させる点は同じ。トリガと実行環境だけが違う。
+
+## A. claude-code-action ラベルトリガ
+
+```yaml
+# .github/workflows/claude-issue.yml (対象 repo)
+name: claude-issue
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: claude-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    # ラベルゲート = セキュリティゲート: ラベルは write 権限者しか付けられない。
+    # 自己発火ガード: Claude App 自身のイベントでは起動しない
+    if: >
+      github.event.label.name == 'claude:ready' &&
+      !endsWith(github.actor, '[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@<SHA をピン留め> # vX.Y.Z
+      - uses: anthropics/claude-code-action@<SHA をピン留め> # vX.Y.Z
+        with:
+          claude_args: "--max-turns 80"
+          prompt: |
+            issue-driven-development skill に従い、この repo の issue #${{ github.event.issue.number }} を処理して PR 作成まで完遂すること。
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+注意:
+
+- action の参照は**必ずコミット SHA でピン留め** (floating tag は供給網リスク)
+- `pull_request_target` は使わない。fork からの issue/PR で secrets が要る workflow を起動しない
+- issue 本文はプロンプトに直接埋め込まない ( injection 面)。番号だけ渡し、skill 側が gh で読む
+
+## B. Routines
+
+```
+毎時 (または GitHub issues イベント):
+  対象 repo で claude:ready ラベルの open issue を作成日昇順で 1 件選び、
+  issue-driven-development skill に従って PR 作成まで完遂する。
+  0 件なら何もせず終了する。
+```
+
+- Routine の secrets に `GH_TOKEN` (repo スコープ PAT)、任意で `LOOP_OPS_TOKEN`
+- 排他はスキル本体の lock コメント protocol が守る (毎時 cron と手動の併走を想定済み)
+
+## CI 修正・レビュー対応の反応 (イベント分割の後半)
+
+```yaml
+# CI 失敗への有界な反応の例 (概形)
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+jobs:
+  fix:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
+    # → claude-code-action で ci-self-heal 相当を 1 反応だけ実行
+```
+
+反応側の必須ルール:
+
+- **`claude-loop:N` を進める**: 修正 push の前に PR の現在値を読み、N>=3 なら修正せず
+  escalate (`ci-3-fail`)。ラベル更新と judge は反応の冒頭で行う
+- **no-progress**: 直前の自分の commit と同一ファイル・同一失敗なら反復せず escalate
+- **自己発火ガード**: 反応が push した commit で自分自身が再起動しない条件を必ず入れる
+
+## 計測 (agent_run) の送信
+
+実行の終端で ResultMessage 相当 (`claude -p --output-format json` の出力、または
+Action の実行結果) から 1 イベントを送る。loop-ops を使う環境のみ:
+
+```bash
+jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg repo "$OWNER/$REPO" --argjson issue "$NUMBER" --arg phase "implement" \
+  --arg subtype "$SUBTYPE" --argjson turns "$TURNS" --argjson cost "$COST" \
+  --arg session "$SESSION_ID" \
+  '{v:1, ts:$ts, event:"agent_run", repo:$repo, issue:$issue, phase:$phase,
+    result_subtype:$subtype, num_turns:$turns, total_cost_usd:$cost, session_id:$session}' \
+  | bash emit-event.sh   # loop-ops/scripts/emit-event.sh (要 LOOP_OPS_TOKEN)
+```
+
+phase は反応の種類に合わせる: `implement` (本スキル) / `ci-fix` / `review-respond`。
+PR クローズ時の `pr_closed` は loop-ops の collect-metrics.yml (loop-metrics 配線) が拾う。

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: commit
+description: git commit を「観測 → ガード → 明示パス staging → ファイル経由メッセージ → 検証」の固定順で作る skill。`git add -A` / `git add .` / heredoc を使わないため、permission / hook で汎用コマンドが拒否される環境でもブロックされずに完走する。「commit して」「コミット作って」「この変更コミットしといて」「stage して commit」「きりのいいところで commit 切って」「一区切りだから記録して」のような要請、および tdd / tidy-first / shipping の各サイクル終端の commit 作成で必ず起動すること。commit までが責務 — push・PR 作成は `shipping`(検証ループ付き)または `commit-commands:commit-push-pr` に、リリースタグは RELEASING.md の手順に、structural / behavioral の分割判断は `tidy-first` に渡す。履歴書き換え (amend / rebase / squash / reset / revert) と commit 取り消しは範囲外 — 新規 commit を作る要請だけを扱う。
+allowed-tools:
+  - Read
+  - Write
+  - Bash(git status *)
+  - Bash(git diff *)
+  - Bash(git log *)
+  - Bash(git ls-files *)
+  - Bash(git add *)
+  - Bash(git commit *)
+  - Bash(git rev-parse *)
+  - Bash(git branch *)
+  - Bash(git switch *)
+---
+
+# Commit
+
+コミット作成を、guardrail の強い環境 (permission / hook が `git add -A`・`cat`・heredoc 等を
+拒否する設定) でも**一発で通る手順に固定**する skill。拒否 → 言い換えリトライの往復は
+それ自体が時間と context の浪費であり、拒否されない形を最初から使えば往復は発生しない。
+個別の禁止コマンドは列挙しない — 設定が真実であり (`rules/bash-and-api-discipline.md`)、
+本 skill は**どの設定下でも拒否されにくい最小手順**だけを規定する。
+
+## いつ使うか / 使わない場面
+
+**使う**: コミット作成の要請すべて。「commit して」「コミットしといて」「この変更で commit
+作って」「stage して commit」「きりのいいところで commit 切って」。tdd の GREEN 直後、
+tidy-first の tidying 単位、shipping Phase 3 など上流 skill からの commit 局面も同じ。
+
+**使わない** (成果物で線を引く):
+
+| 要求される成果物 | 渡す先 |
+|---|---|
+| push 済みブランチ + PR | `shipping` (検証ループ付き) / `commit-commands:commit-push-pr` |
+| リリースタグ | RELEASING.md の手順 (存在するリポの場合) |
+| 書き換えられた履歴 (amend / rebase / squash / reset / revert) | 範囲外。明示要求されたら本 skill の外で直接対応 |
+| structural / behavioral の分割方針 | `tidy-first` (何をコミットに入れるかの判断は上流) |
+
+## ワークフロー (順序固定)
+
+### Step 1 — 観測
+
+```bash
+git status --short
+git diff --stat          # unstaged
+git diff --cached --stat # staged (残留がないか)
+git rev-parse --abbrev-ref HEAD
+```
+
+働きかけの前に必ず現状を見る。既に staged の変更が残っていたら、それが今回のコミットに
+属するかを判定してから進む (無言で巻き込まない)。
+
+### Step 2 — ガード
+
+- **default ブランチ (main / master) に居るなら**: 直コミットせず、先にブランチ作成を提案する
+  (`git switch -c <topic>`)。ユーザが「master に直接で良い」と明示したときだけ続行。
+- **無関係な変更が混在**: 1 コミット 1 関心事。混在していたら分割を提案し、今回分だけを
+  staging 対象にする。
+- **コミット対象が空**: 何も stage せず「コミット対象がない」と報告して終了。
+
+### Step 3 — 明示パス staging
+
+```bash
+git add <path1> <path2> <dir/>   # 対象を列挙する。ディレクトリ指定は可
+```
+
+`-A` / `.` / `-u` / `--all` は**使わない**。guardrail 環境で拒否される代表格であり、
+拒否されない環境でも「何が入ったか」を Step 1 の観測と突き合わせられる明示列挙の方が
+巻き込み事故を構造的に防ぐ。staging 後に `git status --short` で意図どおりかを確認する。
+
+### Step 4 — メッセージはファイル経由
+
+メッセージは Write ツールで一時ファイル (scratchpad があればそこ、無ければ
+`/tmp` 相当) に書き、`-F` で渡す:
+
+```bash
+git commit -F <scratch>/commit-msg.txt
+```
+
+`-m` + heredoc / `$(cat <<EOF ...)` は**使わない** — heredoc・`cat` は guardrail 環境で
+拒否される上、複数行・引用符・記号を含むメッセージのエスケープ事故源になる。
+ハーネスが trailer (Co-Authored-By 等) を要求している場合はファイル末尾に含める。
+
+メッセージ本文は conventional な形式に固定する:
+
+```
+<要約 1 行 (50-72 字目安、何を＋なぜ)>
+
+- <変更点 1>
+- <変更点 2>
+<必要なら trailer>
+```
+
+### Step 5 — 検証と報告
+
+```bash
+git log -1 --stat
+```
+
+SHA・ファイル数・行数を確認してから報告する。**pre-commit hook が失敗したら**:
+root cause を読み、直せるものは直して再実行する。`--no-verify` での回避は
+ユーザの明示指示なしには使わない。同型の失敗が 2 回続いたら止めて報告する
+(`rules/bash-and-api-discipline.md` の「同型再試行しない」に従う)。
+
+## このスキルがやらないこと (成果物で定義)
+
+- **push された commit / PR**: 作らない。commit 作成で停止し、続きは呼出側が判断する。
+- **書き換えられた履歴**: amend / rebase / squash / reset / force 系は既定で出力しない。
+- **`--no-verify` で hook を迂回した commit**: 明示指示なしには作らない。
+- **staging 全量 (`-A` / `.`) による commit**: どの環境でも作らない。
+- **コミット分割方針の決定**: structural / behavioral の判断は `tidy-first` の成果物。
+
+## リファレンス
+
+- `rules/bash-and-api-discipline.md` — ブロック時の復帰手順・専用ツール優先の一般規律

--- a/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
+++ b/skills/commit/evals/commit-trigger-results-2026-07-04.jsonl
@@ -1,0 +1,18 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"description の「commit して」に直接マッチ"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「コミット作って」が verbatim で列挙されている"}
+{"id":"t03","predicted":true,"actual":true,"reason":"「stage して commit」が verbatim で列挙されている"}
+{"id":"t04","predicted":true,"actual":true,"reason":"メッセージ作成込みでも成果物は commit 作成"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「この変更コミットしといて」系の直接要請"}
+{"id":"t06","predicted":true,"actual":true,"reason":"「きりのいいところで commit 切って」verbatim"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「一区切りだから記録して」verbatim"}
+{"id":"t08","predicted":true,"actual":true,"reason":"弱マッチ: 「保存」は非掲載だがリポ文脈+リファクタ完了で commit 要請と解釈可能。FN リスク箇所として記録"}
+{"id":"t09","predicted":true,"actual":true,"reason":"弱マッチ: 「テスト通った」= tdd サイクル終端の commit 局面が description に明記"}
+{"id":"t10","predicted":false,"actual":false,"reason":"push・PR は shipping / commit-push-pr へ、と negative space に明記"}
+{"id":"t11","predicted":false,"actual":false,"reason":"リリースタグは RELEASING.md へ、と明記"}
+{"id":"t12","predicted":false,"actual":false,"reason":"履歴書き換え (amend) は範囲外と明記 (初稿の曖昧文を修正済み)"}
+{"id":"t13","predicted":false,"actual":false,"reason":"squash = 履歴書き換えで範囲外"}
+{"id":"t14","predicted":false,"actual":false,"reason":"成果物が調査結果であり commit でない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"hook 設定は範囲外 (commit という語のみ共通の distractor)"}
+{"id":"t16","predicted":false,"actual":false,"reason":"成果物が解説であり commit でない"}
+{"id":"t17","predicted":true,"actual":true,"reason":"部分 staging での commit 作成 — 明示パス staging の中核ケース"}
+{"id":"t18","predicted":false,"actual":false,"reason":"取り消し (revert / reset) は範囲外に明記"}

--- a/skills/commit/evals/commit-trigger.json
+++ b/skills/commit/evals/commit-trigger.json
@@ -1,0 +1,132 @@
+{
+  "target_skill": "commit",
+  "version": "1",
+  "cases": [
+    {
+      "id": "t01",
+      "prompt": "この変更をcommitして",
+      "should_trigger": true,
+      "rationale": "直接的な commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t02",
+      "prompt": "コミット作っておいて",
+      "should_trigger": true,
+      "rationale": "口語のコミット作成要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t03",
+      "prompt": "いま編集したファイルをstageしてcommitまでやって",
+      "should_trigger": true,
+      "rationale": "staging + commit の明示要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t04",
+      "prompt": "commit message 考えてそのままコミットして",
+      "should_trigger": true,
+      "rationale": "メッセージ作成込みの commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t05",
+      "prompt": "現状の追加されているファイルをcommitして",
+      "should_trigger": true,
+      "rationale": "本セッション実発話。untracked を含む commit 要請",
+      "tags": ["explicit"]
+    },
+    {
+      "id": "t06",
+      "prompt": "きりのいいところでcommit切っといて",
+      "should_trigger": true,
+      "rationale": "口語・タイミング委任だが成果物は commit",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t07",
+      "prompt": "ここまでの作業、一区切りだから記録しといて",
+      "should_trigger": true,
+      "rationale": "git 文脈での「記録」= commit の婉曲表現",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t08",
+      "prompt": "リファクタ終わったから一旦保存で",
+      "should_trigger": true,
+      "rationale": "作業リポ文脈の「保存」= commit の口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t09",
+      "prompt": "テスト通ったのでこの分を積んでおいて",
+      "should_trigger": true,
+      "rationale": "「積む」= commit を積む口語",
+      "tags": ["ambiguous"]
+    },
+    {
+      "id": "t10",
+      "prompt": "commitしてpushしてPRまで作って",
+      "should_trigger": false,
+      "rationale": "成果物が PR — shipping / commit-push-pr の担当",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t11",
+      "prompt": "リリースするからv1.2.0のタグ切って",
+      "should_trigger": false,
+      "rationale": "成果物がタグ — RELEASING.md の手順",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t12",
+      "prompt": "直前のcommitにこの修正をamendで足して",
+      "should_trigger": false,
+      "rationale": "履歴書き換えの明示要求 — 本 skill の既定範囲外 (明示要求として直接対応)",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t13",
+      "prompt": "この3つのcommitをsquashしてまとめて",
+      "should_trigger": false,
+      "rationale": "履歴書き換え (rebase/squash) — 範囲外",
+      "tags": ["adjacent"]
+    },
+    {
+      "id": "t14",
+      "prompt": "commit履歴を見て、どこでバグが入ったか調べて",
+      "should_trigger": false,
+      "rationale": "調査タスク — commit という語はあるが成果物はコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t15",
+      "prompt": "pre-commit hookでlintが走るように設定して",
+      "should_trigger": false,
+      "rationale": "hook 設定 — update-config / hook-development の領域",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t16",
+      "prompt": "gitのcommitオブジェクトの仕組みを教えて",
+      "should_trigger": false,
+      "rationale": "解説要請 — 成果物は説明であってコミットでない",
+      "tags": ["distractor"]
+    },
+    {
+      "id": "t17",
+      "prompt": "変更した2ファイルだけコミットに入れて、他は残しといて",
+      "should_trigger": true,
+      "rationale": "明示パス staging の部分 commit — 本 skill の中核ケース",
+      "tags": ["explicit", "edge"]
+    },
+    {
+      "id": "t18",
+      "prompt": "間違えてcommitしちゃったから取り消して",
+      "should_trigger": false,
+      "rationale": "reset / revert — 履歴操作で範囲外",
+      "tags": ["adjacent"]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

retro finding **P1-a** への対処: `commit-commands:commit` が deny rule 環境(`git add -A`/`.` 禁止、`cat`/heredoc 禁止)と衝突して 3 連続拒否された問題を、**guardrail-safe な自前 commit skill** で置き換える。

## 内容

- **`skills/commit/SKILL.md`** — 「観測 → ガード → 明示パス staging → `git commit -F` → 検証」の固定順。特定の deny list はハードコードせず(`rules/bash-and-api-discipline.md` の「設定が真実」原則)、どの guardrail 下でも拒否されにくい最小手順のみ規定
- **`skills/commit/evals/`** — trigger eval 18 cases(explicit 6 / ambiguous 4 / adjacent 5 / distractor 3)+ 1-rater 判定結果(F1=1.0、t08/t09 は弱マッチと明記)
- **`.claude/` / `.agents/`** — rulesync 再生成(`--check` pass)

## 境界

- commit 作成まで。push/PR は `shipping` / `commit-push-pr`、タグは RELEASING.md、履歴書き換え(amend/rebase/squash/reset/revert)は範囲外
- この PR のコミット自体を本 skill の手順で作成(dogfood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyVdLeY7iPBfmt9pf9kAME


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided commit workflow with staged file selection, file-based commit messages, and post-commit verification.
  * Added an issue-driven, headless issue→branch→implementation→PR workflow (with label-based locking and terminal PR handling).

* **Documentation**
  * Documented the commit workflow’s explicit in-scope/out-of-scope guardrails.
  * Added issue-driven-development wiring instructions for autonomous triggering and bounded CI/review/conflict responses.

* **Tests**
  * Added evaluation specs and results to improve detection accuracy for commit-trigger and issue-driven-development triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->