### PR TITLE
Switch release-propagate to Devin API v3 (org sessions)

### DIFF
--- a/.github/workflows/release-propagate.yml
+++ b/.github/workflows/release-propagate.yml
@@ -1,9 +1,10 @@
 name: release propagate
 
-# リリースタグ push 時に Devin API へ session を作成し、consumer リポ
+# リリースタグ push 時に Devin API (v3) へ session を作成し、consumer リポ
 # (agegis / dotfiles) の rulesync pin 追随 PR を作らせる。
 # playbook は .github/devin/consumer-update.md で管理する。
-# 必要 secret: DEVIN_API_KEY
+# 必要 secret: DEVIN_API_KEY (Service User token, prefix "cog_"),
+#              DEVIN_ORG_ID (prefix "org-")
 on:
   push:
     tags: ['v*']
@@ -21,16 +22,21 @@ jobs:
       - name: Create Devin session
         env:
           DEVIN_API_KEY: ${{ secrets.DEVIN_API_KEY }}
+          DEVIN_ORG_ID: ${{ secrets.DEVIN_ORG_ID }}
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
           if [ -z "$DEVIN_API_KEY" ]; then
             echo "::error::DEVIN_API_KEY secret is not set"; exit 1
           fi
+          if [ -z "$DEVIN_ORG_ID" ]; then
+            echo "::error::DEVIN_ORG_ID secret is not set"; exit 1
+          fi
           PROMPT="$(printf 'kanade0404/skills のリリースタグ %s が発行された。\n\n%s' "$TAG" "$(cat .github/devin/consumer-update.md)")"
-          jq -n --arg p "$PROMPT" '{prompt: $p, idempotent: true}' > body.json
+          jq -n --arg p "$PROMPT" --arg t "skills $TAG consumer update" \
+            '{prompt: $p, title: $t, tags: ["skills-release-propagate"]}' > body.json
           # -f: API エラー時に非ゼロ exit (エラー本文をデータ扱いしない)
-          curl -sS -f -X POST https://api.devin.ai/v1/sessions \
+          curl -sS -f -X POST "https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions" \
             -H "Authorization: Bearer $DEVIN_API_KEY" \
             -H "Content-Type: application/json" \
             -d @body.json | jq '{session_id, url}'


### PR DESCRIPTION
v1 `/v1/sessions` が 403 を返したため ([run 28705779168](https://github.com/kanade0404/skills/actions/runs/28705779168))、[v3 仕様](https://docs.devin.ai/api-reference/v3/sessions/post-organizations-sessions.md) に移行。

- endpoint: `POST /v3/organizations/{org_id}/sessions`
- 認証: Service User token (prefix `cog_`) の Bearer
- **必要 secret が 2 つに**: `DEVIN_API_KEY` (cog_ token) + `DEVIN_ORG_ID` (org- prefix)。未設定は事前ガードで fail
- body: v1 の `idempotent` を除去、v3 の `title` / `tags` を付与

## merge 後の手動ステップ
1. `gh secret set DEVIN_API_KEY -R kanade0404/skills` — **Service User token (cog_...) であること**を確認 (旧 v1 用 key なら発行し直し)
2. `gh secret set DEVIN_ORG_ID -R kanade0404/skills` — `org-...` (Devin の organization settings で確認)
3. 再実行: `gh workflow run release-propagate.yml -f tag=v0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyVdLeY7iPBfmt9pf9kAME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use the latest session creation flow.
  * Added support for an additional required configuration value during release propagation.
  * Improved request details sent during automated release sessions for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->