### PR TITLE
release-propagate: log Devin API error body on failure

### DIFF
--- a/.github/workflows/release-propagate.yml
+++ b/.github/workflows/release-propagate.yml
@@ -35,8 +35,17 @@ jobs:
           PROMPT="$(printf 'kanade0404/skills のリリースタグ %s が発行された。\n\n%s' "$TAG" "$(cat .github/devin/consumer-update.md)")"
           jq -n --arg p "$PROMPT" --arg t "skills $TAG consumer update" \
             '{prompt: $p, title: $t, tags: ["skills-release-propagate"]}' > body.json
-          # -f: API エラー時に非ゼロ exit (エラー本文をデータ扱いしない)
-          curl -sS -f -X POST "https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions" \
+          # exit code でなく HTTP status で成否判定し、失敗時は API のエラー本文を
+          # ログに出す (本文は secret を含まない診断情報)。
+          status=$(curl -sS -o resp.json -w '%{http_code}' -X POST \
+            "https://api.devin.ai/v3/organizations/${DEVIN_ORG_ID}/sessions" \
             -H "Authorization: Bearer $DEVIN_API_KEY" \
             -H "Content-Type: application/json" \
-            -d @body.json | jq '{session_id, url}'
+            -d @body.json)
+          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+            echo "::error::Devin API returned HTTP $status"
+            echo "--- response body ---"
+            jq . resp.json 2>/dev/null || head -c 2000 resp.json
+            exit 1
+          fi
+          jq '{session_id, url}' resp.json


### PR DESCRIPTION
v3 移行 (#25) 後も 403 継続 ([run 28723047536](https://github.com/kanade0404/skills/actions/runs/28723047536))。`curl -f` がエラー本文を捨てて原因判別 (token 種別 / org 不一致 / 権限不足) ができないため、HTTP status 判定 + 失敗時エラー本文ログ出力に変更。

merge 後に `gh workflow run release-propagate.yml -f tag=v0.5.0` を再実行すると、403 の具体的理由がログに出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyVdLeY7iPBfmt9pf9kAME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow error handling so failed session creation now reports the HTTP status and a snippet of the response body, making issues easier to diagnose.
  * Successful responses now return only the session ID and URL, reducing noisy output and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->