### PR TITLE
Add release-propagate workflow (Devin consumer updates on tag push)

### DIFF
--- a/.github/devin/consumer-update.md
+++ b/.github/devin/consumer-update.md
@@ -1,0 +1,25 @@
+# Consumer 更新タスク (rulesync pin 追随)
+
+kanade0404/skills の新しいリリースタグが発行された。上に記載されたタグに、以下の consumer リポジトリの pin / 取得内容を追随させ、**各リポ 1 つの PR** を作成すること。PR の merge はしない (人間が行う)。
+
+## 共通ルール
+
+- 変更は feature ブランチ (`chore/skills-<tag>` 等) で行い、default ブランチに直 push しない。
+- 生成物 (`.claude/`, `.codex/`, `.agents/` 等) は必ずリポ既存のスクリプトで再生成する。手で編集しない。
+- CI がある場合は green を確認してから PR を ready にする。落ちたら root cause を特定して直す。直せない場合は PR コメントに原因分析を書いて escalate する。
+- PR body に「何を・なぜ (新タグへの追随)・生成し直したもの」を記載し、リリースタグの diff リンク (https://github.com/kanade0404/skills/compare/<旧>...<新>) を貼る。
+
+## 対象 1: kanade0404/agegis
+
+- `package.json` の `rulesync:fetch` script が commit SHA で pin されている (`kanade0404/skills@<sha>`)。これを新タグ (`kanade0404/skills@<tag>`) に書き換える。
+- `rulesync:fetch` を実行して `.rulesync/` を更新し、リポ既存の generate 手順 (package.json の rulesync 系 script を確認) で各ツール設定を再生成する。
+- fetch/generate で意図しない大量差分が出た場合は、差分の内訳を PR body で説明する。
+
+## 対象 2: kanade0404/dotfiles
+
+- `rulesync.jsonc` は declarative source (git URL) 方式。`rulesync:skills:update` と `rulesync:skills:claude:update` (package.json 参照) を実行して最新タグ内容に更新・再生成する。
+- **追加確認**: `scripts/patch-rulesync-skill-frontmatter.ts` の役割を読むこと。これが「rulesync generate で落ちる allowed-tools を後付け補正する」ためのパッチである場合、skills v0.5.0 以降は canonical 側が `claudecode:` target-section 形式になり generate が allowed-tools を保持するため、**パッチが不要になっている可能性が高い**。不要と確認できたらパッチスクリプトと package.json の該当ステップを削除して簡素化する (確認できない場合は削除せず、PR コメントに調査結果を書く)。
+
+## 完了報告
+
+作成した PR の URL 一覧と、各リポで行った判断 (特に dotfiles のパッチ削除可否) を報告すること。

--- a/.github/workflows/release-propagate.yml
+++ b/.github/workflows/release-propagate.yml
@@ -1,0 +1,36 @@
+name: release propagate
+
+# リリースタグ push 時に Devin API へ session を作成し、consumer リポ
+# (agegis / dotfiles) の rulesync pin 追随 PR を作らせる。
+# playbook は .github/devin/consumer-update.md で管理する。
+# 必要 secret: DEVIN_API_KEY
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Propagate するリリースタグ (例: v0.5.0)'
+        required: true
+
+jobs:
+  devin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Devin session
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEVIN_API_KEY" ]; then
+            echo "::error::DEVIN_API_KEY secret is not set"; exit 1
+          fi
+          PROMPT="$(printf 'kanade0404/skills のリリースタグ %s が発行された。\n\n%s' "$TAG" "$(cat .github/devin/consumer-update.md)")"
+          jq -n --arg p "$PROMPT" '{prompt: $p, idempotent: true}' > body.json
+          # -f: API エラー時に非ゼロ exit (エラー本文をデータ扱いしない)
+          curl -sS -f -X POST https://api.devin.ai/v1/sessions \
+            -H "Authorization: Bearer $DEVIN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @body.json | jq '{session_id, url}'


### PR DESCRIPTION
## 概要

リリースタグ push 時に **Devin API へ session を自動作成**し、consumer リポ (agegis / dotfiles) の rulesync pin 追随 PR を作らせる自動連鎖。

## 構成

- `.github/workflows/release-propagate.yml` — `v*` タグ push / 手動 (`workflow_dispatch` に tag 入力) で発火。入力は env 経由で run に渡し (injection 対策)、`curl -f` + `jq --arg` で API エラー・エスケープを処理
- `.github/devin/consumer-update.md` — Devin への playbook (repo 管理でレビュー可能)。agegis の SHA pin → タグ pin 化、dotfiles の `patch-rulesync-skill-frontmatter.ts` 要否確認 (v0.5.0 で不要になった可能性) を含む

## merge 後に必要な手動ステップ

1. `gh secret set DEVIN_API_KEY -R kanade0404/skills` (リポオーナー)
2. v0.5.0 分の一括更新を実行: `gh workflow run release-propagate -f tag=v0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyVdLeY7iPBfmt9pf9kAME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release propagation so new version tags can trigger follow-up maintenance work.
  * Enabled a manual trigger for running the release propagation process with a specific tag.
  * Improved the release workflow to surface session details after the automation starts.
* **Documentation**
  * Added guidance for keeping consumer projects in sync during new releases, including verification steps and update instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->