### PR TITLE
ci: add gate-heartbeat — test-mutation-gate 発火率ゼロの週次検知

### DIFF
--- a/.github/workflows/gate-heartbeat.yml
+++ b/.github/workflows/gate-heartbeat.yml
@@ -1,0 +1,232 @@
+name: gate heartbeat
+
+# test-mutation-gate skill (skills/test-mutation-gate) はテスト変更のたびに強制起動され、
+# kanade0404/loop-ops (private) へ agent_run イベント (phase=test-mutation-gate) を送る。
+# skill が不発になっても「イベントが来ないだけ」で誰も気づけないため、週次で
+# 「merged PR はあるのに gate イベントが 1 件も無い」状態を検知して issue を立てる。
+#
+# なぜ actions/checkout が不要か:
+#   このワークフローがやることは (a) loop-ops の metrics/events を gh api で読む、
+#   (b) 閾値判定し、このリポジトリに issue を作る/コメントする、の 2 つだけで、
+#   どちらも gh CLI だけで完結する。リポジトリ内のファイルやスクリプトには一切
+#   依存しない自己完結設計にしてあるため checkout は不要 (checkout したコードが
+#   secrets の載った job で実行される経路自体を無くす)。
+#
+# なぜ token を 2 つ使い分けるか:
+#   LOOP_OPS_TOKEN は他 private repo (loop-ops) を読むための PAT で、このリポジトリ
+#   (skills) への書き込み権限は持たせない。issue の作成/コメントはこのワークフローに
+#   付与した issues: write を使う既定の `${{ github.token }}` で行い、loop-ops への
+#   読み取り権限は持たせない。「読む token」と「書く token」を分離し、どちらかが
+#   漏れても被害範囲を repo 1 つ分に限定する。
+on:
+  schedule:
+    # UTC 21:00 日曜 = JST 06:00 月曜。週次で先週分の状況を月曜朝に拾う想定。
+    - cron: '0 21 * * 0'
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: '集計 window (日数、既定 14)'
+        required: false
+        default: '14'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    env:
+      WINDOW_DAYS: ${{ inputs.window_days || '14' }}
+      # 閾値の根拠: merged PR が 1 件だけだと「たまたまテスト差分を含まない変更
+      # だった」可能性が残り誤検知になりやすい。2 件以上 merge されてなお gate
+      # イベントが 0 件なら偶然では説明しづらく、不発を疑うのに十分な件数と判断した。
+      MIN_MERGED_PRS: '2'
+      LOOP_OPS_REPO: kanade0404/loop-ops
+      ISSUE_TITLE: '[gate-heartbeat] test-mutation-gate が沈黙しています'
+    steps:
+      - name: Fetch loop-ops events and aggregate
+        id: aggregate
+        env:
+          GH_TOKEN: ${{ secrets.LOOP_OPS_TOKEN }}
+        run: |
+          set -u
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::LOOP_OPS_TOKEN secret is not set"
+            exit 1
+          fi
+
+          # 当月 + 前月の 2 ディレクトリを見る (window が月境界をまたぐケースの取りこぼし防止)。
+          # date -d 依存の月計算は月末日 (31 日等) の overflow で壊れやすいので、
+          # 純粋な整数演算で前月を求める。
+          CUR_YEAR=$(date -u +%Y)
+          CUR_MON=$(date -u +%m)
+          CUR_MON10=$((10#$CUR_MON))
+          if [ "$CUR_MON10" -eq 1 ]; then
+            PREV_YEAR=$((CUR_YEAR - 1)); PREV_MON10=12
+          else
+            PREV_YEAR=$CUR_YEAR; PREV_MON10=$((CUR_MON10 - 1))
+          fi
+          CUR_MONTH=$(printf '%04d-%02d' "$CUR_YEAR" "$CUR_MON10")
+          PREV_MONTH=$(printf '%04d-%02d' "$PREV_YEAR" "$PREV_MON10")
+
+          EVENTS_FILE="$RUNNER_TEMP/gate-heartbeat-events.ndjson"
+          : > "$EVENTS_FILE"
+
+          for month in "$CUR_MONTH" "$PREV_MONTH"; do
+            path="metrics/events/${month}"
+            err_file="$RUNNER_TEMP/gh_list_err.$month"
+            resp=$(gh api "repos/${LOOP_OPS_REPO}/contents/${path}" 2>"$err_file")
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              # 404 = そのディレクトリがまだ存在しない (イベント未発生) なので空扱いにする。
+              if grep -qi "not found\|HTTP 404" "$err_file"; then
+                echo "no directory for $month (404, treating as empty)"
+                continue
+              fi
+              echo "::error::failed to list $path"
+              cat "$err_file" >&2
+              exit 1
+            fi
+
+            files=$(echo "$resp" | jq -r '.[] | select(.type=="file") | .path')
+            if [ -z "$files" ]; then
+              continue
+            fi
+            while IFS= read -r filepath; do
+              [ -z "$filepath" ] && continue
+              gh api -H "Accept: application/vnd.github.raw" "repos/${LOOP_OPS_REPO}/contents/${filepath}" >> "$EVENTS_FILE"
+              printf '\n' >> "$EVENTS_FILE"
+            done <<< "$files"
+          done
+
+          # 1 event = 1 file を全部連結したものを --slurpfile で 1 つの JSON 配列にまとめ、
+          # window (直近 WINDOW_DAYS 日) 内だけを対象に ts を fromdateiso8601 で比較する。
+          RESULT=$(jq -n --argjson window_days "$WINDOW_DAYS" --slurpfile events "$EVENTS_FILE" '
+            ($events) as $all
+            | now as $now_epoch
+            | ($all | map(select(
+                (.ts // null) != null
+                and (($now_epoch - (.ts | fromdateiso8601)) <= ($window_days * 86400))
+              ))) as $win
+            | {
+                merged_prs: ($win | map(select(.event=="pr_closed" and .outcome=="merged")) | length),
+                gate_events: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate")) | length),
+                gate_blocks: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate" and .result_subtype=="block")) | length)
+              }
+          ')
+
+          merged_prs=$(echo "$RESULT" | jq '.merged_prs')
+          gate_events=$(echo "$RESULT" | jq '.gate_events')
+          gate_blocks=$(echo "$RESULT" | jq '.gate_blocks')
+
+          is_alert=false
+          if [ "$merged_prs" -ge "$MIN_MERGED_PRS" ] && [ "$gate_events" -eq 0 ]; then
+            is_alert=true
+          fi
+
+          stale_note=""
+          if [ "$gate_events" -ge 10 ] && [ "$gate_blocks" -eq 0 ]; then
+            stale_note="形骸化の疑い (BLOCK 率 0%): gate_events=${gate_events} 件動いているが gate_blocks=0。ゲートが常に pass しているだけで実質何もチェックしていない可能性がある。"
+          fi
+
+          {
+            echo "## gate-heartbeat 集計結果"
+            echo ""
+            echo "- window: 直近 ${WINDOW_DAYS} 日 (対象月: ${CUR_MONTH} + ${PREV_MONTH})"
+            echo "- 閾値: merged_prs >= ${MIN_MERGED_PRS} かつ gate_events == 0 でアラート"
+            echo ""
+            echo "| 指標 | 値 |"
+            echo "|---|---|"
+            echo "| merged_prs | ${merged_prs} |"
+            echo "| gate_events (test-mutation-gate) | ${gate_events} |"
+            echo "| gate_blocks | ${gate_blocks} |"
+            echo ""
+            if [ "$is_alert" = "true" ]; then
+              echo "**ALERT**: test-mutation-gate が沈黙しています。issue を作成/更新します。"
+            else
+              echo "OK: 沈黙は検知されませんでした。"
+            fi
+            if [ -n "$stale_note" ]; then
+              echo ""
+              echo "> ${stale_note}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "merged_prs=${merged_prs}"
+            echo "gate_events=${gate_events}"
+            echo "gate_blocks=${gate_blocks}"
+            echo "is_alert=${is_alert}"
+            echo "cur_month=${CUR_MONTH}"
+            echo "prev_month=${PREV_MONTH}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update alert issue
+        if: steps.aggregate.outputs.is_alert == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          MERGED_PRS: ${{ steps.aggregate.outputs.merged_prs }}
+          GATE_EVENTS: ${{ steps.aggregate.outputs.gate_events }}
+          GATE_BLOCKS: ${{ steps.aggregate.outputs.gate_blocks }}
+          CUR_MONTH: ${{ steps.aggregate.outputs.cur_month }}
+          PREV_MONTH: ${{ steps.aggregate.outputs.prev_month }}
+        run: |
+          set -u
+
+          # heredoc (<<EOF) は使わない: YAML の run: | ブロックはインデントを保つ必要が
+          # あり、ヒアドキュメントの終端行だけ行頭に戻すと YAML パースが壊れる。
+          # 代わりに { echo ...; } > file で本文ファイルを組み立てる (GITHUB_STEP_SUMMARY
+          # と同じパターン)。ダブルクォート内のバッククォートはコマンド置換とみなされる
+          # ため \` でエスケープしてリテラル文字として出す。
+          BODY_FILE="$RUNNER_TEMP/gate-heartbeat-issue-body.md"
+          {
+            echo "## 集計値 (window: 直近 ${WINDOW_DAYS} 日, 対象月: ${CUR_MONTH} + ${PREV_MONTH})"
+            echo ""
+            echo "| 指標 | 値 |"
+            echo "|---|---|"
+            echo "| merged_prs | ${MERGED_PRS} |"
+            echo "| gate_events (test-mutation-gate) | ${GATE_EVENTS} |"
+            echo "| gate_blocks | ${GATE_BLOCKS} |"
+            echo ""
+            echo "merged PR が ${MIN_MERGED_PRS} 件以上あるのに、test-mutation-gate の agent_run"
+            echo "イベントが loop-ops (kanade0404/loop-ops) に 1 件も届いていません。"
+            echo ""
+            echo "## 考えられる原因"
+            echo ""
+            echo "1. 呼び出し元 skill (tdd / pr-review-respond / verify-done 等) からゲート呼び出し"
+            echo "   自体が剥がれた、または条件分岐でスキップされている。"
+            echo "2. 開発マシンから loop-ops への送信が全段失敗し、ローカル fallback"
+            echo "   (\`.cache/test-mutation-gate/gate-events.jsonl\`) に溜まったまま送信されていない。"
+            echo ""
+            echo "## 確認手順"
+            echo ""
+            echo "1. 該当期間 (直近 ${WINDOW_DAYS} 日) に merge された PR に、実際にテストファイルの"
+            echo "   diff が含まれているか確認する (\`gh pr list --repo kanade0404/skills --state merged --search \"merged:>=<date>\"\`"
+            echo "   などで対象 PR を洗い出し、\`gh pr diff <number> --name-only\` でテストファイルの"
+            echo "   有無を見る)。テスト変更を含む PR が無ければ gate 不発は正常。"
+            echo "2. 開発マシン側の \`.cache/test-mutation-gate/gate-events.jsonl\` を確認し、"
+            echo "   未送信イベントが滞留していないか見る。"
+            echo "3. 滞留イベントがあれば DuckDB で内容を確認できる:"
+            echo ""
+            echo "   \`\`\`sql"
+            echo "   SELECT ts, phase, result_subtype, caller"
+            echo "   FROM read_json_auto('.cache/test-mutation-gate/gate-events.jsonl')"
+            echo "   ORDER BY ts DESC"
+            echo "   LIMIT 20;"
+            echo "   \`\`\`"
+            echo ""
+            echo "_gate-heartbeat workflow により自動生成 (run: ${GITHUB_RUN_ID})_"
+          } > "$BODY_FILE"
+
+          existing=$(gh issue list --search "in:title \"$ISSUE_TITLE\"" --state open --json number,title \
+            | jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)] | first // empty')
+
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            number=$(echo "$existing" | jq -r '.number')
+            gh issue comment "$number" --body-file "$BODY_FILE"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/gate-heartbeat.yml
+++ b/.github/workflows/gate-heartbeat.yml
@@ -77,9 +77,12 @@ jobs:
           for month in "$CUR_MONTH" "$PREV_MONTH"; do
             path="metrics/events/${month}"
             err_file="$RUNNER_TEMP/gh_list_err.$month"
-            resp=$(gh api "repos/${LOOP_OPS_REPO}/contents/${path}" 2>"$err_file")
-            rc=$?
-            if [ $rc -ne 0 ]; then
+            # `resp=$(...)` を素の代入文のまま書くと、既定シェル (unspecified => `bash -e {0}`)
+            # の下で gh api が非 0 を返した瞬間に、後続の rc=$? へ到達する前にスクリプトごと
+            # abort してしまい、意図している「404 は空扱い」分岐が実行されない
+            # (bash の -e は if/while/until の条件式内のコマンドだけを例外扱いする)。
+            # 代入自体を if の条件式に含めることで -e の対象外にする。
+            if ! resp=$(gh api "repos/${LOOP_OPS_REPO}/contents/${path}" 2>"$err_file"); then
               # 404 = そのディレクトリがまだ存在しない (イベント未発生) なので空扱いにする。
               if grep -qi "not found\|HTTP 404" "$err_file"; then
                 echo "no directory for $month (404, treating as empty)"
@@ -103,12 +106,18 @@ jobs:
 
           # 1 event = 1 file を全部連結したものを --slurpfile で 1 つの JSON 配列にまとめ、
           # window (直近 WINDOW_DAYS 日) 内だけを対象に ts を fromdateiso8601 で比較する。
-          RESULT=$(jq -n --argjson window_days "$WINDOW_DAYS" --slurpfile events "$EVENTS_FILE" '
+          # loop-ops (kanade0404/loop-ops) は複数リポジトリが同じ metrics/events/<month>/ に
+          # 書き込む共有ストアであり (emit_gate_event.sh の repo フィールドは呼び出し元の
+          # git remote から決まる)、.repo でこのリポジトリ ($GITHUB_REPOSITORY, GitHub Actions
+          # が既定で提供する env var) に絞らないと、他リポジトリの gate_events/merged_prs が
+          # 混入して検知漏れ・誤検知の両方向にブレる。
+          RESULT=$(jq -n --argjson window_days "$WINDOW_DAYS" --arg repo "$GITHUB_REPOSITORY" --slurpfile events "$EVENTS_FILE" '
             ($events) as $all
             | now as $now_epoch
             | ($all | map(select(
                 (.ts // null) != null
                 and (($now_epoch - (.ts | fromdateiso8601)) <= ($window_days * 86400))
+                and ((.repo // null) == $repo)
               ))) as $win
             | {
                 merged_prs: ($win | map(select(.event=="pr_closed" and .outcome=="merged")) | length),
@@ -221,8 +230,18 @@ jobs:
             echo "_gate-heartbeat workflow により自動生成 (run: ${GITHUB_RUN_ID})_"
           } > "$BODY_FILE"
 
-          existing=$(gh issue list --search "in:title \"$ISSUE_TITLE\"" --state open --json number,title \
-            | jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)] | first // empty')
+          # `gh issue list | jq ...` をそのままパイプで繋ぐと、既定シェル (unspecified =>
+          # `bash -e {0}`) には pipefail が無い (pipefail は `shell: bash` を明示した場合のみ
+          # 付く) ため、パイプの終了ステータスは最後のコマンド (jq) のものになる。gh issue
+          # list が失敗しても jq が空 stdin から `empty` を返して 0 終了すれば existing が
+          # 空のまま else 分岐 (issue 新規作成) に流れ、検索失敗を「既存 issue 無し」と誤認
+          # して重複 issue を作ってしまう。gh issue list の失敗を明示的にチェックしてから jq
+          # に渡すことで、パイプの exit code 合成に依存しない。
+          if ! issue_list_json=$(gh issue list --search "in:title \"$ISSUE_TITLE\"" --state open --json number,title); then
+            echo "::error::failed to list issues for dedup check"
+            exit 1
+          fi
+          existing=$(echo "$issue_list_json" | jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)] | first // empty')
 
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             number=$(echo "$existing" | jq -r '.number')


### PR DESCRIPTION
## 概要

「skill が不発になっても何も起きない(静かに素通りする)」問題への対応 3 = **発火率ゼロの自動検知**。test-mutation-gate が loop-ops に送る `agent_run` イベントを週次で照会し、「PR は merge されているのにゲートが一度も発火していない」沈黙を **issue として自動可視化**する workflow を追加する。

test-review が 100 セッション超で 0 回しか呼ばれなかった劣化は、当時誰も気づけなかった。本 workflow はその再演を「検出可能」から「検出される」に変える。

## 動作

- **週次**(月曜 06:00 JST)+ `workflow_dispatch`(`window_days` 上書き可、既定 14)
- `LOOP_OPS_TOKEN` で loop-ops の当月 + 前月イベントを取得し、直近 window の `merged_prs` / `gate_events` / `gate_blocks` を集計
- **アラート条件**: `merged_prs >= 2` かつ `gate_events == 0` → 本リポジトリに issue 起票
  - タイトル固定 + 完全一致検索で**多重作成防止**(既存 open があれば comment 追記)
  - 本文に原因候補 2 つ(① 呼び出し元 skill からゲート呼び出しが剥がれた ② 送信が全段失敗しローカル fallback に滞留)と確認手順を記載
- 常に step summary へ集計表を出力。`gate_events >= 10` かつ BLOCK 0 件は「形骸化の疑い」を summary に注記(issue は立てない)
- checkout 不要の自己完結型。読み取り(`LOOP_OPS_TOKEN`)と issue 書き込み(`github.token`)でトークン分離

## 検証(実施済み)

- 実データ: window 14 日で `merged_prs=22 / gate_events=1 / gate_blocks=0` → **非アラート**(正)
- `agent_run` を除外した合成入力 → **アラート発火**(正)
- window=1 日で `merged_prs` が 22→18 に減少 = 時間フィルタの実効性を確認
- issue 検索: fuzzy 検索が無関係 issue (#36/#37) に部分一致することを確認し、完全一致 jq フィルタの必要性を実証
- actionlint(nix run 経由)/ shellcheck: clean
- 前月ディレクトリ 404(未作成)は空扱いで正常動作

## 前提(依存 PR)

このアラートが誤報にならないためには、開発マシンからのイベント送信が実際に届く必要がある。**#40 に含まれる emit_gate_event.sh の gh 環境認証 fallback が前提**(検証で loop-ops に初の agent_run イベントが到着済み)。merge 順は #40 → 本 PR を推奨。

## 残された既知の限界

- 「merged PR にテスト diff が含まれていたか」までは判定しない(cross-repo のファイル参照権限が無いため)。誤報方向に倒れる設計で、issue 本文の確認手順で人間が 1 分で判別できる
- skill 不発を**物理的に防ぐ**わけではない(それは PostToolUse hook / CI 必須 check の領域で、未実装のまま)。本 PR は「不発が 1 週間以上続いた事実を必ず可視化する」まで

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HJPNWS3MTB7ggCvhnKRow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated weekly “gate heartbeat” check that aggregates recent activity and merged PR counts.
  * If merged PRs are present while gate test activity drops below expectations, it opens a new issue or updates an existing one with key metrics.
  * When gate-related blocks are detected but no blocks are confirmed, it includes a “stale” note with suggested next steps.
  * Supports manual runs with a configurable lookback window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->