### PR TITLE
feat(effect-ts): vendor Effect-TS skill (copy-in, pinned)

### DIFF
--- a/.agents/skills/effect-ts/PROVENANCE.md
+++ b/.agents/skills/effect-ts/PROVENANCE.md
@@ -1,0 +1,39 @@
+# Provenance
+
+This skill is **vendored** (copied in) from a third-party repository, per the
+copy-in exception in the repo-root `CLAUDE.md` ("copy-in 例外は skill ディレクトリ内に
+出典 + LICENSE を残す").
+
+- Source: https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+- Upstream repo: https://github.com/Effect-TS/skills
+- Pinned commit: `b5026c68318f395bbfd258182ea6b524ff2be549`
+- Commit date: 2026-05-15
+- Vendored on: 2026-07-05
+- Reason: supply-chain safety — copied verbatim instead of fetching at consume time.
+
+## License status
+
+At the time of vendoring, the upstream `Effect-TS/skills` repository contained
+**no LICENSE file and no explicit license statement** (verified via the GitHub
+API and the upstream README). The Effect project is generally published under the
+MIT License, but this `skills` repository carries no explicit grant. This copy is
+made in good faith for internal use. If upstream adds an explicit license, or
+requests removal, update or remove this vendored copy accordingly.
+
+## Re-syncing from upstream
+
+Re-fetch each file at a chosen commit `<SHA>`:
+
+```sh
+for f in SKILL.md references/features.md references/guide-effect.md \
+  references/guide-error-handling.md references/guide-layers.md \
+  references/guide-observability.md references/guide-retries.md \
+  references/guide-schedule.md references/guide-schema.md \
+  references/guide-sql.md references/guide-testing.md references/setup.md; do
+  gh api "repos/Effect-TS/skills/contents/skills/effect-ts/$f?ref=<SHA>" \
+    --jq '.content' | base64 -d > "skills/effect-ts/$f"
+done
+```
+
+After re-syncing, re-apply the source-attribution comment in SKILL.md and update the
+pinned commit / dates above.

--- a/.agents/skills/effect-ts/SKILL.md
+++ b/.agents/skills/effect-ts/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: effect-ts
+description: >-
+  Use this skill whenever working in a repository that uses Effect, even if the
+  current task is in a new file or the user does not explicitly ask for Effect
+  help. Apply it to any work that should follow the repository's Effect
+  patterns, conventions, architecture, or supporting tooling. Also use it for
+  questions about Effect patterns, services, layers, schemas, streams, runtimes,
+  or typed error handling.
+---
+<!--
+Vendored from Effect-TS/skills — https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+Upstream commit: b5026c68318f395bbfd258182ea6b524ff2be549 (2026-05-15)
+Copied verbatim (supply-chain safety). Provenance + re-sync steps: ./PROVENANCE.md
+Do not edit vendored content here; re-sync from upstream instead.
+-->
+
+# Effect Expert
+
+Expert guidance for programming with the Effect library, covering error handling, dependency injection, composability, and testing patterns.
+
+## Prerequisite
+
+Before doing any other Effect-related work, check that `./.repos/effect` exists at the root of the repository where the skill is being used.
+
+If it does not exist, stop and prompt the user with the setup task documented in `./references/setup.md`.
+
+## Research Strategy
+
+Effect has many ways to accomplish the same task. Proactively research best practices when working with Effect patterns, especially for moderate to high complexity tasks.
+
+Use the local guides in `./references/` first. They are the preferred source for best practices, conventions, and common implementation patterns.
+
+Only go directly to the vendored Effect repo when:
+
+- the guides do not cover the question
+- you need exact API details or signatures
+- you need deeper implementation details
+- you need to verify a behavior against the source
+
+### Research Sources
+
+1. Local skill guides first. Start with the relevant files in `./references/` before doing deeper research.
+2. Codebase patterns second. Examine similar patterns in the current project before implementing. If Effect patterns already exist, follow them for consistency. If no patterns exist, skip this step.
+3. Effect source code last. For gaps in the guides, complex type errors, unclear behavior, or implementation details, examine the vendored Effect source at `./.repos/effect/packages/effect/src/`.
+
+### When To Research
+
+- Always research for services, layers, or complex dependency injection.
+- Always research for error handling with multiple error types or complex error hierarchies.
+- Always research for stream-based operations and reactive patterns.
+- Always research for resource management with scoped effects and cleanup.
+- Always research for concurrent or performance-critical code.
+- Always research for unfamiliar testing patterns.
+- Research when needed for complex refactors from promises or try/catch into Effect.
+- Research when needed for new service dependencies or layer restructuring.
+- Research when needed for custom error types or extensions of existing error hierarchies.
+- Research when needed for integrations with external systems such as databases, APIs, or third-party services.
+
+### Research Approach
+
+- Focus on canonical, readable, and maintainable solutions rather than clever optimizations.
+- Verify suggested approaches against existing codebase patterns when those patterns exist.
+- When multiple approaches are possible, prefer the most idiomatic Effect solution supported by the codebase and the vendored source.
+
+### Codebase Pattern Discovery
+
+When working in a project that uses Effect, check for existing patterns before implementing new code:
+
+1. Search for Effect imports and existing module usage to understand current conventions.
+2. Identify how services and layers are structured in the project.
+3. Note how errors are defined and propagated.
+4. Examine how Effect code is tested in the project.
+
+If no Effect patterns exist in the codebase, proceed using canonical patterns from the vendored Effect source and examples. Do not block on missing codebase patterns.
+
+### Feature Discovery
+
+When you need to discover available Effect modules, packages, or capabilities, search `./references/features.md` first.
+
+- Use it to identify the right package or module for a task.
+- Use the listed repo paths to jump directly into the vendored source under `./.repos/effect`.
+- Use it before inventing custom abstractions when Effect may already provide the functionality.
+
+### Guide Discovery
+
+When the task touches one of these areas, consult the matching guide before implementing:
+
+- `./references/guide-effect.md` for core `Effect` usage patterns, common constructors, composition, provisioning, and runtime boundaries
+- `./references/guide-error-handling.md` for defining errors, schema-based errors, failure handling, defects, and interrupts
+- `./references/guide-layers.md` for services, layer construction, composition, and provisioning patterns
+- `./references/guide-observability.md` for `Effect.fn`, spans, logging, metrics, and telemetry wiring
+- `./references/guide-retries.md` for retry policies, retry conditions, fallback strategies, and `ExecutionPlan`
+- `./references/guide-schedule.md` for retries, repeats, backoff, polling, cron, and schedule composition
+- `./references/guide-schema.md` for schema design, transformations, unions, recursion, opaque/branded types, and schema best practices
+- `./references/guide-sql.md` for Effect SQL usage, transactions, resolvers, schema-aware SQL, and migrations
+- `./references/guide-testing.md` for detailed `@effect/vitest` usage, layered test setup, property tests, and test services
+
+These guides should be treated as the default implementation guidance. Do not skip them and jump straight to `./.repos/effect` unless you need source-level confirmation or the guides do not answer the question.
+
+## Effect Principles
+
+Apply these core principles when writing Effect code.
+
+## Installation
+
+When installing Effect packages in a user repository:
+
+- use `effect@beta`
+- keep all `@effect/*` packages on aligned versions
+- install only the packages needed for the user's runtime and actual task
+
+### Version Rules
+
+- `effect` should be installed as `effect@beta`
+- if you install any `@effect/*` package, make sure all `@effect/*` packages use matching versions
+- do not mix unrelated `@effect/*` versions in the same project
+
+### Package Selection
+
+Choose packages based on the runtime and the work being done.
+
+- core library: `effect@beta`
+- Node.js runtime needs: install the matching `@effect/platform-node`
+- browser runtime needs: install the matching `@effect/platform-browser`
+- Bun runtime needs: install the matching `@effect/platform-bun`
+- Vitest integration needs: install the matching `@effect/vitest`
+- OpenTelemetry integration needs: install the matching `@effect/opentelemetry`
+
+Install additional `@effect/*` packages only when the user task actually needs them.
+
+### Practical Rule
+
+- start with `effect@beta`
+- add `@effect/*` packages as needed by runtime and features
+- keep the full installed Effect package set version-aligned
+
+### Error Handling
+
+- Use Effect's typed error system instead of throwing exceptions.
+- Define descriptive error types with proper error propagation.
+- Prefer `Schema.TaggedErrorClass` when the error can be schema-defined.
+- Use `Effect.fail`, `Effect.catchTag`, and `Effect.catch` for error control flow.
+
+### Dependency Injection
+
+- Implement dependency injection using services and layers.
+- Define services with `Context.Tag`.
+- Compose layers with `Layer.merge` and `Layer.provide`.
+- Use `Effect.provide` to inject dependencies at the edge, avoid providing locally.
+- Keep services encapsulated; avoid exporting trivial accessor wrappers that only forward to one service method.
+
+### Composability
+
+- Leverage Effect composability for complex operations.
+- Use appropriate constructors such as `Effect.succeed`, `Effect.fail`, `Effect.tryPromise`, `Effect.try`, and `Effect.sync`.
+- Apply proper resource management with scoped effects.
+- Chain operations with `Effect.flatMap`, `Effect.map`, and `Effect.tap`.
+
+### Business Logic Functions
+
+- Prefer `Effect.fn` for reusable business-logic functions that return `Effect`.
+- Prefer `Effect.fn` over raw `Effect.gen` definitions even when the function takes no arguments.
+- If you do not want an explicit named span, use `Effect.fn` without a span name.
+- Do not use `Effect.fnUntraced` as the default.
+- Use `Effect.fnUntraced` only for edge cases with a concrete low-level reason, such as measured hot-path overhead.
+
+### TypeScript Preferences
+
+- Never use `any`.
+- Never use `as` casts.
+- Never use unsafe type assertions or escape hatches.
+- Never use `namespace`.
+- Prefer correct typing, schema-driven decoding, narrowing, and proper generic constraints instead of forcing types.
+- If a value comes from an external boundary, validate or decode it instead of asserting its type.
+- If a type is hard to express, simplify the design or introduce a properly typed helper instead of using unsafe TypeScript.
+- For layers, do not hide them inside `namespace` blocks. Prefer either `static` members on the service class or plain exported layer constants.
+
+### Code Quality
+
+- Write type-safe code that leverages Effect's type system.
+- Use `Effect.gen` for readable sequential code.
+- Implement proper testing patterns using Effect testing utilities.
+- Prefer existing Effect primitives before introducing custom helpers.
+- Prefer `Schema.Class` / `Schema.TaggedClass` variants over plain `Schema.Struct` for named reusable schemas when possible.
+
+### Explaining Solutions
+
+When providing solutions, explain the Effect concepts being used and why they fit the specific use case. If you encounter patterns not covered in local references, prefer consistency with the codebase when possible and otherwise rely on the vendored Effect source.
+
+## References
+
+- `./references/features.md`
+- `./references/guide-effect.md`
+- `./references/guide-error-handling.md`
+- `./references/guide-layers.md`
+- `./references/guide-observability.md`
+- `./references/guide-retries.md`
+- `./references/guide-schedule.md`
+- `./references/guide-schema.md`
+- `./references/guide-sql.md`
+- `./references/guide-testing.md`
+- `./references/setup.md`

--- a/.agents/skills/effect-ts/references/features.md
+++ b/.agents/skills/effect-ts/references/features.md
@@ -1,0 +1,504 @@
+# Features
+
+Public package and module surface area to be aware of when researching or implementing a solution. Each module entry includes its vendored repo path so it can be located quickly.
+
+## `effect` Package
+
+Package path: `packages/effect`
+
+- `Array` - `packages/effect/src/Array.ts` - Immutable array utilities. Use: transform arrays immutably.
+- `BigDecimal` - `packages/effect/src/BigDecimal.ts` - Arbitrary-precision decimal arithmetic. Use: avoid floating-point errors.
+- `BigInt` - `packages/effect/src/BigInt.ts` - `bigint` utilities and instances. Use: work with large integers.
+- `Boolean` - `packages/effect/src/Boolean.ts` - Boolean utilities and instances. Use: compose boolean logic.
+- `Brand` - `packages/effect/src/Brand.ts` - Branded type helpers. Use: prevent accidental type mixing.
+- `Cache` - `packages/effect/src/Cache.ts` - Effect cache utilities. Use: memoize effectful lookups.
+- `Cause` - `packages/effect/src/Cause.ts` - Structured effect failure representation. Use: inspect failures and defects.
+- `Channel` - `packages/effect/src/Channel.ts` - Bidirectional streaming I/O abstraction. Use: build stream pipelines.
+- `ChannelSchema` - `packages/effect/src/ChannelSchema.ts` - Schema helpers for channels. Use: type channel protocols.
+- `Chunk` - `packages/effect/src/Chunk.ts` - Immutable high-performance sequence. Use: efficient functional sequences.
+- `Clock` - `packages/effect/src/Clock.ts` - Time service and sleep utilities. Use: schedule and measure time.
+- `Combiner` - `packages/effect/src/Combiner.ts` - Combine two values of one type. Use: merge values consistently.
+- `Config` - `packages/effect/src/Config.ts` - Schema-driven configuration loading. Use: read typed app config.
+- `ConfigProvider` - `packages/effect/src/ConfigProvider.ts` - Configuration data source abstraction. Use: load config from env/files.
+- `Console` - `packages/effect/src/Console.ts` - Effectful console operations. Use: log and debug safely.
+- `Context` - `packages/effect/src/Context.ts` - Dependency injection context table. Use: provide and access services.
+- `Cron` - `packages/effect/src/Cron.ts` - Cron scheduling utilities. Use: express recurring schedules.
+- `Data` - `packages/effect/src/Data.ts` - Immutable data and tagged unions. Use: model domain data and errors.
+- `DateTime` - `packages/effect/src/DateTime.ts` - Date-time utilities. Use: handle timestamps and calendars.
+- `Deferred` - `packages/effect/src/Deferred.ts` - Single-assignment async variable. Use: coordinate concurrent fibers.
+- `Differ` - `packages/effect/src/Differ.ts` - Value diffing utilities. Use: compute incremental updates.
+- `Duration` - `packages/effect/src/Duration.ts` - Precise time span type. Use: represent delays and intervals.
+- `Effect` - `packages/effect/src/Effect.ts` - Core effect type and operators. Use: model async and concurrent work.
+- `Effectable` - `packages/effect/src/Effectable.ts` - Protocols for effect-like values. Use: integrate custom yieldables.
+- `Encoding` - `packages/effect/src/Encoding.ts` - Base64, Base64Url, and Hex codecs. Use: encode binary/text values.
+- `Equal` - `packages/effect/src/Equal.ts` - Structural and custom equality. Use: compare immutable values deeply.
+- `Equivalence` - `packages/effect/src/Equivalence.ts` - Equivalence relation helpers. Use: dedupe or compare with custom rules.
+- `ErrorReporter` - `packages/effect/src/ErrorReporter.ts` - Pluggable error reporting. Use: forward failures to observability tools.
+- `ExecutionPlan` - `packages/effect/src/ExecutionPlan.ts` - Execution plan utilities. Use: inspect planned work.
+- `Exit` - `packages/effect/src/Exit.ts` - Synchronous effect outcome value. Use: inspect success or failure.
+- `Fiber` - `packages/effect/src/Fiber.ts` - Lightweight concurrency primitive. Use: fork and join work.
+- `FiberHandle` - `packages/effect/src/FiberHandle.ts` - Managed fiber handle helpers. Use: control child fibers.
+- `FiberMap` - `packages/effect/src/FiberMap.ts` - Fiber map utilities. Use: track fibers by key.
+- `FiberSet` - `packages/effect/src/FiberSet.ts` - Fiber set utilities. Use: manage groups of fibers.
+- `FileSystem` - `packages/effect/src/FileSystem.ts` - Effectful file system abstraction. Use: read and write files safely.
+- `Filter` - `packages/effect/src/Filter.ts` - Filter result utilities. Use: compose filtering operations.
+- `Formatter` - `packages/effect/src/Formatter.ts` - Human-readable value formatting. Use: pretty-print data for logs.
+- `Function` - `packages/effect/src/Function.ts` - Core function helpers. Use: pipe and compose functions.
+- `Graph` - `packages/effect/src/Graph.ts` - Graph utilities. Use: model dependency graphs.
+- `Hash` - `packages/effect/src/Hash.ts` - Hashing utilities. Use: hash values for collections.
+- `HashMap` - `packages/effect/src/HashMap.ts` - Immutable hash map. Use: keyed immutable storage.
+- `HashRing` - `packages/effect/src/HashRing.ts` - Consistent hashing utilities. Use: distribute keys across nodes.
+- `HashSet` - `packages/effect/src/HashSet.ts` - Immutable hash set. Use: store unique immutable values.
+- `HKT` - `packages/effect/src/HKT.ts` - Higher-kinded type utilities. Use: define generic type classes.
+- `Inspectable` - `packages/effect/src/Inspectable.ts` - Custom inspection helpers. Use: improve debugging output.
+- `Iterable` - `packages/effect/src/Iterable.ts` - Functional iterable utilities. Use: process lazy iterables.
+- `JsonPatch` - `packages/effect/src/JsonPatch.ts` - JSON Patch operations. Use: diff and patch JSON documents.
+- `JsonPointer` - `packages/effect/src/JsonPointer.ts` - JSON Pointer token helpers. Use: escape pointer path segments.
+- `JsonSchema` - `packages/effect/src/JsonSchema.ts` - JSON Schema dialect conversion. Use: convert schemas between formats.
+- `Latch` - `packages/effect/src/Latch.ts` - Latch synchronization primitive. Use: gate concurrent progress.
+- `Layer` - `packages/effect/src/Layer.ts` - Service construction recipes. Use: build and wire dependencies.
+- `LayerMap` - `packages/effect/src/LayerMap.ts` - Layer registry helpers. Use: share and look up layers.
+- `Logger` - `packages/effect/src/Logger.ts` - Structured logging system. Use: emit runtime logs.
+- `LogLevel` - `packages/effect/src/LogLevel.ts` - Log level utilities. Use: filter logs by severity.
+- `ManagedRuntime` - `packages/effect/src/ManagedRuntime.ts` - Managed runtime helpers. Use: own runtime lifecycle.
+- `Match` - `packages/effect/src/Match.ts` - Type-safe pattern matching. Use: replace switch-heavy branching.
+- `Metric` - `packages/effect/src/Metric.ts` - Application metrics system. Use: count, gauge, and histogram events.
+- `MutableHashMap` - `packages/effect/src/MutableHashMap.ts` - Mutable hash map. Use: high-performance mutable key-value storage.
+- `MutableHashSet` - `packages/effect/src/MutableHashSet.ts` - Mutable hash set. Use: high-performance mutable uniqueness checks.
+- `MutableList` - `packages/effect/src/MutableList.ts` - Mutable linked-list-like buffer. Use: efficient append/prepend workloads.
+- `MutableRef` - `packages/effect/src/MutableRef.ts` - Mutable reference container. Use: hold local mutable state.
+- `Newtype` - `packages/effect/src/Newtype.ts` - Zero-cost wrapper types. Use: distinguish same-shaped values.
+- `NonEmptyIterable` - `packages/effect/src/NonEmptyIterable.ts` - Non-empty iterable helpers. Use: require at least one element.
+- `Number` - `packages/effect/src/Number.ts` - Number utilities and instances. Use: do typed numeric operations.
+- `Optic` - `packages/effect/src/Optic.ts` - Immutable data accessors and updaters. Use: read or update nested state.
+- `Option` - `packages/effect/src/Option.ts` - Optional value type. Use: model absence safely.
+- `Order` - `packages/effect/src/Order.ts` - Total ordering type class. Use: sort and compare values.
+- `Ordering` - `packages/effect/src/Ordering.ts` - Comparison result helpers. Use: combine sort outcomes.
+- `PartitionedSemaphore` - `packages/effect/src/PartitionedSemaphore.ts` - Partition-aware semaphore. Use: limit concurrency by key.
+- `Path` - `packages/effect/src/Path.ts` - Path utilities. Use: work with filesystem-style paths.
+- `Pipeable` - `packages/effect/src/Pipeable.ts` - Pipeable protocol helpers. Use: support fluent pipelines.
+- `PlatformError` - `packages/effect/src/PlatformError.ts` - Platform error types. Use: normalize platform-specific failures.
+- `Pool` - `packages/effect/src/Pool.ts` - Resource pool utilities. Use: reuse scarce resources.
+- `Predicate` - `packages/effect/src/Predicate.ts` - Predicate and refinement helpers. Use: filter and narrow values.
+- `PrimaryKey` - `packages/effect/src/PrimaryKey.ts` - Primary key helpers. Use: define stable string identifiers.
+- `PubSub` - `packages/effect/src/PubSub.ts` - Publish-subscribe hub. Use: broadcast messages to subscribers.
+- `Pull` - `packages/effect/src/Pull.ts` - Pull protocol helpers. Use: model pull-based streaming.
+- `Queue` - `packages/effect/src/Queue.ts` - Effect queue utilities. Use: buffer producer-consumer work.
+- `Random` - `packages/effect/src/Random.ts` - Randomness service. Use: generate testable random values.
+- `RcMap` - `packages/effect/src/RcMap.ts` - Reference-counted map. Use: share keyed resources.
+- `RcRef` - `packages/effect/src/RcRef.ts` - Reference-counted ref. Use: share scoped resources.
+- `Record` - `packages/effect/src/Record.ts` - Record utilities. Use: transform string-keyed objects.
+- `Redactable` - `packages/effect/src/Redactable.ts` - Context-aware redaction protocol. Use: mask sensitive values.
+- `Redacted` - `packages/effect/src/Redacted.ts` - Sensitive value wrapper. Use: keep secrets out of logs.
+- `Reducer` - `packages/effect/src/Reducer.ts` - Fold values into one result. Use: aggregate collections.
+- `Ref` - `packages/effect/src/Ref.ts` - Atomic mutable reference. Use: manage concurrent state.
+- `References` - `packages/effect/src/References.ts` - Runtime reference services. Use: tune runtime configuration.
+- `RegExp` - `packages/effect/src/RegExp.ts` - RegExp utilities. Use: work with regular expressions.
+- `Request` - `packages/effect/src/Request.ts` - External request description. Use: batch and cache data fetching.
+- `RequestResolver` - `packages/effect/src/RequestResolver.ts` - Request execution abstraction. Use: resolve batched requests.
+- `Resource` - `packages/effect/src/Resource.ts` - Resource utilities. Use: acquire and release shared resources.
+- `Result` - `packages/effect/src/Result.ts` - Synchronous success/failure type. Use: validate without effects.
+- `Runtime` - `packages/effect/src/Runtime.ts` - Effect runtime helpers. Use: run main programs.
+- `Schedule` - `packages/effect/src/Schedule.ts` - Retry and repetition schedules. Use: control retry timing.
+- `Scheduler` - `packages/effect/src/Scheduler.ts` - Scheduler utilities. Use: control task execution.
+- `Schema` - `packages/effect/src/Schema.ts` - Data schema, validation, and codecs. Use: decode and encode typed data.
+- `SchemaAST` - `packages/effect/src/SchemaAST.ts` - Runtime schema AST. Use: inspect or transform schemas.
+- `SchemaGetter` - `packages/effect/src/SchemaGetter.ts` - One-way schema transformations. Use: decode individual fields.
+- `SchemaIssue` - `packages/effect/src/SchemaIssue.ts` - Structured schema validation errors. Use: inspect parse failures.
+- `SchemaParser` - `packages/effect/src/SchemaParser.ts` - Schema parsing helpers. Use: build parsing workflows.
+- `SchemaRepresentation` - `packages/effect/src/SchemaRepresentation.ts` - Serializable schema IR. Use: round-trip schemas through JSON/codegen.
+- `SchemaTransformation` - `packages/effect/src/SchemaTransformation.ts` - Bidirectional schema transformations. Use: map encoded and decoded forms.
+- `SchemaUtils` - `packages/effect/src/SchemaUtils.ts` - Schema utility helpers. Use: support schema internals.
+- `Scope` - `packages/effect/src/Scope.ts` - Resource lifetime scope. Use: ensure cleanup of acquired resources.
+- `ScopedCache` - `packages/effect/src/ScopedCache.ts` - Scoped cache utilities. Use: cache scoped resources.
+- `ScopedRef` - `packages/effect/src/ScopedRef.ts` - Scoped mutable reference. Use: swap scoped resources safely.
+- `Semaphore` - `packages/effect/src/Semaphore.ts` - Concurrency semaphore. Use: limit parallel access.
+- `Sink` - `packages/effect/src/Sink.ts` - Stream consumer abstraction. Use: fold or write stream inputs.
+- `Stdio` - `packages/effect/src/Stdio.ts` - Standard I/O utilities. Use: access stdin/stdout/stderr.
+- `Stream` - `packages/effect/src/Stream.ts` - Functional stream abstraction. Use: process streaming data.
+- `String` - `packages/effect/src/String.ts` - String utilities and instances. Use: manipulate text functionally.
+- `Struct` - `packages/effect/src/Struct.ts` - Immutable object utilities. Use: transform plain objects.
+- `SubscriptionRef` - `packages/effect/src/SubscriptionRef.ts` - Subscribable reference. Use: observe state changes.
+- `Symbol` - `packages/effect/src/Symbol.ts` - Symbol utilities. Use: work with JavaScript symbols.
+- `SynchronizedRef` - `packages/effect/src/SynchronizedRef.ts` - Effect-synchronized ref. Use: update state with effects.
+- `Take` - `packages/effect/src/Take.ts` - Stream take representation. Use: carry chunk, end, or error.
+- `Terminal` - `packages/effect/src/Terminal.ts` - Terminal interaction utilities. Use: build CLI prompts/output.
+- `Tracer` - `packages/effect/src/Tracer.ts` - Tracing abstractions. Use: create spans and traces.
+- `Trie` - `packages/effect/src/Trie.ts` - Prefix tree for strings. Use: do prefix lookups.
+- `Tuple` - `packages/effect/src/Tuple.ts` - Immutable tuple utilities. Use: transform fixed-length arrays.
+- `TxChunk` - `packages/effect/src/TxChunk.ts` - Transactional chunk. Use: mutate chunk state in STM.
+- `TxDeferred` - `packages/effect/src/TxDeferred.ts` - Transactional deferred cell. Use: coordinate STM completion.
+- `TxHashMap` - `packages/effect/src/TxHashMap.ts` - Transactional hash map. Use: keyed STM state.
+- `TxHashSet` - `packages/effect/src/TxHashSet.ts` - Transactional hash set. Use: unique STM state.
+- `TxPriorityQueue` - `packages/effect/src/TxPriorityQueue.ts` - Transactional priority queue. Use: ordered STM queueing.
+- `TxPubSub` - `packages/effect/src/TxPubSub.ts` - Transactional pub-sub hub. Use: broadcast within STM.
+- `TxQueue` - `packages/effect/src/TxQueue.ts` - Transactional queue. Use: queue data within STM.
+- `TxReentrantLock` - `packages/effect/src/TxReentrantLock.ts` - Transactional reentrant RW lock. Use: coordinate STM access.
+- `TxRef` - `packages/effect/src/TxRef.ts` - Transactional reference. Use: read and write STM state.
+- `TxSemaphore` - `packages/effect/src/TxSemaphore.ts` - Transactional semaphore. Use: limit STM concurrency.
+- `TxSubscriptionRef` - `packages/effect/src/TxSubscriptionRef.ts` - Transactional subscribable ref. Use: observe committed STM changes.
+- `Types` - `packages/effect/src/Types.ts` - Type-level utility aliases. Use: shape complex TypeScript types.
+- `UndefinedOr` - `packages/effect/src/UndefinedOr.ts` - Helpers for `A | undefined`. Use: model lightweight optional values.
+- `Unify` - `packages/effect/src/Unify.ts` - Type unification helpers. Use: simplify inferred types.
+- `Utils` - `packages/effect/src/Utils.ts` - Generator and HKT internals. Use: support yieldable APIs.
+
+### `effect/testing`
+
+- `FastCheck` - `packages/effect/src/testing/FastCheck.ts` - Re-export of fast-check for property testing. Use: generate random test cases.
+- `TestClock` - `packages/effect/src/testing/TestClock.ts` - Controllable clock for tests. Use: advance time deterministically.
+- `TestConsole` - `packages/effect/src/testing/TestConsole.ts` - Test console implementation. Use: assert console output.
+- `TestSchema` - `packages/effect/src/testing/TestSchema.ts` - Schema assertion helpers. Use: verify decode/encode behavior.
+
+### `effect/unstable/ai`
+
+- `AiError` - `packages/effect/src/unstable/ai/AiError.ts` - AI-related error types. Use: handle model failures.
+- `AnthropicStructuredOutput` - `packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts` - Anthropic structured-output codec helpers. Use: parse structured model responses.
+- `Chat` - `packages/effect/src/unstable/ai/Chat.ts` - Stateful AI conversation API. Use: manage chat sessions.
+- `EmbeddingModel` - `packages/effect/src/unstable/ai/EmbeddingModel.ts` - Provider-agnostic embedding API. Use: generate text vectors.
+- `IdGenerator` - `packages/effect/src/unstable/ai/IdGenerator.ts` - Pluggable ID generation. Use: issue stable request IDs.
+- `LanguageModel` - `packages/effect/src/unstable/ai/LanguageModel.ts` - AI text generation with tools. Use: call LLMs.
+- `McpSchema` - `packages/effect/src/unstable/ai/McpSchema.ts` - MCP schema helpers. Use: type MCP messages.
+- `McpServer` - `packages/effect/src/unstable/ai/McpServer.ts` - MCP server support. Use: expose model context tools.
+- `Model` - `packages/effect/src/unstable/ai/Model.ts` - Unified AI provider interface. Use: swap AI backends.
+- `OpenAiStructuredOutput` - `packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts` - OpenAI structured-output codecs. Use: decode typed model output.
+- `Prompt` - `packages/effect/src/unstable/ai/Prompt.ts` - Prompt-building data structures. Use: compose prompts.
+- `Response` - `packages/effect/src/unstable/ai/Response.ts` - AI response data structures. Use: inspect completions.
+- `ResponseIdTracker` - `packages/effect/src/unstable/ai/ResponseIdTracker.ts` - Response ID tracking utilities. Use: correlate model replies.
+- `Telemetry` - `packages/effect/src/unstable/ai/Telemetry.ts` - OpenTelemetry integration for AI operations. Use: trace model calls.
+- `Tokenizer` - `packages/effect/src/unstable/ai/Tokenizer.ts` - Tokenization and truncation utilities. Use: enforce token budgets.
+- `Tool` - `packages/effect/src/unstable/ai/Tool.ts` - Tool definition and management. Use: expose callable tools.
+- `Toolkit` - `packages/effect/src/unstable/ai/Toolkit.ts` - Collection of tools. Use: bundle tool implementations.
+
+### `effect/unstable/cli`
+
+- `Argument` - `packages/effect/src/unstable/cli/Argument.ts` - CLI argument definitions. Use: positional arguments.
+- `CliError` - `packages/effect/src/unstable/cli/CliError.ts` - CLI error types. Use: report parse failures.
+- `CliOutput` - `packages/effect/src/unstable/cli/CliOutput.ts` - CLI rendering/output helpers. Use: format command output.
+- `Command` - `packages/effect/src/unstable/cli/Command.ts` - CLI command definitions. Use: build subcommands.
+- `Completions` - `packages/effect/src/unstable/cli/Completions.ts` - Shell completion generation. Use: generate completion scripts.
+- `Flag` - `packages/effect/src/unstable/cli/Flag.ts` - CLI flag definitions. Use: parse options.
+- `GlobalFlag` - `packages/effect/src/unstable/cli/GlobalFlag.ts` - Global CLI flags. Use: shared top-level options.
+- `HelpDoc` - `packages/effect/src/unstable/cli/HelpDoc.ts` - CLI help document model. Use: render usage text.
+- `Param` - `packages/effect/src/unstable/cli/Param.ts` - CLI parameter helpers. Use: define typed params.
+- `Primitive` - `packages/effect/src/unstable/cli/Primitive.ts` - Primitive CLI parsers. Use: parse numbers or strings.
+- `Prompt` - `packages/effect/src/unstable/cli/Prompt.ts` - Interactive CLI prompts. Use: ask users for input.
+
+### `effect/unstable/cluster`
+
+- `ClusterCron` - `packages/effect/src/unstable/cluster/ClusterCron.ts` - Cluster cron scheduling. Use: distributed recurring jobs.
+- `ClusterError` - `packages/effect/src/unstable/cluster/ClusterError.ts` - Cluster error types. Use: classify cluster failures.
+- `ClusterMetrics` - `packages/effect/src/unstable/cluster/ClusterMetrics.ts` - Cluster metrics helpers. Use: observe cluster health.
+- `ClusterSchema` - `packages/effect/src/unstable/cluster/ClusterSchema.ts` - Cluster schema types. Use: encode cluster messages.
+- `ClusterWorkflowEngine` - `packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts` - Workflow engine for clusters. Use: run distributed workflows.
+- `DeliverAt` - `packages/effect/src/unstable/cluster/DeliverAt.ts` - Deferred delivery scheduling. Use: schedule message delivery.
+- `Entity` - `packages/effect/src/unstable/cluster/Entity.ts` - Cluster entity abstraction. Use: model sharded actors.
+- `EntityAddress` - `packages/effect/src/unstable/cluster/EntityAddress.ts` - Entity addressing types. Use: route entity messages.
+- `EntityId` - `packages/effect/src/unstable/cluster/EntityId.ts` - Typed entity identifiers. Use: identify actor instances.
+- `EntityProxy` - `packages/effect/src/unstable/cluster/EntityProxy.ts` - Client proxy for entities. Use: call remote entities.
+- `EntityProxyServer` - `packages/effect/src/unstable/cluster/EntityProxyServer.ts` - Server for entity proxies. Use: serve entity calls.
+- `EntityResource` - `packages/effect/src/unstable/cluster/EntityResource.ts` - Entity-backed resource helpers. Use: manage entity state.
+- `EntityType` - `packages/effect/src/unstable/cluster/EntityType.ts` - Entity type descriptors. Use: register entity kinds.
+- `Envelope` - `packages/effect/src/unstable/cluster/Envelope.ts` - Message envelope types. Use: wrap cluster messages.
+- `HttpRunner` - `packages/effect/src/unstable/cluster/HttpRunner.ts` - HTTP-based runner. Use: transport cluster traffic over HTTP.
+- `K8sHttpClient` - `packages/effect/src/unstable/cluster/K8sHttpClient.ts` - Kubernetes HTTP client helpers. Use: discover cluster peers.
+- `MachineId` - `packages/effect/src/unstable/cluster/MachineId.ts` - Machine identifier utilities. Use: label cluster nodes.
+- `Message` - `packages/effect/src/unstable/cluster/Message.ts` - Cluster message model. Use: send typed payloads.
+- `MessageStorage` - `packages/effect/src/unstable/cluster/MessageStorage.ts` - Message persistence abstraction. Use: durable message storage.
+- `Reply` - `packages/effect/src/unstable/cluster/Reply.ts` - Reply message helpers. Use: respond to cluster requests.
+- `Runner` - `packages/effect/src/unstable/cluster/Runner.ts` - Cluster runner abstraction. Use: host cluster workloads.
+- `RunnerAddress` - `packages/effect/src/unstable/cluster/RunnerAddress.ts` - Runner addressing types. Use: locate a runner.
+- `RunnerHealth` - `packages/effect/src/unstable/cluster/RunnerHealth.ts` - Runner health reporting. Use: track node readiness.
+- `Runners` - `packages/effect/src/unstable/cluster/Runners.ts` - Runner collection utilities. Use: manage active runners.
+- `RunnerServer` - `packages/effect/src/unstable/cluster/RunnerServer.ts` - Runner server implementation. Use: expose runner endpoints.
+- `RunnerStorage` - `packages/effect/src/unstable/cluster/RunnerStorage.ts` - Runner persistence abstraction. Use: store runner metadata.
+- `ShardId` - `packages/effect/src/unstable/cluster/ShardId.ts` - Shard identifier type. Use: map keys to shards.
+- `Sharding` - `packages/effect/src/unstable/cluster/Sharding.ts` - Sharding utilities. Use: distribute entities.
+- `ShardingConfig` - `packages/effect/src/unstable/cluster/ShardingConfig.ts` - Sharding configuration. Use: tune partitioning behavior.
+- `ShardingRegistrationEvent` - `packages/effect/src/unstable/cluster/ShardingRegistrationEvent.ts` - Sharding registration events. Use: observe topology changes.
+- `SingleRunner` - `packages/effect/src/unstable/cluster/SingleRunner.ts` - Single-process runner. Use: local cluster execution.
+- `Singleton` - `packages/effect/src/unstable/cluster/Singleton.ts` - Cluster singleton abstraction. Use: one active service instance.
+- `SingletonAddress` - `packages/effect/src/unstable/cluster/SingletonAddress.ts` - Singleton addressing types. Use: route singleton calls.
+- `Snowflake` - `packages/effect/src/unstable/cluster/Snowflake.ts` - Snowflake-style ID generation. Use: unique distributed IDs.
+- `SocketRunner` - `packages/effect/src/unstable/cluster/SocketRunner.ts` - Socket-based runner. Use: cluster transport over sockets.
+- `SqlMessageStorage` - `packages/effect/src/unstable/cluster/SqlMessageStorage.ts` - SQL-backed message storage. Use: persist cluster messages.
+- `SqlRunnerStorage` - `packages/effect/src/unstable/cluster/SqlRunnerStorage.ts` - SQL-backed runner storage. Use: persist runner state.
+- `TestRunner` - `packages/effect/src/unstable/cluster/TestRunner.ts` - Test runner utilities. Use: simulate cluster execution.
+
+### `effect/unstable/devtools`
+
+- `DevTools` - `packages/effect/src/unstable/devtools/DevTools.ts` - Devtools integration. Use: inspect runtime behavior.
+- `DevToolsClient` - `packages/effect/src/unstable/devtools/DevToolsClient.ts` - Devtools client API. Use: connect to devtools server.
+- `DevToolsSchema` - `packages/effect/src/unstable/devtools/DevToolsSchema.ts` - Devtools message schemas. Use: type devtools payloads.
+- `DevToolsServer` - `packages/effect/src/unstable/devtools/DevToolsServer.ts` - Devtools server API. Use: expose inspection endpoints.
+
+### `effect/unstable/encoding`
+
+- `Msgpack` - `packages/effect/src/unstable/encoding/Msgpack.ts` - MessagePack encoding helpers. Use: compact binary serialization.
+- `Ndjson` - `packages/effect/src/unstable/encoding/Ndjson.ts` - NDJSON encoding helpers. Use: stream JSON lines.
+- `Sse` - `packages/effect/src/unstable/encoding/Sse.ts` - Server-sent event encoding helpers. Use: emit SSE streams.
+
+### `effect/unstable/eventlog`
+
+- `Event` - `packages/effect/src/unstable/eventlog/Event.ts` - Event model types. Use: represent domain events.
+- `EventGroup` - `packages/effect/src/unstable/eventlog/EventGroup.ts` - Event grouping helpers. Use: batch related events.
+- `EventJournal` - `packages/effect/src/unstable/eventlog/EventJournal.ts` - Event journal abstraction. Use: append and read events.
+- `EventLog` - `packages/effect/src/unstable/eventlog/EventLog.ts` - Event log API. Use: stream recorded events.
+- `EventLogEncryption` - `packages/effect/src/unstable/eventlog/EventLogEncryption.ts` - Event log encryption helpers. Use: protect event payloads.
+- `EventLogMessage` - `packages/effect/src/unstable/eventlog/EventLogMessage.ts` - Event log message types. Use: transport log entries.
+- `EventLogRemote` - `packages/effect/src/unstable/eventlog/EventLogRemote.ts` - Remote event log client/server helpers. Use: access remote logs.
+- `EventLogServer` - `packages/effect/src/unstable/eventlog/EventLogServer.ts` - Event log server support. Use: host event streams.
+- `EventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts` - Encrypted event log server. Use: secure event serving.
+- `EventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts` - Unencrypted event log server. Use: plain local serving.
+- `EventLogSessionAuth` - `packages/effect/src/unstable/eventlog/EventLogSessionAuth.ts` - Event log session auth helpers. Use: authorize event sessions.
+- `SqlEventJournal` - `packages/effect/src/unstable/eventlog/SqlEventJournal.ts` - SQL-backed event journal. Use: persist events in SQL.
+- `SqlEventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts` - SQL-backed encrypted event server. Use: secure persisted logs.
+- `SqlEventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts` - SQL-backed plain event server. Use: simple persisted logs.
+
+### `effect/unstable/http`
+
+- `Cookies` - `packages/effect/src/unstable/http/Cookies.ts` - HTTP cookie helpers. Use: parse and set cookies.
+- `Etag` - `packages/effect/src/unstable/http/Etag.ts` - ETag utilities. Use: cache validation headers.
+- `FetchHttpClient` - `packages/effect/src/unstable/http/FetchHttpClient.ts` - Fetch-based HTTP client. Use: run requests in browsers.
+- `FindMyWay` - `packages/effect/src/unstable/http/FindMyWay.ts` - `find-my-way` router integration. Use: path routing.
+- `Headers` - `packages/effect/src/unstable/http/Headers.ts` - HTTP header utilities. Use: manage request headers.
+- `HttpBody` - `packages/effect/src/unstable/http/HttpBody.ts` - HTTP body representations. Use: send JSON or bytes.
+- `HttpClient` - `packages/effect/src/unstable/http/HttpClient.ts` - Effect HTTP client API. Use: perform outbound requests.
+- `HttpClientError` - `packages/effect/src/unstable/http/HttpClientError.ts` - HTTP client error types. Use: handle request failures.
+- `HttpClientRequest` - `packages/effect/src/unstable/http/HttpClientRequest.ts` - HTTP client request builders. Use: construct requests.
+- `HttpClientResponse` - `packages/effect/src/unstable/http/HttpClientResponse.ts` - HTTP client response utilities. Use: read status and body.
+- `HttpEffect` - `packages/effect/src/unstable/http/HttpEffect.ts` - HTTP-specific effect helpers. Use: compose HTTP workflows.
+- `HttpIncomingMessage` - `packages/effect/src/unstable/http/HttpIncomingMessage.ts` - Incoming message abstraction. Use: read request bodies.
+- `HttpMethod` - `packages/effect/src/unstable/http/HttpMethod.ts` - HTTP method helpers. Use: branch on verbs.
+- `HttpMiddleware` - `packages/effect/src/unstable/http/HttpMiddleware.ts` - HTTP middleware utilities. Use: add auth or logging.
+- `HttpPlatform` - `packages/effect/src/unstable/http/HttpPlatform.ts` - Platform HTTP integration. Use: supply runtime adapters.
+- `HttpRouter` - `packages/effect/src/unstable/http/HttpRouter.ts` - HTTP routing abstraction. Use: define endpoints.
+- `HttpServer` - `packages/effect/src/unstable/http/HttpServer.ts` - HTTP server API. Use: serve requests.
+- `HttpServerError` - `packages/effect/src/unstable/http/HttpServerError.ts` - HTTP server error types. Use: render server failures.
+- `HttpServerRequest` - `packages/effect/src/unstable/http/HttpServerRequest.ts` - Server request utilities. Use: inspect inbound requests.
+- `HttpServerRespondable` - `packages/effect/src/unstable/http/HttpServerRespondable.ts` - Response conversion protocol. Use: return custom response types.
+- `HttpServerResponse` - `packages/effect/src/unstable/http/HttpServerResponse.ts` - Server response builders. Use: send JSON or text.
+- `HttpStaticServer` - `packages/effect/src/unstable/http/HttpStaticServer.ts` - Static file serving helpers. Use: serve assets.
+- `HttpTraceContext` - `packages/effect/src/unstable/http/HttpTraceContext.ts` - HTTP trace-context propagation. Use: carry tracing headers.
+- `Multipart` - `packages/effect/src/unstable/http/Multipart.ts` - Multipart form-data helpers. Use: file uploads.
+- `Multipasta` - `packages/effect/src/unstable/http/Multipasta.ts` - Multipasta integration. Use: parse multipart streams.
+- `Template` - `packages/effect/src/unstable/http/Template.ts` - HTTP templating helpers. Use: generate responses from templates.
+- `Url` - `packages/effect/src/unstable/http/Url.ts` - URL utilities. Use: parse and build URLs.
+- `UrlParams` - `packages/effect/src/unstable/http/UrlParams.ts` - URL parameter helpers. Use: encode query strings.
+
+### `effect/unstable/httpapi`
+
+- `HttpApi` - `packages/effect/src/unstable/httpapi/HttpApi.ts` - Typed HTTP API description. Use: define an API contract.
+- `HttpApiBuilder` - `packages/effect/src/unstable/httpapi/HttpApiBuilder.ts` - Build servers from `HttpApi`. Use: implement typed endpoints.
+- `HttpApiClient` - `packages/effect/src/unstable/httpapi/HttpApiClient.ts` - Client generation for `HttpApi`. Use: call typed APIs.
+- `HttpApiEndpoint` - `packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts` - Endpoint descriptors. Use: define route inputs/outputs.
+- `HttpApiError` - `packages/effect/src/unstable/httpapi/HttpApiError.ts` - HTTP API error types. Use: model typed API failures.
+- `HttpApiGroup` - `packages/effect/src/unstable/httpapi/HttpApiGroup.ts` - Group API endpoints. Use: organize related routes.
+- `HttpApiMiddleware` - `packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts` - API middleware helpers. Use: add auth policies.
+- `HttpApiScalar` - `packages/effect/src/unstable/httpapi/HttpApiScalar.ts` - Scalar UI/integration helpers. Use: expose API docs tooling.
+- `HttpApiSchema` - `packages/effect/src/unstable/httpapi/HttpApiSchema.ts` - Schema annotations for HTTP metadata. Use: tag schema fields for APIs.
+- `HttpApiSecurity` - `packages/effect/src/unstable/httpapi/HttpApiSecurity.ts` - Security scheme helpers. Use: define auth requirements.
+- `HttpApiSwagger` - `packages/effect/src/unstable/httpapi/HttpApiSwagger.ts` - Swagger/OpenAPI integration. Use: serve interactive docs.
+- `HttpApiTest` - `packages/effect/src/unstable/httpapi/HttpApiTest.ts` - HttpApi test helpers. Use: test typed endpoints.
+- `OpenApi` - `packages/effect/src/unstable/httpapi/OpenApi.ts` - OpenAPI generation helpers. Use: export API specs.
+
+### `effect/unstable/observability`
+
+- `Otlp` - `packages/effect/src/unstable/observability/Otlp.ts` - OTLP integration entrypoint. Use: configure OTLP telemetry.
+- `OtlpExporter` - `packages/effect/src/unstable/observability/OtlpExporter.ts` - OTLP exporter utilities. Use: send telemetry externally.
+- `OtlpLogger` - `packages/effect/src/unstable/observability/OtlpLogger.ts` - OTLP log export support. Use: ship structured logs.
+- `OtlpMetrics` - `packages/effect/src/unstable/observability/OtlpMetrics.ts` - OTLP metrics export support. Use: export counters and histograms.
+- `OtlpResource` - `packages/effect/src/unstable/observability/OtlpResource.ts` - OTLP resource metadata helpers. Use: tag service identity.
+- `OtlpSerialization` - `packages/effect/src/unstable/observability/OtlpSerialization.ts` - OTLP serialization helpers. Use: encode telemetry payloads.
+- `OtlpTracer` - `packages/effect/src/unstable/observability/OtlpTracer.ts` - OTLP tracing export support. Use: export spans.
+- `PrometheusMetrics` - `packages/effect/src/unstable/observability/PrometheusMetrics.ts` - Prometheus metrics exporter. Use: expose scrape endpoint.
+
+### `effect/unstable/persistence`
+
+- `KeyValueStore` - `packages/effect/src/unstable/persistence/KeyValueStore.ts` - Key-value storage abstraction. Use: persist simple state.
+- `Persistable` - `packages/effect/src/unstable/persistence/Persistable.ts` - Persistable type helpers. Use: encode stored values.
+- `PersistedCache` - `packages/effect/src/unstable/persistence/PersistedCache.ts` - Durable cache. Use: cache across restarts.
+- `PersistedQueue` - `packages/effect/src/unstable/persistence/PersistedQueue.ts` - Durable queue. Use: persist work items.
+- `Persistence` - `packages/effect/src/unstable/persistence/Persistence.ts` - Persistence service APIs. Use: back durable components.
+- `RateLimiter` - `packages/effect/src/unstable/persistence/RateLimiter.ts` - Persistent rate limiter. Use: enforce cross-process limits.
+- `Redis` - `packages/effect/src/unstable/persistence/Redis.ts` - Redis-backed persistence helpers. Use: store state in Redis.
+
+### `effect/unstable/process`
+
+- `ChildProcess` - `packages/effect/src/unstable/process/ChildProcess.ts` - Child process abstractions. Use: manage spawned commands.
+- `ChildProcessSpawner` - `packages/effect/src/unstable/process/ChildProcessSpawner.ts` - Generic child-process spawning service. Use: launch subprocesses.
+
+### `effect/unstable/reactivity`
+
+- `AsyncResult` - `packages/effect/src/unstable/reactivity/AsyncResult.ts` - Reactive async result type. Use: represent loading/error/data.
+- `Atom` - `packages/effect/src/unstable/reactivity/Atom.ts` - Reactive atom state primitive. Use: local reactive state.
+- `AtomHttpApi` - `packages/effect/src/unstable/reactivity/AtomHttpApi.ts` - HttpApi integration for atoms. Use: sync state over HTTP.
+- `AtomRef` - `packages/effect/src/unstable/reactivity/AtomRef.ts` - Ref-backed atom helpers. Use: bridge refs to reactivity.
+- `AtomRegistry` - `packages/effect/src/unstable/reactivity/AtomRegistry.ts` - Atom registry utilities. Use: track application atoms.
+- `AtomRpc` - `packages/effect/src/unstable/reactivity/AtomRpc.ts` - RPC integration for atoms. Use: sync state over RPC.
+- `Hydration` - `packages/effect/src/unstable/reactivity/Hydration.ts` - Hydration helpers. Use: restore reactive state.
+- `Reactivity` - `packages/effect/src/unstable/reactivity/Reactivity.ts` - Core reactivity utilities. Use: compose reactive computations.
+
+### `effect/unstable/rpc`
+
+- `Rpc` - `packages/effect/src/unstable/rpc/Rpc.ts` - Typed RPC description. Use: define RPC contracts.
+- `RpcClient` - `packages/effect/src/unstable/rpc/RpcClient.ts` - RPC client API. Use: call remote procedures.
+- `RpcClientError` - `packages/effect/src/unstable/rpc/RpcClientError.ts` - RPC client error types. Use: handle transport failures.
+- `RpcGroup` - `packages/effect/src/unstable/rpc/RpcGroup.ts` - Group RPC endpoints. Use: organize procedures.
+- `RpcMessage` - `packages/effect/src/unstable/rpc/RpcMessage.ts` - RPC message model. Use: encode request/response payloads.
+- `RpcMiddleware` - `packages/effect/src/unstable/rpc/RpcMiddleware.ts` - RPC middleware helpers. Use: add auth or tracing.
+- `RpcSchema` - `packages/effect/src/unstable/rpc/RpcSchema.ts` - Schema helpers for RPC. Use: type RPC payloads.
+- `RpcSerialization` - `packages/effect/src/unstable/rpc/RpcSerialization.ts` - RPC serialization helpers. Use: encode wire formats.
+- `RpcServer` - `packages/effect/src/unstable/rpc/RpcServer.ts` - RPC server API. Use: expose procedures.
+- `RpcTest` - `packages/effect/src/unstable/rpc/RpcTest.ts` - RPC testing helpers. Use: test RPC handlers.
+- `RpcWorker` - `packages/effect/src/unstable/rpc/RpcWorker.ts` - Worker integration for RPC. Use: run RPC over workers.
+- `Utils` - `packages/effect/src/unstable/rpc/Utils.ts` - Shared RPC utilities. Use: support custom RPC plumbing.
+
+### `effect/unstable/schema`
+
+- `Model` - `packages/effect/src/unstable/schema/Model.ts` - Unstable schema model helpers. Use: define schema-backed models.
+- `VariantSchema` - `packages/effect/src/unstable/schema/VariantSchema.ts` - Variant/discriminated schema helpers. Use: model tagged unions.
+
+### `effect/unstable/socket`
+
+- `Socket` - `packages/effect/src/unstable/socket/Socket.ts` - Socket abstractions. Use: connect stream transports.
+- `SocketServer` - `packages/effect/src/unstable/socket/SocketServer.ts` - Socket server helpers. Use: accept socket clients.
+
+### `effect/unstable/sql`
+
+- `Migrator` - `packages/effect/src/unstable/sql/Migrator.ts` - SQL migration helpers. Use: run schema migrations.
+- `SqlClient` - `packages/effect/src/unstable/sql/SqlClient.ts` - SQL client API. Use: execute queries.
+- `SqlConnection` - `packages/effect/src/unstable/sql/SqlConnection.ts` - SQL connection abstraction. Use: manage DB sessions.
+- `SqlError` - `packages/effect/src/unstable/sql/SqlError.ts` - SQL error types. Use: classify database failures.
+- `SqlModel` - `packages/effect/src/unstable/sql/SqlModel.ts` - SQL-backed model helpers. Use: map tables to models.
+- `SqlResolver` - `packages/effect/src/unstable/sql/SqlResolver.ts` - SQL request resolution helpers. Use: batch DB-backed requests.
+- `SqlSchema` - `packages/effect/src/unstable/sql/SqlSchema.ts` - Schema helpers for SQL. Use: type query values.
+- `SqlStream` - `packages/effect/src/unstable/sql/SqlStream.ts` - Streaming SQL query helpers. Use: consume large result sets.
+- `Statement` - `packages/effect/src/unstable/sql/Statement.ts` - SQL statement builders/types. Use: prepare typed statements.
+
+### `effect/unstable/workers`
+
+- `Transferable` - `packages/effect/src/unstable/workers/Transferable.ts` - Transferable value helpers. Use: send data between workers.
+- `Worker` - `packages/effect/src/unstable/workers/Worker.ts` - Worker abstractions. Use: run isolated tasks.
+- `WorkerError` - `packages/effect/src/unstable/workers/WorkerError.ts` - Worker error types. Use: handle worker failures.
+- `WorkerRunner` - `packages/effect/src/unstable/workers/WorkerRunner.ts` - Worker runner utilities. Use: host jobs in workers.
+
+### `effect/unstable/workflow`
+
+- `Activity` - `packages/effect/src/unstable/workflow/Activity.ts` - Workflow activity helpers. Use: define durable steps.
+- `DurableClock` - `packages/effect/src/unstable/workflow/DurableClock.ts` - Durable clock API. Use: schedule workflow time.
+- `DurableDeferred` - `packages/effect/src/unstable/workflow/DurableDeferred.ts` - Durable deferred primitive. Use: await external completion.
+- `DurableQueue` - `packages/effect/src/unstable/workflow/DurableQueue.ts` - Durable queue primitive. Use: persist workflow worklists.
+- `Workflow` - `packages/effect/src/unstable/workflow/Workflow.ts` - Workflow definition API. Use: declare durable workflows.
+- `WorkflowEngine` - `packages/effect/src/unstable/workflow/WorkflowEngine.ts` - Workflow engine runtime. Use: execute workflows.
+- `WorkflowProxy` - `packages/effect/src/unstable/workflow/WorkflowProxy.ts` - Workflow client proxy. Use: call workflow instances.
+- `WorkflowProxyServer` - `packages/effect/src/unstable/workflow/WorkflowProxyServer.ts` - Workflow proxy server. Use: expose workflow endpoints.
+
+## `@effect/opentelemetry` Package
+
+Package path: `packages/opentelemetry`
+
+- `Logger` - `packages/opentelemetry/src/Logger.ts` - OpenTelemetry logging integration. Use: export structured logs.
+- `Metrics` - `packages/opentelemetry/src/Metrics.ts` - OpenTelemetry metrics integration. Use: publish application metrics.
+- `NodeSdk` - `packages/opentelemetry/src/NodeSdk.ts` - Node OpenTelemetry SDK wiring. Use: bootstrap telemetry in Node.
+- `Resource` - `packages/opentelemetry/src/Resource.ts` - OpenTelemetry resource helpers. Use: describe service metadata.
+- `Tracer` - `packages/opentelemetry/src/Tracer.ts` - OpenTelemetry tracing integration. Use: create and export spans.
+- `WebSdk` - `packages/opentelemetry/src/WebSdk.ts` - Web OpenTelemetry SDK wiring. Use: bootstrap telemetry in browsers.
+
+## `@effect/platform-browser` Package
+
+Package path: `packages/platform-browser`
+
+- `BrowserHttpClient` - `packages/platform-browser/src/BrowserHttpClient.ts` - Browser HTTP client implementation. Use: make fetch-based requests.
+- `BrowserKeyValueStore` - `packages/platform-browser/src/BrowserKeyValueStore.ts` - Browser key-value storage adapter. Use: persist small client values.
+- `BrowserPersistence` - `packages/platform-browser/src/BrowserPersistence.ts` - Browser persistence services. Use: store app state locally.
+- `BrowserRuntime` - `packages/platform-browser/src/BrowserRuntime.ts` - Browser runtime entrypoints. Use: run Effect apps in browsers.
+- `BrowserSocket` - `packages/platform-browser/src/BrowserSocket.ts` - Browser socket implementation. Use: open WebSocket-style connections.
+- `BrowserStream` - `packages/platform-browser/src/BrowserStream.ts` - Browser stream adapters. Use: bridge web streams.
+- `BrowserWorker` - `packages/platform-browser/src/BrowserWorker.ts` - Browser worker integration. Use: communicate with web workers.
+- `BrowserWorkerRunner` - `packages/platform-browser/src/BrowserWorkerRunner.ts` - Worker-side runtime helpers. Use: run Effect code inside workers.
+- `Clipboard` - `packages/platform-browser/src/Clipboard.ts` - Clipboard API wrappers. Use: read or write clipboard data.
+- `Geolocation` - `packages/platform-browser/src/Geolocation.ts` - Geolocation API wrappers. Use: access device location.
+- `IndexedDb` - `packages/platform-browser/src/IndexedDb.ts` - IndexedDB integration. Use: build browser databases.
+- `IndexedDbDatabase` - `packages/platform-browser/src/IndexedDbDatabase.ts` - IndexedDB database helpers. Use: define database handles.
+- `IndexedDbQueryBuilder` - `packages/platform-browser/src/IndexedDbQueryBuilder.ts` - IndexedDB query builder. Use: compose indexed queries.
+- `IndexedDbTable` - `packages/platform-browser/src/IndexedDbTable.ts` - IndexedDB table helpers. Use: work with object stores.
+- `IndexedDbVersion` - `packages/platform-browser/src/IndexedDbVersion.ts` - IndexedDB versioning helpers. Use: manage schema upgrades.
+- `Permissions` - `packages/platform-browser/src/Permissions.ts` - Permissions API wrappers. Use: query browser permissions.
+
+## `@effect/platform-bun` Package
+
+Package path: `packages/platform-bun`
+
+- `BunChildProcessSpawner` - `packages/platform-bun/src/BunChildProcessSpawner.ts` - Bun child-process spawner. Use: launch subprocesses.
+- `BunClusterHttp` - `packages/platform-bun/src/BunClusterHttp.ts` - Bun clustered HTTP helpers. Use: scale HTTP servers.
+- `BunClusterSocket` - `packages/platform-bun/src/BunClusterSocket.ts` - Bun clustered socket helpers. Use: scale socket servers.
+- `BunFileSystem` - `packages/platform-bun/src/BunFileSystem.ts` - Bun file system implementation. Use: do Bun-based file I/O.
+- `BunHttpClient` - `packages/platform-bun/src/BunHttpClient.ts` - Bun HTTP client implementation. Use: make outbound HTTP requests.
+- `BunHttpPlatform` - `packages/platform-bun/src/BunHttpPlatform.ts` - Bun HTTP platform services. Use: provide HTTP runtime pieces.
+- `BunHttpServer` - `packages/platform-bun/src/BunHttpServer.ts` - Bun HTTP server implementation. Use: serve HTTP endpoints.
+- `BunHttpServerRequest` - `packages/platform-bun/src/BunHttpServerRequest.ts` - Bun request adapters. Use: read incoming HTTP requests.
+- `BunMultipart` - `packages/platform-bun/src/BunMultipart.ts` - Bun multipart parsing. Use: handle form uploads.
+- `BunPath` - `packages/platform-bun/src/BunPath.ts` - Bun path service. Use: resolve filesystem paths.
+- `BunRedis` - `packages/platform-bun/src/BunRedis.ts` - Bun Redis integration. Use: talk to Redis.
+- `BunRuntime` - `packages/platform-bun/src/BunRuntime.ts` - Bun runtime entrypoints. Use: run Effect apps on Bun.
+- `BunServices` - `packages/platform-bun/src/BunServices.ts` - Bun service bundle. Use: provide common Bun services.
+- `BunSink` - `packages/platform-bun/src/BunSink.ts` - Bun sink adapters. Use: write streamed output.
+- `BunSocket` - `packages/platform-bun/src/BunSocket.ts` - Bun socket implementation. Use: manage socket connections.
+- `BunSocketServer` - `packages/platform-bun/src/BunSocketServer.ts` - Bun socket server implementation. Use: accept socket clients.
+- `BunStdio` - `packages/platform-bun/src/BunStdio.ts` - Bun stdio integration. Use: access stdin/stdout/stderr.
+- `BunStream` - `packages/platform-bun/src/BunStream.ts` - Bun stream adapters. Use: bridge Bun streams.
+- `BunTerminal` - `packages/platform-bun/src/BunTerminal.ts` - Bun terminal integration. Use: build CLI terminal interactions.
+- `BunWorker` - `packages/platform-bun/src/BunWorker.ts` - Bun worker integration. Use: communicate with workers.
+- `BunWorkerRunner` - `packages/platform-bun/src/BunWorkerRunner.ts` - Bun worker runtime helpers. Use: run Effect code in workers.
+
+## `@effect/platform-node` Package
+
+Package path: `packages/platform-node`
+
+- `Mime` - `packages/platform-node/src/Mime.ts` - MIME type helpers. Use: detect or assign content types.
+- `NodeChildProcessSpawner` - `packages/platform-node/src/NodeChildProcessSpawner.ts` - Node child-process spawner. Use: launch subprocesses.
+- `NodeClusterHttp` - `packages/platform-node/src/NodeClusterHttp.ts` - Node clustered HTTP helpers. Use: scale HTTP servers.
+- `NodeClusterSocket` - `packages/platform-node/src/NodeClusterSocket.ts` - Node clustered socket helpers. Use: scale socket servers.
+- `NodeFileSystem` - `packages/platform-node/src/NodeFileSystem.ts` - Node file system implementation. Use: do Node-based file I/O.
+- `NodeHttpClient` - `packages/platform-node/src/NodeHttpClient.ts` - Node HTTP client implementation. Use: make outbound HTTP requests.
+- `NodeHttpIncomingMessage` - `packages/platform-node/src/NodeHttpIncomingMessage.ts` - Node incoming message adapters. Use: read raw Node HTTP messages.
+- `NodeHttpPlatform` - `packages/platform-node/src/NodeHttpPlatform.ts` - Node HTTP platform services. Use: provide HTTP runtime pieces.
+- `NodeHttpServer` - `packages/platform-node/src/NodeHttpServer.ts` - Node HTTP server implementation. Use: serve HTTP endpoints.
+- `NodeHttpServerRequest` - `packages/platform-node/src/NodeHttpServerRequest.ts` - Node request adapters. Use: read incoming HTTP requests.
+- `NodeMultipart` - `packages/platform-node/src/NodeMultipart.ts` - Node multipart parsing. Use: handle form uploads.
+- `NodePath` - `packages/platform-node/src/NodePath.ts` - Node path service. Use: resolve filesystem paths.
+- `NodeRedis` - `packages/platform-node/src/NodeRedis.ts` - Node Redis integration. Use: talk to Redis.
+- `NodeRuntime` - `packages/platform-node/src/NodeRuntime.ts` - Node runtime entrypoints. Use: run Effect apps on Node.
+- `NodeServices` - `packages/platform-node/src/NodeServices.ts` - Node service bundle. Use: provide common Node services.
+- `NodeSink` - `packages/platform-node/src/NodeSink.ts` - Node sink adapters. Use: write streamed output.
+- `NodeSocket` - `packages/platform-node/src/NodeSocket.ts` - Node socket implementation. Use: manage socket connections.
+- `NodeSocketServer` - `packages/platform-node/src/NodeSocketServer.ts` - Node socket server implementation. Use: accept socket clients.
+- `NodeStdio` - `packages/platform-node/src/NodeStdio.ts` - Node stdio integration. Use: access stdin/stdout/stderr.
+- `NodeStream` - `packages/platform-node/src/NodeStream.ts` - Node stream adapters. Use: bridge Node streams.
+- `NodeTerminal` - `packages/platform-node/src/NodeTerminal.ts` - Node terminal integration. Use: build CLI terminal interactions.
+- `NodeWorker` - `packages/platform-node/src/NodeWorker.ts` - Node worker integration. Use: communicate with worker threads.
+- `NodeWorkerRunner` - `packages/platform-node/src/NodeWorkerRunner.ts` - Node worker runtime helpers. Use: run Effect code in workers.
+- `Undici` - `packages/platform-node/src/Undici.ts` - Undici integration helpers. Use: use Undici-based HTTP features.
+
+## `@effect/platform-node-shared` Package
+
+Package path: `packages/platform-node-shared`
+
+- No public `src/index.ts` barrel is present in this vendored repo, so there are no barrel exports to inventory here.
+
+## `@effect/vitest` Package
+
+Package path: `packages/vitest`
+
+- `vitest` - `packages/vitest/src/index.ts` - Re-export of `vitest` APIs. Use: use standard Vitest APIs.
+- `API` - `packages/vitest/src/index.ts` - Test API type alias. Use: type custom test helpers.
+- `Vitest` - `packages/vitest/src/index.ts` - Effect-aware Vitest namespace types. Use: type Effect-based tests.
+- `addEqualityTesters` - `packages/vitest/src/index.ts` - Installs equality testers. Use: compare Effect values in assertions.
+- `effect` - `packages/vitest/src/index.ts` - Effect-aware `it` variant. Use: write scoped Effect tests.
+- `live` - `packages/vitest/src/index.ts` - Live-service test variant. Use: run tests with live services.
+- `layer` - `packages/vitest/src/index.ts` - Share a `Layer` across tests. Use: provide services to test groups.
+- `flakyTest` - `packages/vitest/src/index.ts` - Flaky-test wrapper. Use: stabilize eventually consistent checks.
+- `prop` - `packages/vitest/src/index.ts` - Property-test helper. Use: generate property-based cases.
+- `it` - `packages/vitest/src/index.ts` - Extended Vitest `it`. Use: mix regular and Effect tests.
+- `makeMethods` - `packages/vitest/src/index.ts` - Build extended test methods. Use: wrap a custom test API.
+- `describeWrapped` - `packages/vitest/src/index.ts` - `describe` helper with Effect methods. Use: define grouped Effect test suites.

--- a/.agents/skills/effect-ts/references/guide-effect.md
+++ b/.agents/skills/effect-ts/references/guide-effect.md
@@ -1,0 +1,447 @@
+# Effect Guide
+
+This guide is based on common usage patterns in the vendored repo at `./.repos/effect`.
+
+Key source areas:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/tools/`
+- `./.repos/effect/packages/platform-*`
+- `./.repos/effect/packages/opentelemetry/`
+- `./.repos/effect/packages/vitest/`
+
+## Mental Model
+
+`Effect<A, E, R>` is the default way to represent application work.
+
+It describes a computation that:
+
+- succeeds with `A`
+- fails with `E`
+- requires services `R`
+
+The repo consistently uses `Effect` as the main abstraction for:
+
+- business workflows
+- service methods
+- platform integrations
+- resource lifecycles
+- tests
+
+## Most Common Patterns In The Repo
+
+The dominant usage pattern is:
+
+1. use `Effect.gen` for workflows and orchestration
+2. use `Effect.fn` for reusable effectful functions
+3. use precise constructors such as `succeed`, `fail`, `sync`, `try`, and `tryPromise`
+4. use `map`, `flatMap`, and `tap` for local transformations
+5. access services in implementations and `provide*` only at edges
+6. use `acquireRelease` and `scoped` for owned resources
+7. use `catchTag` and `match` for typed recovery
+8. use `run*` only at runtime boundaries
+
+## Prefer `Effect.fn` For Reusable Operations
+
+For reusable effectful operations, prefer `Effect.fn`.
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Use `Effect.fn` when:
+
+- the operation is reusable
+- the operation takes parameters
+- the operation is part of business logic or a module API
+- you want consistent tracing and stack frames
+
+Do not treat `Effect.fnUntraced` as the default. If you do not want an explicit named span, use `Effect.fn` without a span name.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+
+## Use `Effect.gen` For Workflows
+
+Use `Effect.gen` for orchestration and sequential workflows, especially when there are multiple `yield*` steps.
+
+```ts
+const program = Effect.gen(function*() {
+  const config = yield* Config
+  const repo = yield* UserRepo
+  const user = yield* repo.getById("u_123")
+  return { config, user }
+})
+```
+
+Use `Effect.gen` when:
+
+- the body is a workflow
+- you are reading multiple services
+- you have branching or multiple sequential steps
+- you are implementing a layer, handler, or orchestration
+
+Repo examples:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+
+## `Effect.fn` vs `Effect.gen`
+
+Use this rule:
+
+- reusable operation: `Effect.fn`
+- inline workflow block: `Effect.gen`
+
+Good split:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+
+const program = Effect.gen(function*() {
+  const user = yield* loadUser("u_123")
+  yield* Effect.logInfo("loaded user", user)
+})
+```
+
+## `Effect.fnUntraced` Is An Escape Hatch
+
+For application and business code, `Effect.fnUntraced` is not the default.
+
+Use it only when:
+
+- the function is an internal low-level helper
+- observability is intentionally being traded away
+- there is a concrete performance or tracing reason
+
+If the only goal is to avoid an explicit named span, prefer:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Instead of:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+## Constructor Functions
+
+The repo uses constructor functions very deliberately.
+
+### `Effect.succeed`
+
+Use for pure successful values.
+
+```ts
+const ok = Effect.succeed(42)
+```
+
+### `Effect.fail`
+
+Use for expected typed failures.
+
+```ts
+const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }))
+```
+
+### `Effect.sync`
+
+Use for synchronous side effects or pure synchronous construction that should live inside `Effect`.
+
+```ts
+const buildConfig = Effect.sync(() => ({ retries: 3 }))
+```
+
+### `Effect.try`
+
+Use for synchronous code that may throw.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
+  cause: Schema.Defect
+}) {}
+
+const parseJson = (input: string) =>
+  Effect.try({
+    try: () => JSON.parse(input),
+    catch: (cause) => ParseError.make({ cause })
+  })
+```
+
+### `Effect.tryPromise`
+
+Use for Promise-returning APIs.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class FetchError extends Schema.TaggedErrorClass<FetchError>()("FetchError", {
+  cause: Schema.Defect
+}) {}
+
+const fetchText = (url: string) =>
+  Effect.tryPromise({
+    try: () => fetch(url).then((response) => response.text()),
+    catch: (cause) => FetchError.make({ cause })
+  })
+```
+
+Preferred rule:
+
+- pure value: `succeed`
+- expected failure: `fail`
+- synchronous non-throwing effect: `sync`
+- synchronous throwing boundary: `try`
+- Promise boundary: `tryPromise`
+
+## Local Composition
+
+The repo uses `map`, `flatMap`, and `tap` constantly for small local transformations.
+
+### `Effect.map`
+
+Use to transform successful values.
+
+```ts
+const userName = loadUser("u_123").pipe(
+  Effect.map((user) => user.name)
+)
+```
+
+### `Effect.flatMap`
+
+Use when the next step returns another `Effect`.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.flatMap((user) => saveAudit(user.id))
+)
+```
+
+### `Effect.tap`
+
+Use for side effects that should preserve the main value.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.tap((user) => Effect.logDebug("loaded user", { userId: user.id }))
+)
+```
+
+Preferred rule:
+
+- outer workflow: `Effect.gen`
+- local transformation: `map`, `flatMap`, `tap`
+
+## Services And Provisioning
+
+Repo style is:
+
+- access services in implementation code
+- provide them at boundaries
+
+### Access services in implementations
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+```
+
+or:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.service(UserRepo).pipe(
+    Effect.flatMap((repo) => repo.getById(userId))
+  )
+```
+
+### Provide at the edge
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Use `provideService` and `provideServiceEffect` for targeted overrides, especially in tests or framework boundaries.
+
+Do not default to exporting thin accessor functions that just fetch a service and forward to one service method. Prefer real business operations or direct service usage within the owning workflow.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/bin.ts`
+- `./.repos/effect/packages/tools/openapi-generator/test/`
+
+## Error Handling
+
+Common repo patterns:
+
+- `catchTag` for expected tagged errors
+- `match` for totalizing an effect into a value
+- `catchCause` for full-cause infra handling
+
+### `Effect.catchTag`
+
+Use for targeted typed recovery.
+
+```ts
+const safe = loadUser("u_123").pipe(
+  Effect.catchTag("UserNotFound", () => Effect.succeed(null))
+)
+```
+
+### `Effect.match`
+
+Use when the caller wants a value either way.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.match({
+    onFailure: () => null,
+    onSuccess: (user) => user
+  })
+)
+```
+
+For deeper guidance, see `./references/guide-error-handling.md`.
+
+## Resource Management
+
+One of the strongest repo patterns is explicit resource ownership.
+
+### `Effect.acquireRelease`
+
+Use for resources that must be cleaned up.
+
+```ts
+const connection = Effect.acquireRelease(
+  openConnection,
+  (conn) => closeConnection(conn)
+)
+```
+
+### `Effect.scoped`
+
+Use when a workflow consumes scoped resources and should tie cleanup to scope lifetime.
+
+```ts
+const program = Effect.scoped(
+  Effect.gen(function*() {
+    const conn = yield* connection
+    return yield* conn.query("select 1")
+  })
+)
+```
+
+Repo examples:
+
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+
+## SQL And Runtime Integrations
+
+When Effect already provides a domain module for a capability, prefer that module over direct raw runtime client usage in business code.
+
+Important example:
+
+- prefer Effect SQL modules from `effect/unstable/sql/*` over embedding a native SQL driver directly in domain services
+
+Why:
+
+- transactions, spans, and typed errors stay inside the Effect model
+- layering stays cleaner
+- migrations and query conventions stay consistent
+
+For SQL-specific guidance, see `./references/guide-sql.md`.
+
+## Observability
+
+The repo uses observability around meaningful boundaries, not every tiny helper.
+
+Common patterns:
+
+- `Effect.fn` for named operations
+- `Effect.withSpan` for nested span boundaries
+- `Effect.log*` for operational events
+- `Effect.track` for metrics
+
+For detailed guidance, see `./references/guide-observability.md`.
+
+## Runtime Boundaries
+
+The repo keeps `run*` APIs at true runtime boundaries.
+
+### `Effect.runPromise`
+
+Use when leaving Effect world into Promise-based hosts.
+
+### `Effect.runFork`
+
+Use for background fibers or long-running integration hooks.
+
+### `Effect.runSync`
+
+Use sparingly, mostly in specialized internals where synchrony is guaranteed.
+
+Preferred rule:
+
+- library/business code should return `Effect`
+- entrypoints and integration boundaries should run `Effect`
+
+If you have multiple external entrypoints, prefer `ManagedRuntime`.
+
+## Commonly Used Effect APIs In This Repo
+
+These are the most practically important `Effect` functions to know first:
+
+- `Effect.fn`
+- `Effect.gen`
+- `Effect.succeed`
+- `Effect.fail`
+- `Effect.sync`
+- `Effect.try`
+- `Effect.tryPromise`
+- `Effect.map`
+- `Effect.flatMap`
+- `Effect.tap`
+- `Effect.service`
+- `Effect.provide`
+- `Effect.provideService`
+- `Effect.catchTag`
+- `Effect.match`
+- `Effect.acquireRelease`
+- `Effect.scoped`
+- `Effect.withSpan`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.runPromise`
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/vitest/src/index.ts`

--- a/.agents/skills/effect-ts/references/guide-error-handling.md
+++ b/.agents/skills/effect-ts/references/guide-error-handling.md
@@ -1,0 +1,540 @@
+# Error Handling Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Mental Model
+
+Effect distinguishes three failure modes:
+
+- failure: expected, typed errors in the `E` channel of `Effect<A, E, R>`
+- defect: unexpected unchecked failures, represented as `Cause.Die`
+- interrupt: cooperative cancellation, represented as `Cause.Interrupt`
+
+This distinction is explicit in `Cause`.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Error Definition Styles
+
+Preference order:
+
+1. use schema-based errors when possible
+2. fall back to `Data.TaggedError` only when the error payload is not meaningfully serializable or schema-shaped
+
+Schema-based errors are strictly more powerful because they give you:
+
+- typed yieldable errors
+- schema-defined fields
+- encode/decode support
+- better protocol and boundary interoperability
+- stronger documentation and tooling hooks
+
+### 1. `Schema.TaggedErrorClass` for schema-backed tagged errors
+
+Use `Schema.TaggedErrorClass` by default when the error can be described with schemas.
+
+Why:
+
+- it creates a yieldable tagged error
+- fields are defined with `Schema`
+- the error shape can participate in schema-based tooling and encode/decode flows
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()(
+  "InvalidPayload",
+  {
+    field: Schema.String,
+    reason: Schema.String
+  }
+) {}
+
+const validate = Effect.fail(
+  InvalidPayload.make({
+    field: "email",
+    reason: "missing"
+  })
+)
+```
+
+Use this when:
+
+- the error is part of a protocol or transport boundary
+- the error needs a precise schema representation
+- the error should be serializable or documented structurally
+
+This is also a good default for domain errors when their payload is schema-friendly.
+
+### 2. `Schema.ErrorClass` for schema-backed errors without `_tag` routing
+
+Use `Schema.ErrorClass` when you want schema-defined error objects but do not specifically need tag-based pattern matching.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- examples across `./.repos/effect/packages/effect/src/unstable/*`
+
+Example shape from the vendored repo:
+
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+
+### 3. `Data.TaggedError` for non-serializable or lightweight domain errors
+
+Use `Data.TaggedError` when schema-based errors are not a good fit.
+
+This is mainly the fallback for:
+
+- non-serializable payloads
+- ad hoc in-memory-only errors
+- cases where schema shape would be artificial or misleading
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+
+Example:
+
+```ts
+import { Data, Effect } from "effect"
+
+class UserNotFound extends Data.TaggedError("UserNotFound")<{
+  readonly userId: string
+}> {}
+
+const loadUser = (userId: string) =>
+  Effect.fail(new UserNotFound({ userId }))
+
+const program = Effect.gen(function*() {
+  yield* loadUser("u_123")
+})
+```
+
+## When To Prefer `Data.TaggedError` vs `Schema.TaggedErrorClass`
+
+Prefer `Schema.TaggedErrorClass` when:
+
+- the error can be expressed as a schema
+- the error payload must be described by schemas
+- the error crosses process, protocol, persistence, or serialization boundaries
+- you want the error type to participate in schema tooling
+
+Prefer `Data.TaggedError` when:
+
+- the payload is not meaningfully serializable
+- the payload cannot reasonably be modeled as a schema
+- the error is intentionally local and in-memory only
+
+## Schema-Based Error Workflows
+
+### Boundary validation should fail with `SchemaError`
+
+When validating external input, Effect's schema APIs return `SchemaError` in the error channel.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownEffect`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = Schema.decodeUnknownEffect(UserPayload)
+```
+
+This gives you:
+
+- success: validated typed data
+- failure: `Schema.SchemaError`
+
+### Normalize `SchemaError` at the boundary
+
+For application code, it is often better to convert `SchemaError` into a domain error near the boundary.
+
+Example:
+
+```ts
+import { Data, Effect, Schema } from "effect"
+
+class InvalidRequestBody extends Data.TaggedError("InvalidRequestBody")<{
+  readonly message: string
+}> {}
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = (input: unknown) =>
+  Schema.decodeUnknownEffect(UserPayload)(input).pipe(
+    Effect.catchTag("SchemaError", (error) =>
+      Effect.fail(new InvalidRequestBody({ message: error.message }))
+    )
+  )
+```
+
+Why:
+
+- transport validation stays close to the transport layer
+- the rest of the application can work with domain-specific errors
+
+### Use schema-backed errors for protocol errors
+
+The vendored repo uses schema-backed errors in places like SQL, RPC, sockets, and HTTP APIs.
+
+Strong examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/eventlog/EventLogMessage.ts`
+
+These are good reference points when the error contract matters externally.
+
+## Wrapping Foreign Or Generic Errors
+
+When an error comes from a library, runtime API, or generic `Error`, prefer wrapping it in a typed error instead of leaking the foreign error directly through your domain or protocol boundary.
+
+This is a very common pattern in the vendored repo.
+
+Good examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Redis.ts`
+
+### Preferred Pattern
+
+Wrap the foreign error in a schema-backed typed error and preserve the original error in a `cause` field.
+
+Prefer using:
+
+- `Schema.Defect` when you want to preserve a generic encoded defect
+- `Schema.DefectWithStack` when the stack should be preserved in the schema contract
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class TodoStorageError extends Schema.TaggedErrorClass<TodoStorageError>()(
+  "TodoStorageError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect
+  }
+) {}
+
+const makeStorageError = (operation: string) => (cause: unknown) =>
+  TodoStorageError.make({
+    operation,
+    cause
+  })
+
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: makeStorageError("loadTodo")
+  })
+```
+
+When stack preservation matters in the encoded schema, prefer:
+
+```ts
+class WorkerFailure extends Schema.TaggedErrorClass<WorkerFailure>()(
+  "WorkerFailure",
+  {
+    cause: Schema.DefectWithStack
+  }
+) {}
+```
+
+### Why This Is Preferred
+
+- the application still exposes a typed error contract
+- the original foreign failure is preserved for diagnostics
+- schema-aware transports can encode and decode the failure shape
+- business code does not become coupled to a raw library error type
+
+### When To Use This Pattern
+
+Use it when:
+
+- a third-party library throws or rejects with `Error`
+- a runtime API returns generic failures
+- a lower-level subsystem failure should be surfaced through a typed domain or protocol error
+- you need to preserve the underlying failure for debugging without leaking the foreign type as the public error contract
+
+### `Schema.Defect` vs `Schema.DefectWithStack`
+
+Prefer `Schema.Defect` by default.
+
+Use `Schema.DefectWithStack` when:
+
+- stack information is part of the intended encoded error contract
+- the error is primarily infrastructural or diagnostic
+- the downstream consumer benefits from the preserved stack
+
+### Avoid This Anti-Pattern
+
+Avoid exposing raw generic errors directly as the application error contract.
+
+Bad:
+
+```ts
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: (cause) => cause as Error
+  })
+```
+
+Why this is bad:
+
+- the error channel loses a stable typed contract
+- the code depends on unsafe assertions
+- transport and schema integration become weaker
+- callers must understand foreign error shapes instead of your own typed error model
+
+## Handling Failures
+
+### Handle specific tagged errors with `Effect.catchTag`
+
+Use `catchTag` when your error type has `_tag` and you want focused recovery.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+Example:
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTag("UserNotFound", (error) =>
+    Effect.succeed({ id: error.userId, guest: true })
+  )
+)
+```
+
+### Handle several tagged errors with `Effect.catchTags`
+
+Use `catchTags` when multiple domain errors should be handled together.
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTags({
+    UserNotFound: () => Effect.succeed(null),
+    InvalidPayload: (error) => Effect.succeed({ error: error.reason })
+  })
+)
+```
+
+### Handle predicate-based subsets with `Effect.catchIf`
+
+Use `catchIf` when matching on a predicate or refinement, not just `_tag`.
+
+### Turn failure into a value with `Effect.match`
+
+Use `match` when you want to fully fold the typed error channel into a success value.
+
+```ts
+const outcome = program.pipe(
+  Effect.match({
+    onFailure: (error) => ({ ok: false as const, error }),
+    onSuccess: (value) => ({ ok: true as const, value })
+  })
+)
+```
+
+## Handling Defects
+
+Defects are not normal domain failures.
+
+They come from:
+
+- `Effect.die`
+- unchecked exceptions in effectful code
+- invariants that were broken
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Preferred rule
+
+Do not model expected business failures as defects.
+
+Use defects for:
+
+- impossible states
+- programmer errors
+- unrecoverable infrastructure corruption
+
+### Inspect defects with `sandbox`, `catchCause`, or `matchCause`
+
+Use `sandbox` to expose `Cause<E>` in the error channel.
+
+```ts
+import { Cause, Effect } from "effect"
+
+const diagnosed = program.pipe(
+  Effect.sandbox,
+  Effect.catchCause((cause) => {
+    if (Cause.hasDies(cause)) {
+      return Effect.succeed("defect")
+    }
+    return Effect.failCause(cause)
+  })
+)
+```
+
+Use `matchCause` or `matchCauseEffect` when you need to distinguish:
+
+- typed failures
+- defects
+- interrupts
+
+### Boundary-only recovery for defects
+
+If you recover from defects at all, do it only at clear boundaries.
+
+Examples:
+
+- worker or RPC boundary
+- CLI top-level runner
+- HTTP server adapter
+
+Typical pattern:
+
+- log or report defect details
+- translate to a safe external error
+- avoid continuing as if it were a normal domain failure
+
+### `Effect.orDie`
+
+Use `orDie` when an error channel should be treated as unrecoverable from this point onward.
+
+That is appropriate when:
+
+- a failure has already been validated elsewhere as impossible
+- continuing with typed recovery would only obscure a broken invariant
+
+Do not use `orDie` just to silence a type you do not want to handle.
+
+## Handling Interrupts
+
+Interrupts are cancellation, not business failure.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Use `Effect.interrupt` to stop work cooperatively
+
+Interrupts signal that the fiber should stop. They should not usually be translated into a domain error.
+
+### Use `Effect.onInterrupt` for cleanup
+
+If interrupted work needs special cleanup, use `onInterrupt`.
+
+```ts
+import { Console, Effect } from "effect"
+
+const program = longRunningTask.pipe(
+  Effect.onInterrupt(() => Console.log("cleaning up after interrupt"))
+)
+```
+
+### Use `Cause` inspection when interrupts must be distinguished
+
+When handling full causes, use `Cause.isInterruptReason`, `Cause.hasInterrupts`, or filtering over `cause.reasons`.
+
+This is useful for:
+
+- deciding whether to suppress logs for normal cancellation
+- keeping retries for failure but not for cancellation
+- distinguishing timeout/cancel flows from real errors
+
+### Do not treat interrupts as ordinary failures
+
+Avoid patterns that collapse all causes into a single error value too early. Interrupts often need different operational behavior.
+
+## Recommended Patterns
+
+### Pattern: domain errors inside the app, schema errors at the edge
+
+- decode external input with `Schema.decodeUnknownEffect`
+- convert `SchemaError` into a domain or transport error near the boundary
+- keep the rest of the application on domain errors
+
+### Pattern: tagged errors for recovery
+
+- define domain failures with `Data.TaggedError`
+- recover with `catchTag` or `catchTags`
+- keep `_tag` names stable and descriptive
+
+### Pattern: schema-backed errors for protocols
+
+- use `Schema.TaggedErrorClass` or `Schema.ErrorClass` when the error contract itself matters
+- follow examples in SQL, socket, RPC, and HTTP modules
+
+### Pattern: only inspect `Cause` when you really need the full failure structure
+
+Use `catchCause`, `matchCause`, or `sandbox` when you must distinguish:
+
+- expected failures
+- defects
+- interrupts
+
+Otherwise prefer the simpler typed error operators.
+
+## Anti-Patterns
+
+- using defects for expected validation or business-rule failures
+- converting every error immediately to `unknown` or `string`
+- using `orDie` to avoid proper handling of expected errors
+- treating interrupts as ordinary business failures
+- leaking `SchemaError` deep into domain code when it should be normalized at the boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpServerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`

--- a/.agents/skills/effect-ts/references/guide-layers.md
+++ b/.agents/skills/effect-ts/references/guide-layers.md
@@ -1,0 +1,1018 @@
+# Layers Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## Mental Model
+
+A service is a typed dependency.
+
+A layer is a recipe for building one or more services, possibly using other services as dependencies.
+
+Effect's model is:
+
+- define service identifiers with `Context.Service` or `Context.Service(...)`
+- require services from effects with `Effect.service` or by yielding the service key directly
+- build implementations with `Layer`
+- provide layers at the program boundary or subsystem boundary
+
+`Layer<ROut, E, RIn>` means:
+
+- `ROut`: services produced by the layer
+- `E`: possible failures while constructing the layer
+- `RIn`: dependencies required to build it
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+
+## Services
+
+## What A Service Is
+
+A service is a typed key plus its implementation shape.
+
+In Effect, services are values in `Context`, not global singletons.
+
+This gives you:
+
+- explicit dependencies
+- easy substitution in tests
+- layer-based composition
+- multiple implementations for the same interface
+
+## Preferred Service Definition Style
+
+Prefer the class syntax with `Context.Service`.
+
+This matches the vendored repo's current style.
+
+There are two good definition styles:
+
+- explicit service shape in the `Context.Service<...>` generic
+- inferred service shape from the `make` argument
+
+Example:
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserRepoError>
+}>()("UserRepo") {}
+```
+
+Why this style is preferred:
+
+- the service identifier and shape live in one place
+- it works naturally with `yield* UserRepo`
+- it matches the patterns used across `.repos/effect`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+## Service Shape Inference With `make`
+
+When the implementation shape is clearer than the interface declaration, prefer using the `make` argument so the service shape is inferred from the implementation.
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo>()("UserRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("UserRepo.getById")(function*(id: string) {
+      return yield* Effect.fail(
+        UserRepoError.make({ message: `User ${id} not found` })
+      )
+    })
+  })
+}) {}
+```
+
+Why this style is useful:
+
+- the implementation and inferred API stay together
+- TypeScript derives the service shape automatically
+- it avoids repeating the same method signatures twice
+
+Prefer this style when:
+
+- the implementation is small and obvious
+- the explicit service shape would only duplicate the implementation
+
+Prefer the explicit generic shape when:
+
+- you want the contract stated before the implementation
+- the API surface should be emphasized separately from the implementation
+
+## Service Example
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
+  "UserNotFound",
+  {
+    userId: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserNotFound>
+}>()("UserRepo") {}
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+```
+
+Key points:
+
+- `UserRepo` is both the identifier and a value you can yield from `Effect.gen`
+- the implementation shape is explicit in the service definition
+- the effect that uses it stays abstract over the implementation
+
+## When To Use `Context.Reference`
+
+Use `Context.Reference` for contextual values with defaults, not for full service APIs.
+
+Good use cases:
+
+- current configuration knobs
+- current request metadata
+- feature flags or tracing flags with defaults
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+Use a full service instead when:
+
+- behavior matters more than data
+- you need multiple methods
+- you want a concrete test double or alternate implementation
+
+## Accessing Services
+
+Common patterns:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+})
+```
+
+or:
+
+```ts
+const program = Effect.service(UserRepo).pipe(
+  Effect.flatMap((repo) => repo.getById("u_123"))
+)
+```
+
+Best practice:
+
+- use `yield* Service` or `Effect.service(Service)` inside business logic
+- do not manually thread service implementations through function arguments when they are real application dependencies
+
+## Service Encapsulation
+
+Prefer keeping service access inside the business operation that needs it rather than exporting thin accessor wrappers for every method.
+
+Avoid this pattern:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoService
+  return yield* todos.create(title)
+})
+```
+
+Why this is usually a bad pattern:
+
+- it leaks the service dependency into a second public API layer
+- it encourages a redundant accessor function per service method
+- it spreads dependency access patterns across the codebase
+- it weakens service encapsulation instead of improving it
+
+Prefer one of these patterns instead:
+
+1. Put the real business logic in a function that uses the service internally because it adds behavior beyond simple forwarding.
+2. Expose the service itself and call its methods from the module that owns the workflow.
+3. If you need a public operation, make it a real business operation, not a trivial alias of one service method.
+
+Good:
+
+```ts
+export const completeTodo = Effect.fn("completeTodo")(function*(id: number) {
+  const todos = yield* TodoService
+  const todo = yield* todos.getById(id)
+  if (todo.completed) {
+    return todo
+  }
+  return yield* todos.setCompleted(id, true)
+})
+```
+
+This is good because:
+
+- the exported function represents a business operation
+- the service remains an internal dependency of that operation
+- the function adds behavior rather than just forwarding one method call
+
+## Layers
+
+## What A Layer Is
+
+A layer constructs services from dependencies.
+
+Use a layer when:
+
+- service construction is effectful
+- the service depends on other services
+- the service owns resources that must be acquired and released safely
+- you want composition and reuse across modules
+
+## Preferred Layer Constructors
+
+### `Layer.succeed`
+
+Use for pure, already-constructed implementations.
+
+```ts
+const UserRepoTest = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test User" })
+})
+```
+
+Use this when:
+
+- construction is pure
+- no dependencies are needed
+- no scoped resources are involved
+
+### `Layer.effect`
+
+Use when constructing a service requires effects, other services, or scoped resource acquisition.
+
+```ts
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Fetched from ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+```
+
+Use this when:
+
+- construction is effectful
+- construction depends on other services
+- construction needs `Scope` and finalization
+- you want typed construction failure
+
+This is also the correct constructor for services that own resources with acquisition and release semantics. In this repo, `Layer.effect` replaces the old `Layer.scoped` API.
+
+Typical examples:
+
+- database pools
+- sockets
+- background worker processes
+- long-lived subscriptions
+
+### `Layer.effectDiscard`
+
+Use `Layer.effectDiscard` for scoped startup effects that do not provide a service.
+
+Good use cases:
+
+- starting background fibers in a layer
+- one-time scoped initialization side effects
+- subsystem startup hooks
+
+### `Layer.effectContext`
+
+Use when one effect constructs a full `Context` containing multiple services.
+
+This is useful for subsystem builders that provide several related services together.
+
+## Layer Composition
+
+These operators do different things. Do not treat them as interchangeable.
+
+### Composition Cheat Sheet
+
+- `Layer.mergeAll(a, b, ...)`: combine outputs of multiple layers
+- `Layer.provide(target, dependencies)`: feed dependency outputs into `target` and keep only `target` outputs
+- `Layer.provideMerge(target, dependencies)`: feed dependency outputs into `target` and keep both dependency outputs and target outputs
+- `Layer.flatMap(layer, f)`: choose the next layer based on the built service value
+
+### Example Services
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class Logger extends Context.Service<Logger, {
+  readonly log: (message: string) => Effect.Effect<void>
+}>()("Logger") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const LoggerLayer = Layer.succeed(Logger)({
+  log: (message) => Effect.sync(() => console.log(message))
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+    const logger = yield* Logger
+
+    return {
+      getById: (id) =>
+        Effect.gen(function*() {
+          yield* logger.log(`loading ${id} from ${config.apiBaseUrl}`)
+          return { id, name: "Ada" }
+        })
+    }
+  })
+)
+```
+
+### `Layer.mergeAll`
+
+Use `Layer.mergeAll` to combine outputs of independent layers.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+Use this when:
+
+- the layers provide different services
+- neither needs to transform the other directly
+
+Semantics:
+
+- inputs are combined
+- outputs are combined
+- no dependency feeding happens automatically
+
+Important:
+
+- `Layer.mergeAll(ConfigLayer, UserRepoLayer)` is wrong if `UserRepoLayer` requires `Config` and `Logger`
+- `mergeAll` does not satisfy `UserRepoLayer`'s requirements
+- it only places both layers side by side in the output graph
+
+Correct pattern:
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+### `Layer.provide`
+
+Use `Layer.provide` to satisfy a target layer's dependencies with another layer, while keeping only the target layer's outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserRepoLayerReady = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` requires `Config` and `Logger`
+- `Dependencies` provides those dependencies
+- the resulting layer provides only `UserRepo`
+- `Config` and `Logger` are used for construction but are not kept in the final output
+
+This is the operator to use when you want to hide construction dependencies behind a narrower public layer.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+### `Layer.provideMerge`
+
+Use `provideMerge` when you want to satisfy dependencies and retain both the dependency outputs and the target outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const AppLayer = Layer.provideMerge(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` still gets `Config` and `Logger`
+- the resulting layer provides `UserRepo`, `Config`, and `Logger`
+
+This is useful for assembling larger application layers incrementally, especially when downstream code still needs access to the dependencies.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  const logger = yield* Logger
+
+  const user = yield* repo.getById("u_123")
+  yield* logger.log(user.name)
+  return user
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Preferred rule:
+
+- use `provide` when you want to hide dependency details
+- use `provideMerge` when you want to keep dependency services available downstream
+
+### `Layer.mergeAll` vs `Layer.provide` vs `Layer.provideMerge`
+
+Think of them like this:
+
+- `mergeAll`: put layers next to each other
+- `provide`: plug one layer into another, expose only the target
+- `provideMerge`: plug one layer into another, expose both sides
+
+### Composition Style Best Practice
+
+Layers should almost always be fully composed locally before they are assembled into the final application layer.
+
+Preferred style:
+
+- define each service layer separately
+- define local subsystem dependency bundles separately
+- fully compose each subsystem locally with `Layer.provide` or `Layer.provideMerge`
+- assemble the final application layer with `Layer.mergeAll(...)`
+- apply top-level cross-cutting provisioning in a small number of explicit trailing steps
+
+Good pattern:
+
+```ts
+const UserDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserLayer = Layer.provide(UserRepoLayer, UserDependencies)
+
+const BillingDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer,
+  DatabaseLayer
+)
+
+const BillingLayer = Layer.provide(BillingServiceLayer, BillingDependencies)
+
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why this style is preferred:
+
+- subsystem wiring stays local to the subsystem
+- the final application layer reads as a high-level composition map
+- cross-cutting concerns such as telemetry stay visible at the top level
+- it avoids deeply nested inline layer expressions
+
+Avoid this style when a clearer local name would help:
+
+```ts
+const AppLayer = Layer.provide(
+  Layer.mergeAll(
+    Layer.provide(UserRepoLayer, Layer.mergeAll(ConfigLayer, LoggerLayer)),
+    Layer.provide(BillingServiceLayer, Layer.mergeAll(ConfigLayer, LoggerLayer, DatabaseLayer)),
+    HttpLayer
+  ),
+  Telemetry
+).pipe(Layer.provide(NodeSdk))
+```
+
+That style is harder to read because:
+
+- subsystem composition is hidden inside the final assembly
+- shared dependencies are harder to spot
+- it is harder to refactor or reuse subsystem layers
+
+### `Layer.flatMap`
+
+Use `flatMap` when the next layer depends on the actual constructed service value, not just its type-level requirement.
+
+Example:
+
+```ts
+const UserRepoLayerFromConfig = Layer.flatMap(ConfigLayer, (config) =>
+  Layer.succeed(UserRepo)({
+    getById: (id) => Effect.succeed({ id, name: config.apiBaseUrl })
+  })
+)
+```
+
+This is more specialized than `merge` or `provide`.
+
+Prefer simpler composition first:
+
+- `merge` for combining
+- `provide` for dependency satisfaction
+- `flatMap` only when construction logic truly depends on the built value
+
+## Providing Layers To Effects
+
+## Preferred Rule
+
+Provide layers at boundaries.
+
+Usually that means:
+
+- the application entrypoint
+- a subsystem entrypoint
+- a test boundary
+
+Avoid repeatedly providing layers deep inside business logic unless you are deliberately isolating a subsystem.
+
+### Anti-Pattern: Local `Effect.provide`
+
+`Effect.provide` should be used only once at the entry of your program in normal application code.
+
+Bad pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  }).pipe(
+    Effect.provide(UserRepoLayer)
+  )
+```
+
+Why this is an anti-pattern:
+
+- it hides dependency wiring inside business logic
+- it makes implementations harder to swap in tests
+- it prevents clean top-level composition
+- it encourages many small local runtimes instead of one coherent application graph
+- it makes shared cross-cutting services harder to reason about
+
+Preferred pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Rule of thumb:
+
+- business logic should require services
+- composition should happen in layers
+- `Effect.provide` should happen at the outermost entry boundary
+
+### Multiple Entry Points
+
+If your code integrates with a framework and has multiple entry points, prefer `ManagedRuntime` instead of repeatedly calling `Effect.provide` at many call sites.
+
+Typical examples:
+
+- HTTP handlers registered separately
+- queue consumers
+- cron jobs
+- framework lifecycle hooks
+- RPC handlers or worker callbacks
+
+Preferred pattern:
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (id: string) =>
+  runtime.runPromise(loadUser(id))
+```
+
+Why:
+
+- the layer graph is still composed once
+- services remain shared according to layer semantics
+- the framework integration gets a stable runtime boundary
+- resource lifecycle is explicit through `ManagedRuntime`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## `Effect.provide`
+
+Use `Effect.provide` to satisfy an effect's dependencies with a layer or context.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+This is the main boundary provisioning operator.
+
+## `Effect.provideService`
+
+Use `provideService` for a single ad hoc implementation.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provideService(UserRepo, {
+    getById: (id) => Effect.succeed({ id, name: "Inline User" })
+  })
+)
+```
+
+Good use cases:
+
+- small tests
+- one-off overrides
+- local customization
+
+Do not use this as the default replacement for real application layers.
+
+## `Effect.provideServiceEffect`
+
+Use `provideServiceEffect` when one service instance must be built effectfully without creating a reusable layer.
+
+This is useful for targeted overrides, but if the construction is reusable or part of application wiring, prefer a named `Layer.effect`.
+
+## Best Practices
+
+## 1. Keep service interfaces small and focused
+
+Prefer cohesive services over giant "everything" services.
+
+Good:
+
+- `UserRepo`
+- `Mailer`
+- `Clock`-like configuration or time abstractions
+
+Avoid:
+
+- large service shapes that mix unrelated responsibilities
+
+## 2. Prefer layers over manual wiring
+
+If construction has dependencies or effects, represent it as a layer.
+
+Avoid manually grabbing dependencies and assembling concrete objects all over the codebase.
+
+## 2.5 Prefer Effect-native integrations over raw runtime clients
+
+When Effect already provides a module for a capability, prefer the Effect-native integration over directly embedding a raw runtime client in service code.
+
+Examples:
+
+- prefer `effect/unstable/sql` modules over directly coupling business services to native SQL driver APIs
+- prefer Effect HTTP modules over direct ad hoc request clients when the project is already using Effect HTTP abstractions
+
+Why:
+
+- resource handling, tracing, and errors stay inside the Effect model
+- integrations compose better with layers and services
+- observability and transactions are easier to keep consistent
+
+## 3. Keep business logic abstract over implementations
+
+Business functions should require services, not construct them.
+
+Good:
+
+```ts
+const sendWelcomeEmail = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    const user = yield* repo.getById(userId)
+    return user
+  })
+```
+
+Avoid constructing `UserRepo` inside `sendWelcomeEmail`.
+
+## 4. Use `Layer.succeed` only for pure values
+
+Do not hide effectful initialization inside supposedly pure service objects.
+
+If initialization can fail, depends on effects, or needs scoped acquisition, use `Layer.effect`.
+
+## 5. Use `Layer.effect` for owned resources
+
+If the service opens something that must later close, model that lifecycle explicitly.
+
+This is one of the main reasons layers exist.
+
+## 6. Prefer top-level composition
+
+Compose major application layers once near the boundary.
+
+Good pattern:
+
+- define `ConfigLayer`
+- define `UserRepoLayer`
+- define `Dependencies = Layer.mergeAll(...)`
+- define `AppLayer` separately with `Layer.provide(...)` or `Layer.provideMerge(...)`
+- provide `AppLayer` to the top-level program
+
+## 7. Use `Layer.fresh` only when you really need a new instance
+
+Layers are shared by default.
+
+That is usually what you want.
+
+Use `Layer.fresh` only when you intentionally need to bypass sharing and rebuild the layer.
+
+## 7.5 Understand Layer Memoization
+
+Layers are memoized by reference.
+
+That means:
+
+- reusing the same layer value preserves memoization and sharing
+- creating a new layer value creates a new memoization identity
+
+Because of this, functions that return layers should be avoided unless they are absolutely necessary.
+
+Prefer plain named layer constants over layer factory functions.
+
+Only use a function returning a layer when:
+
+- the layer genuinely depends on runtime parameters
+- the caller truly needs distinct configurations or instances
+- a constant layer value cannot express the construction cleanly
+
+Even in those cases, call the function once during construction and reuse the resulting layer value.
+
+### Function Dependencies Should Stay Unprovided
+
+If a dependency of a layer is itself represented by a function that returns a layer, do not call that function locally just to satisfy the dependency.
+
+Instead, leave that dependency unprovided and let it be supplied at the edge.
+
+Bad pattern:
+
+```ts
+const UserLayer = Layer.provide(UserRepoLayer, makeDatabaseLayer(config))
+```
+
+Why this is bad:
+
+- it creates a fresh layer reference locally
+- it breaks or weakens memoization and sharing assumptions
+- it hides an important construction dependency inside subsystem wiring
+- it makes the final application graph harder to understand
+
+Preferred pattern:
+
+```ts
+const UserLayer = UserRepoLayer
+
+const DatabaseLayer = makeDatabaseLayer(config)
+
+const AppLayer = Layer.provideMerge(UserLayer, DatabaseLayer)
+```
+
+More generally:
+
+- if a layer depends on a parameterized layer factory, keep that dependency in the required environment when possible
+- construct the concrete parameterized layer once at the outer boundary
+- provide it only at the edge where the full application graph is assembled
+
+Rule:
+
+- do not call layer-producing dependency functions deep inside subsystem composition
+- keep those dependencies unprovided until the edge
+- provide the concrete layer once in the final top-level assembly
+
+Bad pattern:
+
+```ts
+const makeDatabaseLayer = () => Layer.effect(DatabaseService)(/* ... */)
+
+const AppLayer = Layer.mergeAll(
+  makeDatabaseLayer(),
+  makeDatabaseLayer()
+)
+```
+
+Why this is bad:
+
+- each call creates a distinct layer reference
+- memoization does not apply across those distinct references
+- the underlying resource or service may be constructed more than once
+- sharing assumptions become incorrect
+
+Preferred pattern:
+
+```ts
+const DatabaseLayer = makeDatabaseLayer()
+
+const AppLayer = Layer.mergeAll(
+  DatabaseLayer,
+  OtherLayer
+)
+```
+
+Rule:
+
+- avoid layer-producing functions unless they are truly necessary
+- if a function returns a layer, call it once during construction and bind the result to a named constant
+- reuse that layer value everywhere else
+
+This is especially important for:
+
+- database layers
+- HTTP client layers
+- telemetry layers
+- queues, workers, and other resource-owning services
+
+If you intentionally need a distinct instance, make that explicit with a new layer value or `Layer.fresh`, rather than accidentally creating multiple instances by repeatedly calling a layer factory.
+
+## 8. Treat `Layer.orDie` carefully
+
+`Layer.orDie` converts layer construction failures into defects.
+
+Only use it when failure is truly unrecoverable at that boundary.
+
+Do not use it to hide legitimate configuration or infrastructure failures.
+
+## 9. Use `ManagedRuntime.make` at true runtime boundaries
+
+If you need a reusable runtime built from a layer, `ManagedRuntime.make` is the edge tool for that.
+
+Good use cases:
+
+- embedding Effect into external frameworks
+- scripts or hosts that repeatedly run Effect programs
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## 10. Prefer explicit test layers
+
+For tests, prefer:
+
+- `Layer.succeed` for simple fakes
+- `Layer.mock` for partial mocks when appropriate
+
+This keeps test wiring explicit and close to production composition style.
+
+## Recommended Patterns
+
+## Pattern: service definition plus live layer
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Loaded via ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+
+const Dependencies = Layer.mergeAll(ConfigLayer)
+
+const AppLayer = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+## Pattern: provide at the top level
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+## Pattern: single-service override in tests
+
+```ts
+const TestRepo = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test" })
+})
+```
+
+## Anti-Patterns
+
+- constructing live services directly inside business logic
+- using `Layer.succeed` for values that actually require effectful initialization
+- providing the same large layer repeatedly throughout the call graph
+- collapsing unrelated responsibilities into one service
+- using `Layer.orDie` to hide normal initialization failures
+- bypassing layers entirely for resource-owning services
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+- `./.repos/effect/packages/effect/src/Stream.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Persistence.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcSerialization.ts`
+- `./.repos/effect/packages/effect/src/unstable/reactivity/Reactivity.ts`

--- a/.agents/skills/effect-ts/references/guide-observability.md
+++ b/.agents/skills/effect-ts/references/guide-observability.md
@@ -1,0 +1,724 @@
+# Observability Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+## Mental Model
+
+Observable Effect code should make business operations visible by default.
+
+That means:
+
+- business logic should show up clearly in stack traces
+- important operations should produce spans
+- logs should inherit execution context
+- metrics should be attached at meaningful boundaries
+
+The most important best practice is:
+
+- prefer `Effect.fn(...)` whenever possible for business logic
+
+Why:
+
+- it adds stack frames
+- it creates spans automatically
+- it gives you better tracing and debugging for free
+- it keeps business logic observable without extra boilerplate
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Rule
+
+Use `Effect.fn` as the default constructor for business-logic functions that return `Effect`.
+
+Prefer this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Over this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+The second version works, but it throws away useful observability structure that `Effect.fn` gives you automatically.
+
+## Prefer `Effect.fn` Over Raw `Effect.gen`
+
+For business-logic definitions, prefer `Effect.fn` over writing raw `Effect.gen` directly, even when the operation takes no arguments.
+
+Prefer this:
+
+```ts
+const refreshCache = Effect.fn("refreshCache")(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Over this:
+
+```ts
+const refreshCache = Effect.gen(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Why:
+
+- `Effect.fn` gives the operation a clear observable identity
+- stack traces are better
+- tracing is more consistent
+- the codebase gets a uniform shape for business operations
+
+Use raw `Effect.gen` when necessary, for example:
+
+- inline effect blocks inside another `Effect.fn`
+- small one-off composition at call sites
+- top-level assembly code where you are not defining a reusable business operation
+
+Rule of thumb:
+
+- reusable business operation: `Effect.fn`
+- inline composition block: `Effect.gen`
+
+## `Effect.fn` vs `Effect.fnUntraced`
+
+### `Effect.fn`
+
+Use `Effect.fn` for almost all business logic.
+
+It is the preferred default because it adds:
+
+- stack frames
+- tracing spans
+- optional post-processing of the produced effect
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const createUser = Effect.fn("createUser")(function*(name: string) {
+  return { id: "u_123", name }
+})
+```
+
+Use this for:
+
+- domain operations
+- application services
+- handlers
+- workflows
+- orchestrations
+- repository calls
+
+### `Effect.fnUntraced`
+
+Use `Effect.fnUntraced` only for edge cases.
+
+The vendored Effect repo itself uses `fnUntraced` in a number of low-level internals and integration helpers. That does not make it the default recommendation for downstream application or business code.
+
+If you do not want an explicit named span, prefer `Effect.fn` without a span name so you still keep stack traces and the normal traced-function behavior.
+
+Prefer this:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Over this:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Typical cases:
+
+- extremely hot low-level internal helpers
+- very small internal combinators
+- tight loops where you have measured overhead and need to reduce it
+
+Preferred rule:
+
+- `Effect.fn` by default
+- `Effect.fn` without a span name when you want to avoid an explicit named span
+- `Effect.fnUntraced` only with a concrete measured reason
+
+## Business Logic Patterns
+
+### Pattern: one named `Effect.fn` per meaningful operation
+
+Good:
+
+```ts
+const parseCommand = Effect.fn("parseCommand")(function*(input: string) {
+  return input.trim()
+})
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+
+const sendWelcomeEmail = Effect.fn("sendWelcomeEmail")(function*(userId: string) {
+  const user = yield* loadUser(userId)
+  return user.email
+})
+```
+
+Why this is good:
+
+- each operation has a clear span name
+- traces reflect business concepts
+- stack traces reflect the actual workflow
+
+### Pattern: use meaningful names
+
+Span names created through `Effect.fn` should represent business operations, not generic implementation detail.
+
+Prefer:
+
+- `loadUser`
+- `chargeInvoice`
+- `syncGithubInstallation`
+
+Avoid:
+
+- `helper`
+- `run`
+- `process`
+- `step1`
+
+## Explicit Spans
+
+### `Effect.withSpan`
+
+Use `withSpan` when you need an explicit span around an effect that is not already naturally represented by a named `Effect.fn`, or when you want a nested sub-operation span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchProfile(userId).pipe(
+    Effect.withSpan("fetchProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+Use this when:
+
+- you want a nested span inside a larger operation
+- you are instrumenting an existing effect pipeline
+- you need more detailed trace structure than `Effect.fn` alone provides
+
+### `Effect.withSpanScoped`
+
+Use `withSpanScoped` when the span should remain open for the lifetime of a scope.
+
+This is less common in business logic and more common in long-lived resource or streaming workflows.
+
+### `Effect.withParentSpan`
+
+Use `withParentSpan` when integrating with an externally created span or continuing a parent span manually.
+
+This is useful in framework or interoperability boundaries.
+
+## Span Enrichment
+
+### `Effect.annotateCurrentSpan`
+
+Use `annotateCurrentSpan` to attach important structured fields to the current span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+Good span annotations:
+
+- stable identifiers
+- domain-relevant keys
+- request or resource identifiers
+- small structured values
+
+Avoid:
+
+- giant payloads
+- secrets
+- noisy transient data with little diagnostic value
+
+## Logging Patterns
+
+### Use Effect logging inside effects
+
+Prefer:
+
+- `Effect.log`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.logWarning`
+- `Effect.logError`
+
+These integrate with the current Effect execution context.
+
+Example:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.logDebug("loading user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### `Effect.withLogSpan`
+
+Use `withLogSpan` when you want log messages to carry a local logical span label even when you are not creating a full tracing span.
+
+Example:
+
+```ts
+const program = Effect.logInfo("starting sync").pipe(
+  Effect.withLogSpan("user-sync")
+)
+```
+
+This is useful for:
+
+- log grouping
+- quick local context
+- correlation in plain log output
+
+### Logging Best Practices
+
+- log at business boundaries, not every tiny helper
+- prefer structured values over concatenated strings
+- keep logs high-signal
+- avoid duplicate logs at every layer of the stack
+- rely on spans plus a few well-placed logs, not log spam
+
+## Metrics Patterns
+
+### Track effects at meaningful boundaries
+
+Use metric tracking on meaningful operations such as:
+
+- requests
+- jobs
+- retries
+- external calls
+- queue handlers
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `Effect.track`
+
+Example:
+
+```ts
+import { Effect, Metric } from "effect"
+
+const requests = Metric.counter("user_load_requests").pipe(
+  Metric.withConstantInput(1)
+)
+
+const loadUser = Effect.fn("loadUser")(
+  function*(userId: string) {
+    return { id: userId, name: "Ada" }
+  },
+  Effect.track(requests)
+)
+```
+
+### Prefer boundary metrics over micro-metrics
+
+Good metrics are usually attached to:
+
+- endpoint handlers
+- queue/job handlers
+- repository operations
+- external API boundaries
+
+Avoid putting a metric on every tiny internal helper.
+
+## OpenTelemetry Integration
+
+For real application observability, compose telemetry at the layer level.
+
+The vendored repo provides `@effect/opentelemetry` layers such as:
+
+- `NodeSdk.layer`
+- `Tracer.layer`
+- `Logger.layer`
+- `Metrics.layer`
+
+Repo references:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+Preferred composition style:
+
+```ts
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why:
+
+- business code stays observability-agnostic
+- observability is configured once at the boundary
+- spans, logs, and metrics remain consistent across the app
+
+## OpenTelemetry JS Framework Integration
+
+The vendored repo includes a real integration layer for the OpenTelemetry JavaScript ecosystem in `@effect/opentelemetry`.
+
+This is the preferred integration path when the application needs to participate in the standard OpenTelemetry JS framework, exporters, and SDKs.
+
+Relevant modules:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/opentelemetry/src/Metrics.ts`
+- `./.repos/effect/packages/opentelemetry/src/Logger.ts`
+- `./.repos/effect/packages/opentelemetry/src/Resource.ts`
+- `./.repos/effect/packages/opentelemetry/src/WebSdk.ts`
+
+### Preferred Integration Model
+
+Use `@effect/opentelemetry` layers to bridge Effect observability into OpenTelemetry JS.
+
+Do not manually wire OpenTelemetry SDK objects inside business code.
+
+Prefer:
+
+- configuring tracer, metrics, logger, and resource layers once
+- composing them into the application layer graph
+- keeping business code written against Effect tracing, logging, and metrics APIs
+
+This means:
+
+- application code should keep using `Effect.fn`, `Effect.withSpan`, `Effect.log*`, and Effect metrics
+- OpenTelemetry JS should be introduced at the infrastructure layer, not inside domain operations
+
+### `NodeSdk.layer`
+
+`NodeSdk.layer(...)` is the main Node.js integration entrypoint.
+
+From the vendored source, it accepts a configuration that can include:
+
+- span processors
+- tracer config
+- metric readers
+- temporality preference
+- log record processors
+- logger provider config
+- resource information such as service name and version
+- shutdown timeout
+
+It then builds and merges:
+
+- resource layer
+- tracer layer
+- metrics layer
+- logger layer
+
+This makes it the preferred high-level integration for Node applications.
+
+### Resource Configuration
+
+OpenTelemetry JS integration should define resource metadata explicitly.
+
+From `NodeSdk.layer`, the supported resource configuration includes:
+
+- `serviceName`
+- `serviceVersion`
+- additional attributes
+
+This is important because tracer and logger setup depend on the configured resource.
+
+Best practice:
+
+- always provide a meaningful service name
+- provide service version when available
+- use resource attributes for stable deployment or environment metadata
+
+### Tracing Integration
+
+The `Tracer` module bridges Effect spans into OpenTelemetry spans.
+
+Important integration points from the vendored source:
+
+- `Tracer.layer`
+- `Tracer.layerGlobal`
+- `Tracer.layerGlobalProvider`
+- `Tracer.currentOtelSpan`
+- `Tracer.makeExternalSpan`
+
+Use these when:
+
+- you need Effect tracing to export through OpenTelemetry JS
+- you need to continue or bridge external trace context
+- you need access to the current OpenTelemetry span object
+
+Best practice:
+
+- keep creating spans with Effect APIs in application code
+- use the OpenTelemetry tracer layer to export and bridge them
+- use `makeExternalSpan` or parent-span wiring only at integration boundaries
+
+### Metrics Integration
+
+The `Metrics` module connects Effect metrics to OpenTelemetry JS metric readers.
+
+Important details from the vendored implementation:
+
+- `Metrics.layer(...)` registers a producer against one or more metric readers
+- it supports temporality preferences:
+  - `cumulative`
+  - `delta`
+- it handles shutdown through scoped layer cleanup
+
+Best practice:
+
+- choose temporality based on the backend
+- configure metric readers in the telemetry layer
+- keep application code focused on recording Effect metrics, not exporter mechanics
+
+### Logger Integration
+
+The `Logger` module connects Effect logging to OpenTelemetry JS logs.
+
+Important details from the vendored implementation:
+
+- it maps Effect log levels to OpenTelemetry severity numbers
+- it includes fiber ID, span context, log annotations, and log span timing in emitted attributes
+- `Logger.layer({ mergeWithExisting })` can merge with or replace existing application loggers
+
+Best practice:
+
+- prefer merging with existing loggers unless there is a strong reason to replace them
+- use Effect log annotations and log spans so the OpenTelemetry logger receives structured context automatically
+
+### Shutdown And Lifecycle
+
+The vendored layers use scoped acquisition and release for tracer providers, metric readers, and logger providers.
+
+This is the correct lifecycle model.
+
+Do not manually call provider shutdown methods from arbitrary business logic.
+
+Instead:
+
+- let the OpenTelemetry layers own provider lifecycle
+- compose them into the application layer graph
+- let the runtime or outer layer scope manage shutdown
+
+### External Trace Context
+
+When integrating with frameworks or inbound protocols that already carry trace context, prefer using the OpenTelemetry integration helpers rather than hand-rolling context propagation.
+
+The vendored tracer module provides:
+
+- `makeExternalSpan`
+- `currentOtelSpan`
+
+Use these only at integration boundaries such as:
+
+- HTTP adapters
+- RPC adapters
+- worker or queue adapters
+
+Keep business operations oblivious to propagation mechanics.
+
+### Recommended Pattern
+
+Preferred architecture:
+
+1. business code uses Effect observability APIs
+2. infrastructure composes `@effect/opentelemetry` layers
+3. the final app layer provides telemetry once at the top level
+
+Example shape:
+
+```ts
+const TelemetryLayer = NodeSdk.layer(() => ({
+  resource: {
+    serviceName: "todo-service",
+    serviceVersion: "1.0.0"
+  },
+  spanProcessor: mySpanProcessor,
+  metricReader: myMetricReader,
+  logRecordProcessor: myLogProcessor
+}))
+
+const AppLayer = Layer.mergeAll(
+  DomainLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(TelemetryLayer)
+)
+```
+
+This keeps:
+
+- app code portable
+- OTel JS setup centralized
+- shutdown semantics correct
+- exported spans, logs, and metrics aligned
+
+### Anti-Patterns
+
+- constructing OpenTelemetry SDK clients directly inside business services
+- mixing manual exporter setup into domain code
+- bypassing Effect logging and tracing APIs in normal business operations
+- scattering provider shutdown logic across the application
+- configuring telemetry separately in many subsystems instead of one top-level layer
+
+## Anti-Patterns
+
+### Anti-Pattern: business logic built from anonymous `Effect.gen` functions everywhere
+
+Bad:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+Why this is bad:
+
+- weaker tracing structure
+- poorer stack traces
+- less consistent naming in debugging output
+
+Preferred:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Anti-Pattern: using `Effect.fnUntraced` by default
+
+This throws away free observability.
+
+If you just do not want an explicit span name, use `Effect.fn` without a name instead.
+
+Only use `fnUntraced` when you have a specific low-level reason.
+
+### Anti-Pattern: logging without structure or context
+
+Bad:
+
+- giant interpolated strings
+- duplicate logs at every layer
+- logs with no business identifiers
+
+Prefer:
+
+- named operations via `Effect.fn`
+- structured logs with IDs and context
+- a few high-value logs at operation boundaries
+
+### Anti-Pattern: hand-instrumenting every helper with spans
+
+Do not create explicit spans everywhere just because you can.
+
+Preferred order:
+
+1. start with `Effect.fn`
+2. add `Effect.withSpan` only where extra detail is actually useful
+3. add metrics at meaningful boundaries
+
+## Recommended Patterns
+
+### Pattern: observable business operation
+
+```ts
+import { Effect } from "effect"
+
+const fetchUser = Effect.fn("fetchUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  yield* Effect.logDebug("fetching user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Pattern: orchestration with nested spans
+
+```ts
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchRemoteProfile(userId).pipe(
+    Effect.withSpan("fetchRemoteProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+### Pattern: framework boundary with runtime
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (userId: string) =>
+  runtime.runPromise(fetchUser(userId))
+```
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`

--- a/.agents/skills/effect-ts/references/guide-retries.md
+++ b/.agents/skills/effect-ts/references/guide-retries.md
@@ -1,0 +1,433 @@
+# Retries Guide
+
+This guide is based on retry patterns and `ExecutionPlan` usage in the vendored Effect repo.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+Retries in Effect are not just loops.
+
+The repo uses three increasingly powerful levels:
+
+1. simple `Effect.retry` options for bounded or condition-based retries
+2. `Schedule` for timing-aware retry policies
+3. `ExecutionPlan` for fallback across different provided resources or layers
+
+Choose the smallest model that correctly expresses the retry policy.
+
+## Preferred Rule
+
+Prefer structured retry policies over ad hoc retry loops.
+
+Use:
+
+- simple `Effect.retry({ ... })` for straightforward conditions
+- `Effect.retry(schedule)` when timing matters
+- `ExecutionPlan` when retries should escalate across different layers or resources
+
+Avoid:
+
+- hand-written loops with mutable counters
+- inline `catch` plus recursive retry logic
+- resource fallback logic encoded as nested `catch` chains when `ExecutionPlan` is a better fit
+
+## `Effect.retry`
+
+`Effect.retry` is the main retry operator.
+
+The vendored tests show several important supported forms.
+
+## Retry On Success vs Failure
+
+`Effect.retry` only retries failures.
+
+If the effect succeeds, nothing is retried.
+
+This is explicitly covered in the module tests.
+
+## Simple Retry Options
+
+### `{ times: n }`
+
+Use this for the simplest bounded retry case.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+Use this when:
+
+- timing does not matter
+- you only need a fixed retry count
+
+### `{ until: predicate }`
+
+Use `until` when retries should stop once the failure value satisfies a condition.
+
+The module tests show:
+
+- pure `until`
+- effectful `until`
+- that `until` is still evaluated at least once
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ until: (error) => error._tag === "Done" })
+)
+```
+
+### `{ while: predicate }`
+
+Use `while` when retries should continue only while the failure value satisfies a condition.
+
+The tests also show pure and effectful `while` variants.
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ while: (error) => error._tag === "Retryable" })
+)
+```
+
+## Retry With Schedule
+
+Use a `Schedule` whenever timing matters.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry(Schedule.recurs(3))
+)
+```
+
+Or with the richer object form:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: Schedule.recurs(3),
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+This is a very important repo pattern because it lets you combine:
+
+- retry timing
+- retry limits
+- retry predicates
+
+## Current Schedule Metadata During Retries
+
+The module tests show that retry execution updates `Schedule.CurrentMetadata`.
+
+This means retry policies and retry-aware effects can inspect:
+
+- attempt number
+- elapsed time
+- previous delay timing
+- schedule output
+
+Use this when:
+
+- logging retry behavior
+- building retry-aware diagnostics
+- implementing advanced adaptive retry behavior
+
+## When To Use Simple Options Vs Schedule
+
+Prefer simple options when:
+
+- only the retry count matters
+- retry timing does not matter
+- the retry rule is just a condition on the error
+
+Prefer a schedule when:
+
+- retry timing matters
+- backoff matters
+- jitter matters
+- the policy should evolve over time
+
+## Common Retry Schedules In The Repo
+
+The vendored repo repeatedly uses these patterns:
+
+### Fixed retry count
+
+```ts
+Schedule.recurs(3)
+```
+
+### Exponential backoff
+
+```ts
+Schedule.exponential(500, 1.5)
+```
+
+### Exponential plus steady fallback spacing
+
+```ts
+Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This appears in production modules such as RPC and workflow code.
+
+### Error-sensitive delay policy
+
+```ts
+Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+The OTLP exporter uses this shape to derive delays from actual HTTP failure details such as rate limits.
+
+## Retry Only For Specific Failures
+
+The workflow `Activity` module shows an important advanced pattern:
+
+- sandbox the effect
+- retry only when the `Cause` matches a specific retryable category
+- fail or die differently once retries are exhausted
+
+Example shape from the repo:
+
+```ts
+effect.pipe(
+  Effect.sandbox,
+  Effect.retry(policy),
+  Effect.catch((cause) => {
+    if (!Cause.hasInterrupts(cause)) {
+      return Effect.failCause(cause)
+    }
+    return Effect.die("interrupted and retries exhausted")
+  })
+)
+```
+
+Use this when:
+
+- retryability depends on the full cause, not just typed failures
+- interrupt-specific retry behavior is required
+- infrastructure policy is more nuanced than a simple tagged error rule
+
+## Retry Observability
+
+Retry logic should be observable.
+
+Good patterns:
+
+- keep retries inside named `Effect.fn` operations
+- use `Schedule.CurrentMetadata` for diagnostics when needed
+- log or annotate retry attempts at meaningful boundaries
+- prefer central retry policies over duplicating timing logic everywhere
+
+Do not spread retry behavior across many small helpers where it becomes hard to see the operational policy.
+
+## `ExecutionPlan`
+
+Use `ExecutionPlan` when retries should escalate across different provided resources or layers.
+
+This is not just about retry timing. It is about retrying the same operation under different provided environments.
+
+The core use case from `ExecutionPlan.ts` is:
+
+- try one layer some number of times
+- possibly with a schedule and conditions
+- then fall back to another layer
+- then possibly fall back again
+
+### What `ExecutionPlan` Solves
+
+`ExecutionPlan` is the right tool when:
+
+- the same effect should be retried against multiple alternative providers
+- fallback should move across tiers, regions, models, or implementations
+- retry policy includes both attempt counts and provider changes
+
+Examples:
+
+- fail over between multiple language model providers
+- try one upstream cluster, then another
+- fall back from a fast but unreliable service to a slower but more reliable one
+
+## `ExecutionPlan.make`
+
+Use `ExecutionPlan.make(...)` to define ordered retry/fallback steps.
+
+Each step can include:
+
+- `provide`
+- `attempts`
+- `while`
+- `schedule`
+
+Example shape:
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: FastLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("3 seconds")
+  },
+  {
+    provide: SafeLayer,
+    attempts: 3,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+### Step Semantics
+
+For each step:
+
+- `provide` is the context or layer to use
+- `attempts` bounds how many times that step is tried
+- `while` can stop retries for that step based on the input
+- `schedule` defines the timing policy for retries within that step
+
+If `attempts` is omitted, the step attempts once unless a schedule is involved in a way that causes further retries.
+
+## `Effect.withExecutionPlan` And `Stream.withExecutionPlan`
+
+Use:
+
+- `Effect.withExecutionPlan` for effects
+- `Stream.withExecutionPlan` for streams
+
+The vendored tests focus on `Stream.withExecutionPlan` and demonstrate:
+
+- fallback from one provider to another
+- fallback after partial stream failure
+- the ability to prevent fallback on partial streams
+
+This is a strong signal that `ExecutionPlan` is particularly useful for long-running or streaming integrations where failure can happen after partial success.
+
+## `ExecutionPlan.CurrentMetadata`
+
+`ExecutionPlan` exposes metadata with:
+
+- `attempt`
+- `stepIndex`
+
+This is useful for:
+
+- diagnostics
+- logging which fallback tier is being used
+- understanding which plan step ultimately succeeded
+
+## `captureRequirements`
+
+`ExecutionPlan.captureRequirements` converts a plan with requirements into one whose requirements are satisfied from the current context.
+
+Use this when the plan should be frozen with the current environment before being applied later.
+
+## `ExecutionPlan.merge`
+
+Use `ExecutionPlan.merge(...)` when you need to concatenate multiple plans into one ordered plan.
+
+This is useful for assembling more complex fallback policies out of smaller ones.
+
+## When To Use `ExecutionPlan` Instead Of `Schedule`
+
+Use `Schedule` when:
+
+- only timing and retry conditions change
+- the same environment/provider is used for every retry
+
+Use `ExecutionPlan` when:
+
+- the provider or layer should change across retry phases
+- retries are tied to alternative resources, not just delays
+- fallback is part of dependency provisioning strategy
+
+## Recommended Patterns
+
+### Pattern: simple bounded retry
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+### Pattern: retryable-error backoff
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: retryPolicy,
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+### Pattern: fallback across providers
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: PrimaryLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: SecondaryLayer,
+    attempts: 3,
+    schedule: Schedule.exponential(500, 1.5)
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+## Anti-Patterns
+
+- hand-writing retry recursion instead of using `Effect.retry`
+- embedding sleep and counters directly in business logic
+- using `ExecutionPlan` when a simple `Schedule` is enough
+- encoding provider fallback as a maze of nested `catch` branches
+- retrying indiscriminately without checking whether the failure is actually retryable
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`

--- a/.agents/skills/effect-ts/references/guide-schedule.md
+++ b/.agents/skills/effect-ts/references/guide-schedule.md
@@ -1,0 +1,379 @@
+# Schedule Guide
+
+This guide is based on the vendored `Schedule` module and its usage across `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+`Schedule` is the standard Effect abstraction for:
+
+- retries
+- repeats
+- polling
+- backoff
+- cadence and timing policies
+
+A schedule describes when the next step should happen and when execution should stop.
+
+The repo uses schedules heavily for:
+
+- retry policies
+- recurring work
+- time-window alignment
+- cron-based triggering
+- bounded flaky test retries
+
+## Preferred Rule
+
+When the timing behavior of an effect matters, prefer expressing it with `Schedule` rather than ad hoc loops, counters, sleeps, or manual retry recursion.
+
+Prefer:
+
+- `Effect.retry(schedule)`
+- `Effect.repeat(schedule)`
+- `Effect.schedule(schedule)`
+- `Stream.fromSchedule(schedule)`
+
+Over:
+
+- custom retry loops with mutable counters
+- `Effect.forever` plus hand-written `Effect.sleep`
+- manual backoff code scattered across business logic
+
+## Common Repo Patterns
+
+The most common patterns in the vendored repo are:
+
+1. `Schedule.recurs(n)` for bounded retries or repeats
+2. `Schedule.spaced(...)` for simple fixed spacing
+3. `Schedule.fixed(...)` or `Schedule.windowed(...)` for interval-aligned work
+4. `Schedule.exponential(...)` for backoff
+5. `Schedule.either(...)` or sequencing combinators to combine retry policies
+6. `Schedule.while(...)` to stop based on metadata or input
+7. `Schedule.addDelay(...)` for custom backoff logic
+8. `Schedule.jittered(...)` to avoid retry stampedes
+
+## Retry Vs Repeat
+
+Use schedules with the right operator:
+
+- `Effect.retry(schedule)` for failures
+- `Effect.repeat(schedule)` for successes
+- `Effect.schedule(schedule)` when you want to delay/reschedule an effect directly
+
+Good rule of thumb:
+
+- failing workflow: `retry`
+- recurring successful workflow: `repeat`
+- one effect that should run on a cadence: `schedule`
+
+## Core Constructors
+
+### `Schedule.recurs`
+
+Use `recurs(n)` for a bounded number of additional runs.
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+This is one of the most common repo retry policies.
+
+### `Schedule.forever`
+
+Use `forever` when the schedule should never terminate on its own.
+
+```ts
+const retryForever = Schedule.forever
+```
+
+This is common in infrastructure code and long-running retry loops.
+
+### `Schedule.spaced`
+
+Use `spaced(duration)` for simple constant spacing.
+
+```ts
+const pollEverySecond = Schedule.spaced("1 second")
+```
+
+This is the most straightforward schedule for polling or retry spacing.
+
+### `Schedule.fixed`
+
+Use `fixed(duration)` when work should align to fixed interval boundaries.
+
+The tests show that this differs from simple spacing when the action itself takes time.
+
+Use it when interval alignment matters more than naïve spacing.
+
+### `Schedule.windowed`
+
+Use `windowed(duration)` when you want delays to align to the nearest window boundary.
+
+This is useful for periodic flush or batching behavior.
+
+### `Schedule.duration`
+
+Use `duration(duration)` for a one-shot delay schedule.
+
+```ts
+const onceAfterOneSecond = Schedule.duration("1 second")
+```
+
+### `Schedule.cron`
+
+Use `cron(...)` for calendar-based scheduling.
+
+The module tests cover:
+
+- minute-level cron
+- second-level cron
+- calendar matching for specific weekdays and month days
+
+Use this for:
+
+- jobs that should follow wall-clock time
+- operational schedules
+- calendar-driven execution
+
+## Backoff Patterns
+
+### `Schedule.exponential`
+
+Use `exponential(base, factor)` for retry backoff.
+
+This is a dominant repo pattern.
+
+Examples from production code:
+
+- `WorkflowEngine`
+- `RpcClient`
+- persistence and eventlog modules
+
+Typical pattern:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5)
+```
+
+Use this for:
+
+- network retries
+- external system retries
+- contention or lock retries
+
+### Combine exponential with a cap or fallback spacing
+
+The repo often combines exponential backoff with a more stable spaced fallback using `Schedule.either(...)`.
+
+Example pattern from production modules:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This keeps early retries responsive without letting delays grow without bound.
+
+### `Schedule.jittered`
+
+Use `jittered(...)` to randomize timing within safe bounds.
+
+The module tests verify jittered delays remain within a bounded percentage of the original schedule.
+
+Use it when:
+
+- many workers or clients may retry at once
+- you want to avoid synchronized retry storms
+- the system would suffer from coordinated polling spikes
+
+## Combinators
+
+### `Schedule.while`
+
+Use `while(...)` to continue only while a predicate on schedule metadata holds.
+
+The repo uses this for:
+
+- stopping after a number of attempts
+- filtering retries based on the input error or cause
+- bounding retry windows by elapsed time
+
+Example pattern:
+
+```ts
+const bounded = Schedule.spaced("1 second").pipe(
+  Schedule.while(({ attempt }) => Effect.succeed(attempt <= 5))
+)
+```
+
+### `Schedule.andThenResult`
+
+Use `andThenResult(left, right)` when one schedule should run to completion and then another should take over.
+
+The module tests show this clearly.
+
+Use this when:
+
+- you want an initial aggressive policy followed by a slower steady-state policy
+- you want phase-based retry or repeat timing
+
+### `Schedule.either`
+
+Use `either` to combine two schedules so both policies influence the resulting timing.
+
+This appears frequently in repo retry policies that combine exponential growth with a stable fallback cadence.
+
+### `Schedule.addDelay`
+
+Use `addDelay` when the delay should depend on the schedule input or output.
+
+This is a strong fit for custom retry behavior based on the actual error.
+
+The OTLP exporter uses this style to honor `retry-after` behavior and otherwise fall back to a default delay.
+
+Example shape:
+
+```ts
+const policy = Schedule.forever.pipe(
+  Schedule.addDelay((error) =>
+    Effect.succeed("1 second")
+  )
+)
+```
+
+Use this when:
+
+- the delay should depend on the error
+- upstream metadata such as rate-limit headers matters
+- you need custom backoff without leaving the Schedule model
+
+## Metadata
+
+Schedules expose rich metadata including:
+
+- input
+- attempt count
+- start time
+- current time
+- elapsed time
+- elapsed since previous run
+- output
+- duration
+
+This is one of the reasons schedules are better than ad hoc retry loops.
+
+Use metadata when:
+
+- retry behavior depends on the input error
+- stop conditions depend on elapsed time
+- you want to log or collect retry state
+
+## Collection And Inspection Helpers
+
+The module tests highlight several useful helpers:
+
+- `Schedule.collectInputs(...)`
+- `Schedule.collectOutputs(...)`
+- `Schedule.collectWhile(...)`
+- `Schedule.delays(...)`
+- `Schedule.reduce(...)`
+
+Use these when:
+
+- you need to inspect or test a schedule
+- you want to accumulate state across schedule steps
+- you are building a more specialized scheduling policy
+
+These are especially useful in tests and low-level policy construction.
+
+## Typical Policies
+
+### Simple bounded retry
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+### Spaced polling
+
+```ts
+const pollPolicy = Schedule.spaced("5 seconds")
+```
+
+### Exponential retry with a stable fallback cadence
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced("5 seconds"))
+)
+```
+
+### Retry forever with custom delay logic
+
+```ts
+const retryPolicy = Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+### Cron-driven recurring job
+
+```ts
+const nightly = Schedule.cron("0 0 * * *")
+```
+
+## Testing Schedules
+
+The repo tests schedules with `TestClock` and controlled stepping.
+
+Preferred pattern:
+
+- use `TestClock`
+- advance time explicitly
+- inspect emitted delays or outputs
+
+This keeps schedule tests deterministic.
+
+The module tests also use helpers built on `Schedule.toStepWithSleep(...)` to inspect schedule behavior precisely.
+
+## Best Practices
+
+1. Prefer `Schedule` over ad hoc retry loops.
+2. Prefer `Schedule.recurs(...)` for simple bounded retries.
+3. Prefer `Schedule.exponential(...)` for backoff.
+4. Prefer `Schedule.either(...)` or sequencing combinators to compose retry phases.
+5. Prefer `Schedule.addDelay(...)` when delay depends on the actual error.
+6. Prefer `Schedule.jittered(...)` for distributed retry behavior.
+7. Prefer metadata-driven stop conditions over mutable counters.
+8. Prefer testing schedules with `TestClock`.
+
+## Anti-Patterns
+
+- hand-writing retry loops with mutable counters and sleeps
+- putting backoff logic directly in business code instead of in a schedule
+- using `Effect.forever` with embedded `sleep` as a substitute for a schedule
+- scattering retry timing logic across many call sites
+- ignoring jitter when many clients or workers retry concurrently
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`

--- a/.agents/skills/effect-ts/references/guide-schema.md
+++ b/.agents/skills/effect-ts/references/guide-schema.md
@@ -1,0 +1,624 @@
+# Schema Guide
+
+This guide is based on the vendored Schema module and common repo usage in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/SchemaTransformation.ts`
+- `./.repos/effect/packages/effect/src/SchemaGetter.ts`
+- `./.repos/effect/packages/effect/src/SchemaIssue.ts`
+- `./.repos/effect/packages/effect/src/JsonSchema.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/`
+
+## Mental Model
+
+Schema is the standard way to:
+
+- define data shapes
+- validate unknown input
+- encode typed values back to serialized form
+- transform between encoded and decoded representations
+- attach metadata and constraints
+
+The repo uses Schema pervasively for:
+
+- protocol payloads
+- configuration
+- HTTP and RPC contracts
+- database row decoding
+- error types
+- derived tooling such as JSON Schema and arbitrary generation
+
+## Preferred Rule
+
+Prefer Schema-based types whenever data crosses a boundary or should be validated, transformed, documented, or encoded.
+
+Typical boundaries:
+
+- HTTP requests and responses
+- RPC payloads
+- database rows
+- config files
+- worker messages
+- persisted data
+- domain errors
+
+## What A Schema Actually Is
+
+A schema is not just a static shape.
+
+It is a contract between:
+
+- the decoded in-memory value you want to work with
+- the encoded representation that comes from or goes to some boundary
+
+This is the most important thing many implementations get wrong.
+
+Do not think of Schema as “a typed struct definition.”
+Think of it as:
+
+- validation
+- decoding
+- encoding
+- transformation
+- metadata
+- reuse across boundaries
+
+Because of that, schemas should not be duplicated unless there is a real semantic difference.
+
+If two schemas describe the same logical model but differ only because one boundary encodes a field differently, prefer one schema with transformations instead of two parallel schemas.
+
+## Avoid Duplicating Schemas
+
+Do not create multiple parallel schemas for the same logical entity unless they truly represent different models.
+
+Bad pattern:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const TodoSql = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.BooleanFromBit
+})
+```
+
+This is usually a sign that transformations are not being used properly.
+
+If the model is still “Todo”, do not define a second schema just because one boundary stores `completed` as a bit.
+
+Prefer deriving or transforming the representation instead.
+
+Why duplication is bad:
+
+- the same model is now maintained in multiple places
+- fields drift over time
+- boundary logic gets copied instead of centralized
+- refactors become error-prone
+
+Only duplicate schemas when there is a real semantic difference, for example:
+
+- a creation payload really is a different model from a persisted entity
+- a public API contract intentionally differs from an internal domain model
+- a projection or partial view is intentionally a different type
+
+If the difference is only encoding, use a transformation.
+
+## Prefer `Class` Variants Over `Struct` Variants When Possible
+
+When a schema represents a named domain model, reusable payload, or long-lived API shape, prefer `Schema.Class`, `Schema.TaggedClass`, or `Schema.TaggedErrorClass` over a bare `Schema.Struct`.
+
+Prefer:
+
+```ts
+import { Schema } from "effect"
+
+export class User extends Schema.Class<User>("User")({
+  id: Schema.String,
+  name: Schema.String
+}) {}
+```
+
+Over:
+
+```ts
+import { Schema } from "effect"
+
+export const User = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String
+})
+```
+
+Why `Class` variants are usually better:
+
+- the schema has a stable, named identity
+- reusable models are easier to recognize in code and traces
+- constructors and validation are packaged together
+- extension patterns are clearer
+- named schemas read better in contracts and tooling output
+
+Use `Struct` when:
+
+- the shape is local and anonymous
+- it is a small inline request or response shape
+- introducing a class would add unnecessary ceremony
+- the schema is primarily a one-off composition fragment
+
+Good rule of thumb:
+
+- reusable named model: `Class`
+- reusable tagged union member: `TaggedClass`
+- reusable error payload: `TaggedErrorClass`
+- small inline object shape: `Struct`
+
+## One Logical Model, Multiple Representations
+
+The right Schema mindset is:
+
+- one logical model
+- multiple encoded forms when needed
+- transformations connecting them
+
+For example, a `Todo` may be:
+
+- a boolean in memory
+- a bit in SQL
+- a string in some external API
+
+That does not automatically mean you need three separate top-level schemas.
+
+Prefer:
+
+- one main schema for the logical model
+- transformed field schemas or transformed object schemas for boundary-specific encoding
+- derived request/result schemas when the shape is actually different
+
+## Common Schema Building Blocks
+
+Common primitives and collections used throughout the repo:
+
+- `Schema.String`
+- `Schema.Number`
+- `Schema.Boolean`
+- `Schema.BigInt`
+- `Schema.Array(...)`
+- `Schema.Record(key, value)`
+- `Schema.Tuple([...])`
+- `Schema.Struct({...})`
+- `Schema.Union([...])`
+
+Example:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+```
+
+## `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+### `Schema.Class`
+
+Use for named reusable schema-backed models.
+
+```ts
+class Product extends Schema.Class<Product>("Product")({
+  id: Schema.String,
+  price: Schema.Number
+}) {}
+```
+
+### Constructor Rule
+
+When constructing schema classes, prefer `X.make(...)` over `new X(...)`.
+
+Prefer:
+
+```ts
+const todo = Todo.make({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Over:
+
+```ts
+const todo = new Todo({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Why:
+
+- it is the intended schema-class construction style
+- it makes schema-backed construction explicit
+- it keeps the codebase consistent
+- it reads better across `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+Use this rule consistently for:
+
+- `Schema.Class`
+- `Schema.TaggedClass`
+- `Schema.TaggedErrorClass`
+
+### `Schema.TaggedClass`
+
+Use for members of tagged unions.
+
+```ts
+class Circle extends Schema.TaggedClass<Circle>()("Circle", {
+  radius: Schema.Number
+}) {}
+
+class Rectangle extends Schema.TaggedClass<Rectangle>()("Rectangle", {
+  width: Schema.Number,
+  height: Schema.Number
+}) {}
+```
+
+### `Schema.TaggedErrorClass`
+
+Use for schema-backed typed errors.
+
+```ts
+class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  id: Schema.String
+}) {}
+```
+
+## Optional Fields
+
+Be precise about optionality.
+
+Important rule from the vendored docs:
+
+- `Schema.optional(schema)` means `T | undefined`
+- `Schema.optionalKey(schema)` means an exact optional property in a struct
+
+Prefer `optionalKey` for object fields.
+
+Prefer:
+
+```ts
+const Query = Schema.Struct({
+  search: Schema.optionalKey(Schema.String)
+})
+```
+
+Use `optional` when the value itself should be `A | undefined`, not just an omitted field.
+
+## Unions
+
+Use `Schema.Union([...])` for ordinary unions.
+
+```ts
+const Id = Schema.Union([
+  Schema.String,
+  Schema.Number
+])
+```
+
+Prefer tagged unions for domain variants.
+
+```ts
+class Created extends Schema.TaggedClass<Created>()("Created", {
+  id: Schema.String
+}) {}
+
+class Deleted extends Schema.TaggedClass<Deleted>()("Deleted", {
+  id: Schema.String
+}) {}
+
+const TodoEvent = Schema.Union([Created, Deleted])
+```
+
+Why:
+
+- decoding and branching are clearer
+- `_tag`-based matching aligns with Effect code style
+
+## Recursive Schemas
+
+Use `Schema.suspend` for recursive schemas.
+
+```ts
+type Tree = {
+  readonly name: string
+  readonly children: ReadonlyArray<Tree>
+}
+
+const Tree: Schema.Schema<Tree> = Schema.Struct({
+  name: Schema.String,
+  children: Schema.Array(Schema.suspend((): Schema.Schema<Tree> => Tree))
+})
+```
+
+Use it whenever a schema refers to itself, directly or indirectly.
+
+Without `suspend`, recursive definitions will not work correctly.
+
+## Transformations
+
+Transformations are one of the most important Schema features.
+
+Use them when decoded and encoded shapes differ.
+
+This is the main tool that avoids needless schema duplication.
+
+If your instinct is “I need another schema because this boundary encodes the same value differently”, stop and first ask whether this should be one schema with a transformation instead.
+
+### `Schema.decodeTo`
+
+Use `decodeTo` when you want one schema to decode into another schema's type.
+
+```ts
+const TrimmedString = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: (value) => value.trim(),
+    encode: (value) => value
+  })
+)
+```
+
+The vendored docs explicitly note that `decodeTo` is curried and should be used with `pipe`.
+
+### `Schema.encodeTo`
+
+Use `encodeTo` when the reverse direction reads more clearly.
+
+### `SchemaTransformation.transformOrFail`
+
+Use `transformOrFail` when the transformation itself is effectful or may fail.
+
+```ts
+import * as Effect from "effect/Effect"
+import * as SchemaTransformation from "effect/SchemaTransformation"
+
+const VerifiedString = Schema.String.pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transformOrFail({
+      decode: (value) => Effect.succeed(value.trim()),
+      encode: (value) => Effect.succeed(value)
+    })
+  )
+)
+```
+
+Use this when:
+
+- validation depends on services or effects
+- decoding can fail with structured issues
+- encoding also needs logic beyond identity
+
+## Field-Level Transformations
+
+Very often, the right answer is not a second object schema but a transformed field schema.
+
+Example shape:
+
+```ts
+const Completed = Schema.BooleanFromBit
+
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Completed
+})
+```
+
+In this pattern:
+
+- the logical model still has `completed: boolean`
+- the encoded SQL-facing representation can still be a bit
+- the transformation lives at the field where it belongs
+
+This is usually better than defining `Todo` and `TodoSql` as separate object schemas.
+
+## Object-Level Transformations
+
+Use object-level transformations when the whole object encoding differs, not just one field.
+
+Good use cases:
+
+- external keys differ from internal keys
+- several fields need coordinated transformation
+- the encoded shape is a structurally different representation of the same model
+
+Still prefer a single logical schema plus a transformation pipeline over maintaining multiple duplicated top-level schemas.
+
+## Rename Keys
+
+Schema supports key renaming through struct transformations.
+
+The vendored `Schema.ts` implements key renaming by mapping fields and using decode/encode transformations with renamed key maps.
+
+Use key renaming when:
+
+- external payload keys differ from internal keys
+- you want stable internal names while honoring external contract names
+
+Preferred pattern:
+
+- keep the internal decoded shape idiomatic
+- use schema-level transformation or field-mapping to adapt external keys
+
+This is another example of avoiding duplication. If the only difference is key naming, do not define a second schema just to rename fields manually later.
+
+In practice, use struct field mapping helpers and transformation composition rather than manual post-parse object rewriting.
+
+## Opaque And Branded Types
+
+Use opaque or branded schemas when a value should stay distinct from its structural base type.
+
+### `Schema.brand`
+
+Use `brand` for refined nominal distinctions.
+
+```ts
+const UserId = Schema.String.pipe(
+  Schema.brand("UserId")
+)
+```
+
+This is useful for:
+
+- IDs
+- validated domain scalars
+- preventing accidental interchange of same-shaped values
+
+### `Schema.Opaque`
+
+Use `Opaque` when you want an opaque schema-backed type with the same structure as its underlying schema.
+
+This is especially useful when the type should remain distinct at the type level without changing its runtime shape.
+
+## Picking, Omitting, Partial Shapes, And Mutability
+
+Common struct operations include:
+
+- `pick`
+- `omit`
+- `partial`
+- `mutable`
+
+Use them to derive variations instead of redefining near-identical schemas manually.
+
+Good examples:
+
+- request subset from a domain model
+- patch/update payloads
+- mutable representations for specific adapters
+
+Prefer deriving from one source schema rather than maintaining parallel copies.
+
+This is the second major tool for avoiding duplication:
+
+- use transformations when encoded and decoded representations differ
+- use derivation when one schema is a subset, superset, or variation of another
+
+## Constraints And Validation
+
+Use schema checks and filters for validation.
+
+Examples from the module docs include:
+
+- `isMinLength`
+- `isGreaterThan`
+- `isPattern`
+- `isUUID`
+
+Attach them with `.check(...)`.
+
+Use this when:
+
+- the validation is intrinsic to the schema
+- the rule belongs to the data contract
+
+For business-rule validation that depends on services or current state, prefer effectful logic outside the schema or use effectful transformations.
+
+## Decoding And Encoding
+
+Common operations:
+
+- `Schema.decodeUnknownSync`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownSync`
+- `Schema.encodeUnknownEffect`
+
+Preferred rule:
+
+- use `decodeUnknownEffect` and `encodeUnknownEffect` in Effect code
+- avoid throwing sync decode APIs in application flows unless you are intentionally at a sync boundary
+
+Good pattern:
+
+```ts
+const decodeUser = Schema.decodeUnknownEffect(User)
+```
+
+## Schema Metadata And Derived Tooling
+
+Schema is also used for:
+
+- annotations and documentation metadata
+- JSON Schema generation
+- arbitrary generation for tests
+- derived equivalence
+
+Useful operations from the module docs:
+
+- `.annotate(...)`
+- `Schema.toJsonSchemaDocument(...)`
+- `Schema.toArbitrary(...)`
+- `Schema.toEquivalence(...)`
+
+Use annotations when the schema participates in:
+
+- API docs
+- codegen
+- contract generation
+
+## Common Repo Patterns
+
+Patterns visible in the vendored repo:
+
+- `Schema.Class` for named reusable contract types
+- `Schema.Struct` for inline shapes and anonymous fragments
+- `Schema.Union` for alternative payloads
+- `Schema.optionalKey` for request/query/body optional fields
+- `Schema.suspend` for recursive generated schemas
+- `Schema.decodeTo` and `transformOrFail` for non-trivial decode/encode logic
+- `Schema.TaggedErrorClass` for typed error payloads
+
+## Best Practices
+
+1. Prefer `Class` variants over plain `Struct` for named reusable schemas.
+2. Prefer tagged variants for unions and errors.
+3. Prefer `optionalKey` for optional object properties.
+4. Do not duplicate schemas unless there is a real semantic difference.
+5. Prefer schema-level transformations over ad hoc post-parse object rewriting.
+6. Prefer deriving schema variants with `pick`, `omit`, `partial`, and `mutable` instead of duplicating definitions.
+7. Prefer field-level transformations when only a field encoding differs.
+8. Prefer branded or opaque types for important domain identifiers.
+9. Prefer `decodeUnknownEffect` in application code.
+10. Keep internal decoded shapes idiomatic and use schema transforms for external representation differences.
+
+## Anti-Patterns
+
+- using plain `Struct` for every reusable domain model even when `Class` would give a clearer named type
+- duplicating whole schemas when only one field encoding differs
+- creating `Foo` and `FooSql` schemas for the same logical model when a transformation would do
+- using `optional` when you actually want an optional key
+- duplicating near-identical schemas instead of deriving variants
+- rewriting keys manually after decode instead of using schema transformations
+- hand-validating external data after decode when the constraint belongs in the schema
+- exposing unvalidated external payloads deep into business logic
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`

--- a/.agents/skills/effect-ts/references/guide-sql.md
+++ b/.agents/skills/effect-ts/references/guide-sql.md
@@ -1,0 +1,536 @@
+# SQL Guide
+
+This guide is based on the vendored Effect SQL modules in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Preferred Rule
+
+When a project uses Effect, prefer the Effect SQL modules over directly coupling business code to a native SQL driver API.
+
+Prefer:
+
+- `effect/unstable/sql/SqlClient`
+- `effect/unstable/sql/Migrator`
+- `effect/unstable/sql/SqlResolver`
+- `effect/unstable/sql/SqlSchema`
+- `effect/unstable/sql/SqlModel`
+
+Over:
+
+- embedding raw driver calls directly in business services
+- hand-rolling transactions in service methods
+- ad hoc migration scripts disconnected from the Effect runtime
+
+Why:
+
+- transactions are integrated into the Effect model
+- spans and SQL observability are built in
+- SQL errors stay typed and consistent
+- schema decoding and request resolution compose better
+- layers and services stay portable across runtimes and tests
+
+## Mental Model
+
+The Effect SQL stack is organized around:
+
+- `SqlClient` as the main database capability
+- `withTransaction` for transaction boundaries
+- `SqlResolver` for request-style batched and validated access
+- `SqlSchema` and `SqlModel` for schema-aware query/model patterns
+- `Migrator` for managed migrations
+
+The business layer should depend on Effect SQL abstractions, not on a raw driver object.
+
+## `SqlClient`
+
+`SqlClient` is the primary service for executing SQL.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Use it when:
+
+- you need to execute queries
+- you need transactions
+- you want SQL operations to participate in Effect spans and context
+
+Important capabilities from the repo:
+
+- transaction support with `withTransaction`
+- connection reservation with `reserve`
+- reactive queries
+- integration with transaction-scoped context
+
+## Typed Queries
+
+Prefer typed SQL queries instead of leaving row shapes implicit.
+
+The repo uses typed query literals like:
+
+```ts
+const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM test`
+```
+
+This is the first level of typed SQL usage and is already better than untyped row access.
+
+Use typed query literals when:
+
+- the row shape is small and obvious
+- the query is local and does not justify a reusable schema
+- you want immediate row typing without introducing extra helpers
+
+Avoid:
+
+- leaving query results untyped and then recovering shape with unsafe assertions
+- using `as` on rows after query execution
+
+## Schema Integration
+
+Prefer integrating SQL with Schema whenever the row shape matters or the query result crosses a meaningful boundary.
+
+Why:
+
+- Schema validates the shape rather than trusting the database blindly
+- row decoding stays explicit and typed
+- the same schema can often be reused for transport, domain, or contract layers
+- this avoids unsafe row assertions such as `as TodoRow`
+
+### Prefer schema-decoded results over `as`-based rows
+
+Avoid this pattern:
+
+```ts
+const row = yield* sql`SELECT id, title FROM todos WHERE id = ${id}`
+const todo = row[0] as TodoRow
+```
+
+Prefer:
+
+- a typed SQL query plus Schema decoding
+- or a SQL helper such as `SqlResolver`, `SqlSchema`, or `SqlModel` when appropriate
+
+Example boundary decode:
+
+```ts
+const TodoRow = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const decodeTodoRows = Schema.decodeUnknownEffect(Schema.Array(TodoRow))
+```
+
+Then keep the query and decoding together in one SQL-aware operation.
+
+### `SqlResolver` + Schema
+
+`SqlResolver` is one of the clearest examples of SQL and Schema integration in the vendored repo.
+
+It uses:
+
+- a `Request` schema for validating resolver input
+- a `Result` schema for validating query output
+
+Example shape from the repo tests:
+
+```ts
+const resolver = SqlResolver.findById({
+  Id: Schema.Number,
+  Result: Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+  }),
+  ResultId: (row) => row.id,
+  execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
+})
+```
+
+This is a preferred pattern when:
+
+- multiple IDs are fetched together
+- request batching is useful
+- the query contract should be schema-validated
+
+### `SqlSchema` and `SqlModel`
+
+Use `SqlSchema` and `SqlModel` when you want tighter schema integration with SQL itself.
+
+They are preferred over hand-written row types when:
+
+- the row shape is central to the module
+- you want reusable schema-aware model logic
+- manual row mapping is becoming repetitive
+
+## Prefer SQL Services Over Native Driver Services
+
+Avoid this pattern:
+
+```ts
+class TodoService extends Context.Service<TodoService, { ... }>()("TodoService") {
+  static readonly layer = Layer.effect(this)(
+    Effect.acquireRelease(
+      Effect.try({ try: () => new Database("todos.sqlite") })
+    )
+  )
+}
+```
+
+Why this is usually a bad pattern in an Effect codebase:
+
+- the service is now tightly coupled to one runtime-specific database client
+- you lose the shared SQL abstraction that the Effect repo already provides
+- transaction and query conventions become ad hoc
+- it is easier to drift away from typed SQL errors, SQL tracing, and reusable query helpers
+
+Prefer a layer that provides `SqlClient`, and let domain services depend on that.
+
+## Domain Services Should Depend On `SqlClient`
+
+Good pattern:
+
+```ts
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+
+class TodoRepo extends Context.Service<TodoRepo>()("TodoRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("TodoRepo.getById")(function*(id: number) {
+      const sql = yield* SqlClient.SqlClient
+      return yield* sql`SELECT id, title, completed FROM todos WHERE id = ${id}`
+    })
+  })
+}) {}
+```
+
+Why this is better:
+
+- the domain service depends on an Effect SQL capability
+- SQL stays observable and transactional
+- the SQL client implementation can be provided separately from the business service
+
+## Transactions
+
+Use `SqlClient.withTransaction` for transaction boundaries.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Prefer:
+
+```ts
+const createAndAudit = Effect.fn("TodoRepo.createAndAudit")(function*(title: string) {
+  const sql = yield* SqlClient.SqlClient
+
+  return yield* sql.withTransaction(
+    Effect.gen(function*() {
+      yield* sql`INSERT INTO todos ${sql.insert({ title, completed: false })}`
+      yield* sql`INSERT INTO audit_log ${sql.insert({ event: "todo_created" })}`
+    })
+  )
+})
+```
+
+Avoid:
+
+- manual `BEGIN` / `COMMIT` / `ROLLBACK` in application service code
+- driver-specific transaction logic spread across multiple service methods
+
+## Query Composition
+
+Prefer keeping query logic inside SQL-aware services or repositories.
+
+Good patterns:
+
+- keep queries close to the service that owns the behavior
+- use named business operations for multi-step workflows
+- use small local helpers only when they improve clarity
+
+Avoid exposing one exported accessor function per SQL service method if it only forwards to the service.
+
+Bad:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoRepo
+  return yield* todos.create(title)
+})
+```
+
+Prefer:
+
+- use the service method directly within the owning workflow
+- or export a real business operation that adds behavior beyond simple forwarding
+
+## SQL Resolvers
+
+Use `SqlResolver` when request-style batching or schema-validated request/response handling is useful.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+
+It is especially good for:
+
+- batched lookup patterns
+- `findById`-style resolvers
+- grouped query resolution
+- integrating SQL with request batching patterns
+
+Important repo pattern:
+
+- request schema validates inputs
+- result schema validates outputs
+- execution remains effectful and transactional
+
+This is one of the strongest typed-query patterns in the repo and should be preferred over ad hoc batched row mapping when the query fits the resolver model.
+
+## SQL Schemas And Models
+
+When schema-aware SQL helpers fit the task, prefer them over hand-mapped rows.
+
+Look at:
+
+- `SqlSchema`
+- `SqlModel`
+
+These are good fits when:
+
+- the row shape matters strongly
+- schema-based decode/encode should stay aligned with database access
+- you want to reduce ad hoc row mapping logic
+
+Avoid overusing manual `type Row = { ... }` plus custom conversion if the schema-aware modules already express the shape clearly.
+
+Preferred order for query typing:
+
+1. schema-aware SQL module such as `SqlResolver`, `SqlSchema`, or `SqlModel` when it fits
+2. typed query literals plus Schema decoding when the query is local
+3. only use manual row mapping when the first two options are clearly heavier than the problem
+
+## Migrations
+
+Use `Migrator` for migrations.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+
+The repo shows these best practices:
+
+- maintain a dedicated migrations table
+- load migrations through a managed loader
+- run migrations through the Effect runtime
+- keep migration execution observable with logs and spans
+- use SQL client transaction and locking semantics handled by the migrator
+
+Important behavior in the vendored repo:
+
+- migrations table creation is dialect-aware
+- duplicate migration IDs are detected
+- concurrent migration runs are guarded
+- each migration is logged and wrapped in a span
+
+### Concrete Migration Loader Example
+
+The runtime-specific SQL migrator packages expose `fromRecord(...)` to define migrations from an ordered record.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+import * as Effect from "effect/Effect"
+
+const migrations = SqliteMigrator.fromRecord({
+  "1_create_todos": Effect.gen(function*() {
+    yield* sql`
+      CREATE TABLE todos (
+        id INTEGER PRIMARY KEY NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0
+      )
+    `.withoutTransform
+  }),
+  "2_add_todo_index": Effect.gen(function*() {
+    yield* sql`
+      CREATE INDEX todos_completed_idx ON todos (completed)
+    `.withoutTransform
+  })
+})
+```
+
+This matches the model used by the vendored migrator implementation:
+
+- each migration has a numeric prefix and descriptive name
+- each migration resolves to an `Effect`
+- migrations are ordered by ID
+
+### Running Migrations Directly
+
+Use the runtime-specific `run(...)` helper when you want a startup effect that runs migrations explicitly.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const runMigrations = SqliteMigrator.run({
+  loader: migrations
+})
+```
+
+This is a good fit when:
+
+- startup explicitly runs migrations before launching the main app
+- deployment tooling runs migrations as a separate command
+- you want migration results as an ordinary `Effect`
+
+The return value includes the applied migration IDs and names.
+
+### Running Migrations As A Layer
+
+Use the runtime-specific `layer(...)` helper when migrations should run as part of top-level infrastructure setup.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+```
+
+From the vendored packages, this is implemented as `Layer.effectDiscard(run(options))`.
+
+That means:
+
+- the layer performs the migration effect
+- it does not provide a new service of its own
+- it is intended to be composed into startup infrastructure
+
+### Concrete Startup Composition Example
+
+Preferred shape:
+
+```ts
+const SqlLayer = SqliteClient.layer({ filename: "todos.sqlite" })
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+
+const MigratedSqlLayer = Layer.merge(
+  SqlLayer,
+  MigrationLayer.pipe(Layer.provide(SqlLayer))
+)
+```
+
+This keeps the structure explicit:
+
+- one layer provides the SQL client
+- one layer runs migrations
+- the merged layer represents a migrated SQL environment
+
+If the same migrated SQL environment is reused in tests, create it once and reuse the layer value.
+
+### Migration Best Practices
+
+- use stable numeric migration IDs
+- keep migration files ordered and unique
+- do not hand-roll a separate migrations subsystem if `Migrator` already fits the project
+- keep migration execution at startup or a dedicated operational boundary
+- do not bury migration execution inside arbitrary service construction unless startup is explicitly the right place
+
+### Preferred Migration Boundary
+
+Good pattern:
+
+- construct the SQL layer
+- run migrations once at startup or deployment entry
+- then run the main application
+
+Concrete shapes:
+
+- separate startup effect: `SqliteMigrator.run({ loader })`
+- startup layer: `SqliteMigrator.layer({ loader })`
+- migrated environment layer: merge the SQL client layer with the migration layer provided by that client layer
+
+Avoid:
+
+- opportunistic migrations inside ordinary request handlers
+- schema creation hidden inside unrelated business service constructors
+
+## Errors
+
+Prefer SQL errors that stay inside the Effect SQL model as long as possible.
+
+Use domain-level translation only where it helps the business boundary.
+
+Good:
+
+- SQL layer or repository works with `SqlError` and schema decode failures where appropriate
+- higher-level service translates expected cases into domain errors when needed
+
+Avoid:
+
+- converting every SQL error immediately into a string
+- hiding SQL failure details too early
+
+## Observability
+
+The vendored SQL modules already integrate with spans and transaction context.
+
+This is another reason to prefer them over raw driver usage.
+
+Good pattern:
+
+- use `SqlClient` and `withTransaction`
+- keep business operations wrapped with `Effect.fn`
+- add explicit spans only where business-level detail matters beyond the built-in SQL spans
+
+## Layering Pattern
+
+Preferred layering shape:
+
+1. runtime-specific database layer provides `SqlClient`
+2. migrations run at startup boundary
+3. domain repository/service depends on `SqlClient`
+4. top-level application layer composes the database layer with the business layers
+
+This keeps:
+
+- driver choice at the edge
+- SQL capability in the middle
+- business logic above it
+
+## Anti-Patterns
+
+- embedding a native driver directly in business services when Effect SQL modules are available
+- hand-rolling transactions with raw SQL statements in service methods
+- hiding schema creation inside unrelated service constructors
+- exporting one trivial accessor function per repository/service method
+- converting SQL errors to strings too early
+- bypassing `Migrator` when the project already uses Effect SQL
+- creating ad hoc migration effects without a stable loader shape when `fromRecord(...)` already fits the project
+- scattering migration execution across multiple subsystems instead of one explicit startup boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`

--- a/.agents/skills/effect-ts/references/guide-testing.md
+++ b/.agents/skills/effect-ts/references/guide-testing.md
@@ -1,0 +1,504 @@
+# Testing Guide
+
+This guide is based on the vendored `@effect/vitest` package in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`
+
+## Preferred Rule
+
+When testing Effect code with Vitest, prefer `@effect/vitest` over manually calling `Effect.runPromise`, `Effect.runSync`, or ad hoc runtime setup inside ordinary Vitest tests.
+
+Layer provisioning in tests should follow these rules:
+
+1. If multiple tests should share the same layered setup, use `layer(...)`.
+2. If a nested group needs extra dependencies, use `it.layer(...)`.
+3. If tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls.
+4. Do not default to local `.pipe(Effect.provide(...))` inside test bodies.
+
+Use:
+
+- `it.effect` for Effect-based tests with test services
+- `it.live` for Effect-based tests that should use live services
+- `layer(...)` and `it.layer(...)` for shared layered test setup
+- `it.effect.prop` for Effect-based property tests
+
+Do not default to `.pipe(Effect.provide(SomeLayer))` inside test bodies when `layer(...)` or `it.layer(...)` expresses the setup more clearly.
+
+## Imports
+
+Preferred imports for Effect tests:
+
+```ts
+import { assert, describe, it, layer } from "@effect/vitest"
+import { Effect } from "effect"
+```
+
+`@effect/vitest` re-exports Vitest, so it is the normal entrypoint for test APIs in an Effect codebase.
+
+## Core Test Modes
+
+## `it.effect`
+
+Use `it.effect` for most Effect tests.
+
+It automatically:
+
+- runs the effect
+- scopes it correctly
+- provides the default test environment
+
+The default test environment includes:
+
+- `TestConsole`
+- `TestClock`
+
+This comes directly from the internal implementation.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+it.effect("loads a user", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+    assert.isTrue(true)
+  })
+)
+```
+
+Use `it.effect` when:
+
+- the test uses ordinary Effect code
+- the test benefits from `TestClock`
+- the test benefits from `TestConsole`
+- the test should run in a scoped Effect runtime
+
+## `it.live`
+
+Use `it.live` when the test should use live services instead of the default test environment.
+
+Example:
+
+```ts
+it.live("uses live services", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+  })
+)
+```
+
+Use `it.live` when:
+
+- you need the real `Clock`
+- the test should interact with live runtime services
+- you deliberately do not want the test environment overrides
+
+Rule of thumb:
+
+- default: `it.effect`
+- opt into `it.live` only when you actually need live behavior
+
+## Effect Test Structure
+
+Preferred pattern:
+
+```ts
+it.effect("does something", () =>
+  Effect.gen(function*() {
+    const value = yield* someEffect
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+Prefer `Effect.gen` inside `it.effect` and `it.live` for readability.
+
+Avoid:
+
+- `it("...", async () => ...)` for Effect programs
+- `Effect.runPromise(...)` inside plain Vitest tests
+- manual runtime setup for routine Effect tests
+
+## Assertions
+
+Use `assert` for Effect tests.
+
+The vendored repo also uses `expect` in some tests, but for skill guidance prefer `assert` in Effect-based tests because it keeps tests more uniform and explicit inside Effect programs.
+
+Examples:
+
+```ts
+assert.isTrue(value === 1)
+assert.strictEqual(a + b, b + a)
+assert.include(text, substring)
+```
+
+## Test Context
+
+`it.effect` and `it.live` test functions can receive a Vitest `TestContext`.
+
+Example:
+
+```ts
+it.effect("uses context", (ctx) =>
+  Effect.gen(function*() {
+    ctx.onTestFailed(() => {
+      // cleanup or diagnostics
+    })
+  })
+)
+```
+
+Use this when you need:
+
+- failure hooks
+- abort signals
+- ordinary Vitest test context integration
+
+## `each`, `skip`, `skipIf`, `runIf`, `only`, `fails`
+
+The Effect testers support the standard test variants:
+
+- `it.effect.each(...)`
+- `it.live.each(...)`
+- `it.effect.skip(...)`
+- `it.effect.skipIf(...)`
+- `it.effect.runIf(...)`
+- `it.effect.only(...)`
+- `it.live.fails(...)`
+
+Examples from the vendored tests show these are first-class parts of the API.
+
+Use them exactly as you would with Vitest, but return `Effect` from the test body.
+
+## Property Testing
+
+There are two different property-test entrypoints and they do not have identical behavior.
+
+## Top-level `it.prop`
+
+Use `it.prop` for non-Effect property tests.
+
+Example:
+
+```ts
+import { it } from "@effect/vitest"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a)
+```
+
+Important limitation from the internal implementation:
+
+- top-level `it.prop` does not support `Schema` arbitraries yet
+- if you pass a `Schema`, it throws
+
+So use top-level `it.prop` only with explicit `FastCheck` arbitraries.
+
+## `it.effect.prop`
+
+Use `it.effect.prop` for property tests that return `Effect`.
+
+This is the more powerful property-testing mode for Effect code.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(a + b, b + a)
+  })
+)
+```
+
+Unlike top-level `it.prop`, `it.effect.prop` does support `Schema` inputs by converting them with `Schema.toArbitrary`.
+
+So prefer `it.effect.prop` when:
+
+- the property test needs `Effect`
+- you want to use `Schema` values as arbitraries
+- the test needs Effect services or scope
+
+## `layer(...)`
+
+Use top-level `layer(...)` to share a `Layer` across a group of tests.
+
+Hard rule:
+
+- use `layer(...)` when tests should share one layered setup
+- do not use it when each test needs its own isolated layer instance
+
+This is one of the most important `@effect/vitest` features.
+
+Example:
+
+```ts
+import { describe, it, layer } from "@effect/vitest"
+import { Context, Effect, Layer } from "effect"
+
+class Foo extends Context.Service<Foo, string>()("Foo") {
+  static readonly layer = Layer.succeed(Foo)("foo")
+}
+
+describe("foo", () => {
+  layer(Foo.layer)((it) => {
+    it.effect("gets foo", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        return foo
+      })
+    )
+  })
+})
+```
+
+What it does internally:
+
+- builds the layer once for the test group
+- memoizes the built layer with a `MemoMap`
+- keeps the scope open for the group
+- closes the scope in `afterAll`
+
+This makes it the preferred way to share layer setup across related tests.
+
+This is also the preferred alternative to calling `Effect.provide(...)` inside each individual test body.
+
+## Anti-Pattern: Local `Effect.provide(...)` In Tests
+
+If multiple tests use the same layer, do not write tests like this:
+
+```ts
+it.effect("creates and lists todos", () =>
+  Effect.gen(function*() {
+    const service = yield* TodoService
+    yield* service.create("write tests")
+    yield* service.create("ship feature")
+  }).pipe(
+    Effect.provide(TodoService.inMemoryLayer)
+  )
+)
+```
+
+Why this is the wrong pattern:
+
+- it repeats provisioning in every test
+- it hides the layered test setup inside each test body
+- it fights the `@effect/vitest` layer helpers
+- it makes shared setup and teardown less explicit
+- it bypasses the clearer grouped-layer style that the library is designed for
+
+Prefer:
+
+```ts
+describe("TodoService", () => {
+  layer(TodoService.inMemoryLayer)((it) => {
+    it.effect("creates and lists todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        yield* service.create("write tests")
+        yield* service.create("ship feature")
+      })
+    )
+
+    it.effect("updates completion and deletes todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const todo = yield* service.create("close issue")
+        yield* service.setCompleted(todo.id, true)
+        yield* service.remove(todo.id)
+      })
+    )
+  })
+})
+```
+
+Rule:
+
+- if a test or group of tests depends on a layer, prefer `layer(...)`
+- if a nested group needs extra dependencies, prefer `it.layer(...)`
+- if tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls
+- use local `Effect.provide(...)` in tests only for true one-off edge cases, not as the normal pattern
+
+This matches the general layer guidance: provisioning belongs at the boundary, and in `@effect/vitest` the test boundary should usually be expressed with `layer(...)` rather than ad hoc local provisioning.
+
+## `it.layer(...)`
+
+Use `it.layer(...)` inside an existing layered test group to add nested layer context.
+
+Hard rule:
+
+- use `it.layer(...)` when a specific test or nested test block should get its own isolated layered setup
+- if isolation matters, prefer multiple separate `it.layer(...)` calls over one shared `layer(...)` group
+
+Example:
+
+```ts
+layer(Foo.layer)((it) => {
+  it.layer(Bar.layer)("nested", (it) => {
+    it.effect("gets both", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        const bar = yield* Bar
+        return [foo, bar]
+      })
+    )
+  })
+})
+```
+
+Important behavior from the implementation:
+
+- nested `it.layer(...)` reuses the parent memo map
+- nested `it.layer(...)` does not accept `memoMap` or `excludeTestServices`
+- nested layering is meant to extend the current layered test environment, not redefine its runtime policy
+
+Use multiple `it.layer(...)` blocks when each test should get its own isolated layered setup instead of sharing one top-level `layer(...)` group.
+
+## `layer` Options
+
+The top-level `layer(...)` helper accepts:
+
+- `timeout`
+- `memoMap`
+- `excludeTestServices`
+
+### `excludeTestServices`
+
+By default, `layer(...)` merges your layer with the test environment (`TestClock` and `TestConsole`).
+
+Use `excludeTestServices: true` when you want your layer group to run without those test-service overrides.
+
+This is useful for tests that should keep live runtime behavior.
+
+### `memoMap`
+
+Use `memoMap` only when you have a specific reason to coordinate layer memoization manually across test setups.
+
+Most tests should let `@effect/vitest` manage it.
+
+## Scoped Resources In Tests
+
+`@effect/vitest` is designed to work correctly with scoped effects and layered resources.
+
+The vendored tests explicitly verify resource release through `afterAll`.
+
+Use this normally:
+
+- define scoped services in layers
+- use `layer(...)` to share them
+- let the helper own scope setup and teardown
+
+Avoid manually managing large scopes in test code unless the test specifically needs that control.
+
+## `flakyTest`
+
+Use `flakyTest` for tests that need bounded retrying.
+
+Repo behavior:
+
+- wraps the test in `Effect.scoped`
+- retries using a schedule
+- retries for up to a timeout window
+- converts final failure to defect with `Effect.orDie`
+
+Use this only for truly flaky integration-style conditions, not as a substitute for deterministic tests.
+
+## `makeMethods` And `describeWrapped`
+
+These exist for custom integration and wrapper scenarios.
+
+### `makeMethods`
+
+Use `makeMethods` when you need to extend or wrap a custom Vitest `it` instance while preserving Effect-aware helpers.
+
+### `describeWrapped`
+
+Use `describeWrapped` when you want a `describe` wrapper that hands you the augmented Effect-aware `it` methods directly.
+
+Most test code can just use imported `describe` and `it` from `@effect/vitest`.
+
+## Equality Testers
+
+`addEqualityTesters()` exists as part of the public API.
+
+Use it only when you have a concrete need to install equality testers for your Vitest environment.
+
+It is not needed for ordinary test structure.
+
+## Recommended Patterns
+
+### Pattern: normal Effect test
+
+```ts
+it.effect("does work", () =>
+  Effect.gen(function*() {
+    const value = yield* Effect.succeed(1)
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+### Pattern: shared layer for a test group
+
+```ts
+layer(AppLayer)("app", (it) => {
+  it.effect("uses app services", () =>
+    Effect.gen(function*() {
+      yield* Effect.void
+    })
+  )
+})
+```
+
+### Pattern: property test with Effect
+
+```ts
+it.effect.prop("law", [FastCheck.integer()], ([n]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(n + 0, n)
+  })
+)
+```
+
+### Pattern: use `TestClock`
+
+```ts
+it.effect("uses TestClock", () =>
+  Effect.gen(function*() {
+    const fiber = yield* Effect.forkChild(Effect.sleep("1 second"))
+    yield* TestClock.adjust("1 second")
+    yield* Fiber.join(fiber)
+  })
+)
+```
+
+## Anti-Patterns
+
+- using plain `it(...)` with `Effect.runPromise(...)` for normal Effect tests
+- using `it.live` by default when `it.effect` is sufficient
+- manually building and tearing down large layer graphs instead of using `layer(...)`
+- using top-level `it.prop` with `Schema` inputs
+- using `flakyTest` to hide deterministic failures
+- duplicating runtime setup instead of sharing a layer
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`

--- a/.agents/skills/effect-ts/references/setup.md
+++ b/.agents/skills/effect-ts/references/setup.md
@@ -1,0 +1,89 @@
+# Effect Source Setup
+
+This setup task is required when `./.repos/effect` is missing from the root of the repository where this skill is used.
+
+## Prompt
+
+The local Effect source checkout was not found at `./.repos/effect`.
+
+Choose one of these setup options before continuing:
+
+1. Add `https://github.com/Effect-TS/effect-smol` as a git subtree with squashed history at `./.repos/effect`
+2. Add `https://github.com/Effect-TS/effect-smol` as a git submodule at `./.repos/effect`
+3. Use `git clone` into `./.repos/effect`, ignore it via `.gitignore`, and add a prepare script that bootstraps it when missing
+
+## Supported Options
+
+### 1. Git Subtree
+
+Use this when the repository should vendor the Effect source directly while keeping history compact.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: subtree with squashed history
+
+### 2. Git Submodule
+
+Use this when the repository should track the Effect source explicitly as a separate Git dependency.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: standard Git submodule
+
+### 3. Local Clone + Gitignore + Prepare Task
+
+Use this when the repository should avoid vendoring or submodule management, but still provide a reproducible local setup.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Add `.repos/effect` to the repository `.gitignore`
+- Add a `prepare` task that clones the repo automatically when the directory is missing
+
+#### Concrete Shape
+
+Use this exact shape for the setup. Do not invent a different script.
+
+`package.json`:
+
+```json
+{
+  "scripts": {
+    "prepare": "./scripts/prepare-effect.sh"
+  }
+}
+```
+
+`.gitignore`:
+
+```gitignore
+.repos/effect
+```
+
+`scripts/prepare-effect.sh`:
+
+```sh
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect-smol"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"
+```
+
+#### Notes
+
+- This keeps `./.repos/effect` available for local research without forcing it into version control
+- The script is only responsible for ensuring the checkout exists; it does not update or reset an existing clone
+- If you choose this option, the setup task should add this exact script, wire it via `prepare`, and add `.repos/effect` to `.gitignore`
+
+## Guidance
+
+- Do not continue with Effect-specific work until one of the setup options is chosen.
+- Prefer the option that matches the host repository's dependency management style.

--- a/.claude/skills/effect-ts/PROVENANCE.md
+++ b/.claude/skills/effect-ts/PROVENANCE.md
@@ -1,0 +1,39 @@
+# Provenance
+
+This skill is **vendored** (copied in) from a third-party repository, per the
+copy-in exception in the repo-root `CLAUDE.md` ("copy-in 例外は skill ディレクトリ内に
+出典 + LICENSE を残す").
+
+- Source: https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+- Upstream repo: https://github.com/Effect-TS/skills
+- Pinned commit: `b5026c68318f395bbfd258182ea6b524ff2be549`
+- Commit date: 2026-05-15
+- Vendored on: 2026-07-05
+- Reason: supply-chain safety — copied verbatim instead of fetching at consume time.
+
+## License status
+
+At the time of vendoring, the upstream `Effect-TS/skills` repository contained
+**no LICENSE file and no explicit license statement** (verified via the GitHub
+API and the upstream README). The Effect project is generally published under the
+MIT License, but this `skills` repository carries no explicit grant. This copy is
+made in good faith for internal use. If upstream adds an explicit license, or
+requests removal, update or remove this vendored copy accordingly.
+
+## Re-syncing from upstream
+
+Re-fetch each file at a chosen commit `<SHA>`:
+
+```sh
+for f in SKILL.md references/features.md references/guide-effect.md \
+  references/guide-error-handling.md references/guide-layers.md \
+  references/guide-observability.md references/guide-retries.md \
+  references/guide-schedule.md references/guide-schema.md \
+  references/guide-sql.md references/guide-testing.md references/setup.md; do
+  gh api "repos/Effect-TS/skills/contents/skills/effect-ts/$f?ref=<SHA>" \
+    --jq '.content' | base64 -d > "skills/effect-ts/$f"
+done
+```
+
+After re-syncing, re-apply the source-attribution comment in SKILL.md and update the
+pinned commit / dates above.

--- a/.claude/skills/effect-ts/SKILL.md
+++ b/.claude/skills/effect-ts/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: effect-ts
+description: >-
+  Use this skill whenever working in a repository that uses Effect, even if the
+  current task is in a new file or the user does not explicitly ask for Effect
+  help. Apply it to any work that should follow the repository's Effect
+  patterns, conventions, architecture, or supporting tooling. Also use it for
+  questions about Effect patterns, services, layers, schemas, streams, runtimes,
+  or typed error handling.
+---
+<!--
+Vendored from Effect-TS/skills — https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+Upstream commit: b5026c68318f395bbfd258182ea6b524ff2be549 (2026-05-15)
+Copied verbatim (supply-chain safety). Provenance + re-sync steps: ./PROVENANCE.md
+Do not edit vendored content here; re-sync from upstream instead.
+-->
+
+# Effect Expert
+
+Expert guidance for programming with the Effect library, covering error handling, dependency injection, composability, and testing patterns.
+
+## Prerequisite
+
+Before doing any other Effect-related work, check that `./.repos/effect` exists at the root of the repository where the skill is being used.
+
+If it does not exist, stop and prompt the user with the setup task documented in `./references/setup.md`.
+
+## Research Strategy
+
+Effect has many ways to accomplish the same task. Proactively research best practices when working with Effect patterns, especially for moderate to high complexity tasks.
+
+Use the local guides in `./references/` first. They are the preferred source for best practices, conventions, and common implementation patterns.
+
+Only go directly to the vendored Effect repo when:
+
+- the guides do not cover the question
+- you need exact API details or signatures
+- you need deeper implementation details
+- you need to verify a behavior against the source
+
+### Research Sources
+
+1. Local skill guides first. Start with the relevant files in `./references/` before doing deeper research.
+2. Codebase patterns second. Examine similar patterns in the current project before implementing. If Effect patterns already exist, follow them for consistency. If no patterns exist, skip this step.
+3. Effect source code last. For gaps in the guides, complex type errors, unclear behavior, or implementation details, examine the vendored Effect source at `./.repos/effect/packages/effect/src/`.
+
+### When To Research
+
+- Always research for services, layers, or complex dependency injection.
+- Always research for error handling with multiple error types or complex error hierarchies.
+- Always research for stream-based operations and reactive patterns.
+- Always research for resource management with scoped effects and cleanup.
+- Always research for concurrent or performance-critical code.
+- Always research for unfamiliar testing patterns.
+- Research when needed for complex refactors from promises or try/catch into Effect.
+- Research when needed for new service dependencies or layer restructuring.
+- Research when needed for custom error types or extensions of existing error hierarchies.
+- Research when needed for integrations with external systems such as databases, APIs, or third-party services.
+
+### Research Approach
+
+- Focus on canonical, readable, and maintainable solutions rather than clever optimizations.
+- Verify suggested approaches against existing codebase patterns when those patterns exist.
+- When multiple approaches are possible, prefer the most idiomatic Effect solution supported by the codebase and the vendored source.
+
+### Codebase Pattern Discovery
+
+When working in a project that uses Effect, check for existing patterns before implementing new code:
+
+1. Search for Effect imports and existing module usage to understand current conventions.
+2. Identify how services and layers are structured in the project.
+3. Note how errors are defined and propagated.
+4. Examine how Effect code is tested in the project.
+
+If no Effect patterns exist in the codebase, proceed using canonical patterns from the vendored Effect source and examples. Do not block on missing codebase patterns.
+
+### Feature Discovery
+
+When you need to discover available Effect modules, packages, or capabilities, search `./references/features.md` first.
+
+- Use it to identify the right package or module for a task.
+- Use the listed repo paths to jump directly into the vendored source under `./.repos/effect`.
+- Use it before inventing custom abstractions when Effect may already provide the functionality.
+
+### Guide Discovery
+
+When the task touches one of these areas, consult the matching guide before implementing:
+
+- `./references/guide-effect.md` for core `Effect` usage patterns, common constructors, composition, provisioning, and runtime boundaries
+- `./references/guide-error-handling.md` for defining errors, schema-based errors, failure handling, defects, and interrupts
+- `./references/guide-layers.md` for services, layer construction, composition, and provisioning patterns
+- `./references/guide-observability.md` for `Effect.fn`, spans, logging, metrics, and telemetry wiring
+- `./references/guide-retries.md` for retry policies, retry conditions, fallback strategies, and `ExecutionPlan`
+- `./references/guide-schedule.md` for retries, repeats, backoff, polling, cron, and schedule composition
+- `./references/guide-schema.md` for schema design, transformations, unions, recursion, opaque/branded types, and schema best practices
+- `./references/guide-sql.md` for Effect SQL usage, transactions, resolvers, schema-aware SQL, and migrations
+- `./references/guide-testing.md` for detailed `@effect/vitest` usage, layered test setup, property tests, and test services
+
+These guides should be treated as the default implementation guidance. Do not skip them and jump straight to `./.repos/effect` unless you need source-level confirmation or the guides do not answer the question.
+
+## Effect Principles
+
+Apply these core principles when writing Effect code.
+
+## Installation
+
+When installing Effect packages in a user repository:
+
+- use `effect@beta`
+- keep all `@effect/*` packages on aligned versions
+- install only the packages needed for the user's runtime and actual task
+
+### Version Rules
+
+- `effect` should be installed as `effect@beta`
+- if you install any `@effect/*` package, make sure all `@effect/*` packages use matching versions
+- do not mix unrelated `@effect/*` versions in the same project
+
+### Package Selection
+
+Choose packages based on the runtime and the work being done.
+
+- core library: `effect@beta`
+- Node.js runtime needs: install the matching `@effect/platform-node`
+- browser runtime needs: install the matching `@effect/platform-browser`
+- Bun runtime needs: install the matching `@effect/platform-bun`
+- Vitest integration needs: install the matching `@effect/vitest`
+- OpenTelemetry integration needs: install the matching `@effect/opentelemetry`
+
+Install additional `@effect/*` packages only when the user task actually needs them.
+
+### Practical Rule
+
+- start with `effect@beta`
+- add `@effect/*` packages as needed by runtime and features
+- keep the full installed Effect package set version-aligned
+
+### Error Handling
+
+- Use Effect's typed error system instead of throwing exceptions.
+- Define descriptive error types with proper error propagation.
+- Prefer `Schema.TaggedErrorClass` when the error can be schema-defined.
+- Use `Effect.fail`, `Effect.catchTag`, and `Effect.catch` for error control flow.
+
+### Dependency Injection
+
+- Implement dependency injection using services and layers.
+- Define services with `Context.Tag`.
+- Compose layers with `Layer.merge` and `Layer.provide`.
+- Use `Effect.provide` to inject dependencies at the edge, avoid providing locally.
+- Keep services encapsulated; avoid exporting trivial accessor wrappers that only forward to one service method.
+
+### Composability
+
+- Leverage Effect composability for complex operations.
+- Use appropriate constructors such as `Effect.succeed`, `Effect.fail`, `Effect.tryPromise`, `Effect.try`, and `Effect.sync`.
+- Apply proper resource management with scoped effects.
+- Chain operations with `Effect.flatMap`, `Effect.map`, and `Effect.tap`.
+
+### Business Logic Functions
+
+- Prefer `Effect.fn` for reusable business-logic functions that return `Effect`.
+- Prefer `Effect.fn` over raw `Effect.gen` definitions even when the function takes no arguments.
+- If you do not want an explicit named span, use `Effect.fn` without a span name.
+- Do not use `Effect.fnUntraced` as the default.
+- Use `Effect.fnUntraced` only for edge cases with a concrete low-level reason, such as measured hot-path overhead.
+
+### TypeScript Preferences
+
+- Never use `any`.
+- Never use `as` casts.
+- Never use unsafe type assertions or escape hatches.
+- Never use `namespace`.
+- Prefer correct typing, schema-driven decoding, narrowing, and proper generic constraints instead of forcing types.
+- If a value comes from an external boundary, validate or decode it instead of asserting its type.
+- If a type is hard to express, simplify the design or introduce a properly typed helper instead of using unsafe TypeScript.
+- For layers, do not hide them inside `namespace` blocks. Prefer either `static` members on the service class or plain exported layer constants.
+
+### Code Quality
+
+- Write type-safe code that leverages Effect's type system.
+- Use `Effect.gen` for readable sequential code.
+- Implement proper testing patterns using Effect testing utilities.
+- Prefer existing Effect primitives before introducing custom helpers.
+- Prefer `Schema.Class` / `Schema.TaggedClass` variants over plain `Schema.Struct` for named reusable schemas when possible.
+
+### Explaining Solutions
+
+When providing solutions, explain the Effect concepts being used and why they fit the specific use case. If you encounter patterns not covered in local references, prefer consistency with the codebase when possible and otherwise rely on the vendored Effect source.
+
+## References
+
+- `./references/features.md`
+- `./references/guide-effect.md`
+- `./references/guide-error-handling.md`
+- `./references/guide-layers.md`
+- `./references/guide-observability.md`
+- `./references/guide-retries.md`
+- `./references/guide-schedule.md`
+- `./references/guide-schema.md`
+- `./references/guide-sql.md`
+- `./references/guide-testing.md`
+- `./references/setup.md`

--- a/.claude/skills/effect-ts/references/features.md
+++ b/.claude/skills/effect-ts/references/features.md
@@ -1,0 +1,504 @@
+# Features
+
+Public package and module surface area to be aware of when researching or implementing a solution. Each module entry includes its vendored repo path so it can be located quickly.
+
+## `effect` Package
+
+Package path: `packages/effect`
+
+- `Array` - `packages/effect/src/Array.ts` - Immutable array utilities. Use: transform arrays immutably.
+- `BigDecimal` - `packages/effect/src/BigDecimal.ts` - Arbitrary-precision decimal arithmetic. Use: avoid floating-point errors.
+- `BigInt` - `packages/effect/src/BigInt.ts` - `bigint` utilities and instances. Use: work with large integers.
+- `Boolean` - `packages/effect/src/Boolean.ts` - Boolean utilities and instances. Use: compose boolean logic.
+- `Brand` - `packages/effect/src/Brand.ts` - Branded type helpers. Use: prevent accidental type mixing.
+- `Cache` - `packages/effect/src/Cache.ts` - Effect cache utilities. Use: memoize effectful lookups.
+- `Cause` - `packages/effect/src/Cause.ts` - Structured effect failure representation. Use: inspect failures and defects.
+- `Channel` - `packages/effect/src/Channel.ts` - Bidirectional streaming I/O abstraction. Use: build stream pipelines.
+- `ChannelSchema` - `packages/effect/src/ChannelSchema.ts` - Schema helpers for channels. Use: type channel protocols.
+- `Chunk` - `packages/effect/src/Chunk.ts` - Immutable high-performance sequence. Use: efficient functional sequences.
+- `Clock` - `packages/effect/src/Clock.ts` - Time service and sleep utilities. Use: schedule and measure time.
+- `Combiner` - `packages/effect/src/Combiner.ts` - Combine two values of one type. Use: merge values consistently.
+- `Config` - `packages/effect/src/Config.ts` - Schema-driven configuration loading. Use: read typed app config.
+- `ConfigProvider` - `packages/effect/src/ConfigProvider.ts` - Configuration data source abstraction. Use: load config from env/files.
+- `Console` - `packages/effect/src/Console.ts` - Effectful console operations. Use: log and debug safely.
+- `Context` - `packages/effect/src/Context.ts` - Dependency injection context table. Use: provide and access services.
+- `Cron` - `packages/effect/src/Cron.ts` - Cron scheduling utilities. Use: express recurring schedules.
+- `Data` - `packages/effect/src/Data.ts` - Immutable data and tagged unions. Use: model domain data and errors.
+- `DateTime` - `packages/effect/src/DateTime.ts` - Date-time utilities. Use: handle timestamps and calendars.
+- `Deferred` - `packages/effect/src/Deferred.ts` - Single-assignment async variable. Use: coordinate concurrent fibers.
+- `Differ` - `packages/effect/src/Differ.ts` - Value diffing utilities. Use: compute incremental updates.
+- `Duration` - `packages/effect/src/Duration.ts` - Precise time span type. Use: represent delays and intervals.
+- `Effect` - `packages/effect/src/Effect.ts` - Core effect type and operators. Use: model async and concurrent work.
+- `Effectable` - `packages/effect/src/Effectable.ts` - Protocols for effect-like values. Use: integrate custom yieldables.
+- `Encoding` - `packages/effect/src/Encoding.ts` - Base64, Base64Url, and Hex codecs. Use: encode binary/text values.
+- `Equal` - `packages/effect/src/Equal.ts` - Structural and custom equality. Use: compare immutable values deeply.
+- `Equivalence` - `packages/effect/src/Equivalence.ts` - Equivalence relation helpers. Use: dedupe or compare with custom rules.
+- `ErrorReporter` - `packages/effect/src/ErrorReporter.ts` - Pluggable error reporting. Use: forward failures to observability tools.
+- `ExecutionPlan` - `packages/effect/src/ExecutionPlan.ts` - Execution plan utilities. Use: inspect planned work.
+- `Exit` - `packages/effect/src/Exit.ts` - Synchronous effect outcome value. Use: inspect success or failure.
+- `Fiber` - `packages/effect/src/Fiber.ts` - Lightweight concurrency primitive. Use: fork and join work.
+- `FiberHandle` - `packages/effect/src/FiberHandle.ts` - Managed fiber handle helpers. Use: control child fibers.
+- `FiberMap` - `packages/effect/src/FiberMap.ts` - Fiber map utilities. Use: track fibers by key.
+- `FiberSet` - `packages/effect/src/FiberSet.ts` - Fiber set utilities. Use: manage groups of fibers.
+- `FileSystem` - `packages/effect/src/FileSystem.ts` - Effectful file system abstraction. Use: read and write files safely.
+- `Filter` - `packages/effect/src/Filter.ts` - Filter result utilities. Use: compose filtering operations.
+- `Formatter` - `packages/effect/src/Formatter.ts` - Human-readable value formatting. Use: pretty-print data for logs.
+- `Function` - `packages/effect/src/Function.ts` - Core function helpers. Use: pipe and compose functions.
+- `Graph` - `packages/effect/src/Graph.ts` - Graph utilities. Use: model dependency graphs.
+- `Hash` - `packages/effect/src/Hash.ts` - Hashing utilities. Use: hash values for collections.
+- `HashMap` - `packages/effect/src/HashMap.ts` - Immutable hash map. Use: keyed immutable storage.
+- `HashRing` - `packages/effect/src/HashRing.ts` - Consistent hashing utilities. Use: distribute keys across nodes.
+- `HashSet` - `packages/effect/src/HashSet.ts` - Immutable hash set. Use: store unique immutable values.
+- `HKT` - `packages/effect/src/HKT.ts` - Higher-kinded type utilities. Use: define generic type classes.
+- `Inspectable` - `packages/effect/src/Inspectable.ts` - Custom inspection helpers. Use: improve debugging output.
+- `Iterable` - `packages/effect/src/Iterable.ts` - Functional iterable utilities. Use: process lazy iterables.
+- `JsonPatch` - `packages/effect/src/JsonPatch.ts` - JSON Patch operations. Use: diff and patch JSON documents.
+- `JsonPointer` - `packages/effect/src/JsonPointer.ts` - JSON Pointer token helpers. Use: escape pointer path segments.
+- `JsonSchema` - `packages/effect/src/JsonSchema.ts` - JSON Schema dialect conversion. Use: convert schemas between formats.
+- `Latch` - `packages/effect/src/Latch.ts` - Latch synchronization primitive. Use: gate concurrent progress.
+- `Layer` - `packages/effect/src/Layer.ts` - Service construction recipes. Use: build and wire dependencies.
+- `LayerMap` - `packages/effect/src/LayerMap.ts` - Layer registry helpers. Use: share and look up layers.
+- `Logger` - `packages/effect/src/Logger.ts` - Structured logging system. Use: emit runtime logs.
+- `LogLevel` - `packages/effect/src/LogLevel.ts` - Log level utilities. Use: filter logs by severity.
+- `ManagedRuntime` - `packages/effect/src/ManagedRuntime.ts` - Managed runtime helpers. Use: own runtime lifecycle.
+- `Match` - `packages/effect/src/Match.ts` - Type-safe pattern matching. Use: replace switch-heavy branching.
+- `Metric` - `packages/effect/src/Metric.ts` - Application metrics system. Use: count, gauge, and histogram events.
+- `MutableHashMap` - `packages/effect/src/MutableHashMap.ts` - Mutable hash map. Use: high-performance mutable key-value storage.
+- `MutableHashSet` - `packages/effect/src/MutableHashSet.ts` - Mutable hash set. Use: high-performance mutable uniqueness checks.
+- `MutableList` - `packages/effect/src/MutableList.ts` - Mutable linked-list-like buffer. Use: efficient append/prepend workloads.
+- `MutableRef` - `packages/effect/src/MutableRef.ts` - Mutable reference container. Use: hold local mutable state.
+- `Newtype` - `packages/effect/src/Newtype.ts` - Zero-cost wrapper types. Use: distinguish same-shaped values.
+- `NonEmptyIterable` - `packages/effect/src/NonEmptyIterable.ts` - Non-empty iterable helpers. Use: require at least one element.
+- `Number` - `packages/effect/src/Number.ts` - Number utilities and instances. Use: do typed numeric operations.
+- `Optic` - `packages/effect/src/Optic.ts` - Immutable data accessors and updaters. Use: read or update nested state.
+- `Option` - `packages/effect/src/Option.ts` - Optional value type. Use: model absence safely.
+- `Order` - `packages/effect/src/Order.ts` - Total ordering type class. Use: sort and compare values.
+- `Ordering` - `packages/effect/src/Ordering.ts` - Comparison result helpers. Use: combine sort outcomes.
+- `PartitionedSemaphore` - `packages/effect/src/PartitionedSemaphore.ts` - Partition-aware semaphore. Use: limit concurrency by key.
+- `Path` - `packages/effect/src/Path.ts` - Path utilities. Use: work with filesystem-style paths.
+- `Pipeable` - `packages/effect/src/Pipeable.ts` - Pipeable protocol helpers. Use: support fluent pipelines.
+- `PlatformError` - `packages/effect/src/PlatformError.ts` - Platform error types. Use: normalize platform-specific failures.
+- `Pool` - `packages/effect/src/Pool.ts` - Resource pool utilities. Use: reuse scarce resources.
+- `Predicate` - `packages/effect/src/Predicate.ts` - Predicate and refinement helpers. Use: filter and narrow values.
+- `PrimaryKey` - `packages/effect/src/PrimaryKey.ts` - Primary key helpers. Use: define stable string identifiers.
+- `PubSub` - `packages/effect/src/PubSub.ts` - Publish-subscribe hub. Use: broadcast messages to subscribers.
+- `Pull` - `packages/effect/src/Pull.ts` - Pull protocol helpers. Use: model pull-based streaming.
+- `Queue` - `packages/effect/src/Queue.ts` - Effect queue utilities. Use: buffer producer-consumer work.
+- `Random` - `packages/effect/src/Random.ts` - Randomness service. Use: generate testable random values.
+- `RcMap` - `packages/effect/src/RcMap.ts` - Reference-counted map. Use: share keyed resources.
+- `RcRef` - `packages/effect/src/RcRef.ts` - Reference-counted ref. Use: share scoped resources.
+- `Record` - `packages/effect/src/Record.ts` - Record utilities. Use: transform string-keyed objects.
+- `Redactable` - `packages/effect/src/Redactable.ts` - Context-aware redaction protocol. Use: mask sensitive values.
+- `Redacted` - `packages/effect/src/Redacted.ts` - Sensitive value wrapper. Use: keep secrets out of logs.
+- `Reducer` - `packages/effect/src/Reducer.ts` - Fold values into one result. Use: aggregate collections.
+- `Ref` - `packages/effect/src/Ref.ts` - Atomic mutable reference. Use: manage concurrent state.
+- `References` - `packages/effect/src/References.ts` - Runtime reference services. Use: tune runtime configuration.
+- `RegExp` - `packages/effect/src/RegExp.ts` - RegExp utilities. Use: work with regular expressions.
+- `Request` - `packages/effect/src/Request.ts` - External request description. Use: batch and cache data fetching.
+- `RequestResolver` - `packages/effect/src/RequestResolver.ts` - Request execution abstraction. Use: resolve batched requests.
+- `Resource` - `packages/effect/src/Resource.ts` - Resource utilities. Use: acquire and release shared resources.
+- `Result` - `packages/effect/src/Result.ts` - Synchronous success/failure type. Use: validate without effects.
+- `Runtime` - `packages/effect/src/Runtime.ts` - Effect runtime helpers. Use: run main programs.
+- `Schedule` - `packages/effect/src/Schedule.ts` - Retry and repetition schedules. Use: control retry timing.
+- `Scheduler` - `packages/effect/src/Scheduler.ts` - Scheduler utilities. Use: control task execution.
+- `Schema` - `packages/effect/src/Schema.ts` - Data schema, validation, and codecs. Use: decode and encode typed data.
+- `SchemaAST` - `packages/effect/src/SchemaAST.ts` - Runtime schema AST. Use: inspect or transform schemas.
+- `SchemaGetter` - `packages/effect/src/SchemaGetter.ts` - One-way schema transformations. Use: decode individual fields.
+- `SchemaIssue` - `packages/effect/src/SchemaIssue.ts` - Structured schema validation errors. Use: inspect parse failures.
+- `SchemaParser` - `packages/effect/src/SchemaParser.ts` - Schema parsing helpers. Use: build parsing workflows.
+- `SchemaRepresentation` - `packages/effect/src/SchemaRepresentation.ts` - Serializable schema IR. Use: round-trip schemas through JSON/codegen.
+- `SchemaTransformation` - `packages/effect/src/SchemaTransformation.ts` - Bidirectional schema transformations. Use: map encoded and decoded forms.
+- `SchemaUtils` - `packages/effect/src/SchemaUtils.ts` - Schema utility helpers. Use: support schema internals.
+- `Scope` - `packages/effect/src/Scope.ts` - Resource lifetime scope. Use: ensure cleanup of acquired resources.
+- `ScopedCache` - `packages/effect/src/ScopedCache.ts` - Scoped cache utilities. Use: cache scoped resources.
+- `ScopedRef` - `packages/effect/src/ScopedRef.ts` - Scoped mutable reference. Use: swap scoped resources safely.
+- `Semaphore` - `packages/effect/src/Semaphore.ts` - Concurrency semaphore. Use: limit parallel access.
+- `Sink` - `packages/effect/src/Sink.ts` - Stream consumer abstraction. Use: fold or write stream inputs.
+- `Stdio` - `packages/effect/src/Stdio.ts` - Standard I/O utilities. Use: access stdin/stdout/stderr.
+- `Stream` - `packages/effect/src/Stream.ts` - Functional stream abstraction. Use: process streaming data.
+- `String` - `packages/effect/src/String.ts` - String utilities and instances. Use: manipulate text functionally.
+- `Struct` - `packages/effect/src/Struct.ts` - Immutable object utilities. Use: transform plain objects.
+- `SubscriptionRef` - `packages/effect/src/SubscriptionRef.ts` - Subscribable reference. Use: observe state changes.
+- `Symbol` - `packages/effect/src/Symbol.ts` - Symbol utilities. Use: work with JavaScript symbols.
+- `SynchronizedRef` - `packages/effect/src/SynchronizedRef.ts` - Effect-synchronized ref. Use: update state with effects.
+- `Take` - `packages/effect/src/Take.ts` - Stream take representation. Use: carry chunk, end, or error.
+- `Terminal` - `packages/effect/src/Terminal.ts` - Terminal interaction utilities. Use: build CLI prompts/output.
+- `Tracer` - `packages/effect/src/Tracer.ts` - Tracing abstractions. Use: create spans and traces.
+- `Trie` - `packages/effect/src/Trie.ts` - Prefix tree for strings. Use: do prefix lookups.
+- `Tuple` - `packages/effect/src/Tuple.ts` - Immutable tuple utilities. Use: transform fixed-length arrays.
+- `TxChunk` - `packages/effect/src/TxChunk.ts` - Transactional chunk. Use: mutate chunk state in STM.
+- `TxDeferred` - `packages/effect/src/TxDeferred.ts` - Transactional deferred cell. Use: coordinate STM completion.
+- `TxHashMap` - `packages/effect/src/TxHashMap.ts` - Transactional hash map. Use: keyed STM state.
+- `TxHashSet` - `packages/effect/src/TxHashSet.ts` - Transactional hash set. Use: unique STM state.
+- `TxPriorityQueue` - `packages/effect/src/TxPriorityQueue.ts` - Transactional priority queue. Use: ordered STM queueing.
+- `TxPubSub` - `packages/effect/src/TxPubSub.ts` - Transactional pub-sub hub. Use: broadcast within STM.
+- `TxQueue` - `packages/effect/src/TxQueue.ts` - Transactional queue. Use: queue data within STM.
+- `TxReentrantLock` - `packages/effect/src/TxReentrantLock.ts` - Transactional reentrant RW lock. Use: coordinate STM access.
+- `TxRef` - `packages/effect/src/TxRef.ts` - Transactional reference. Use: read and write STM state.
+- `TxSemaphore` - `packages/effect/src/TxSemaphore.ts` - Transactional semaphore. Use: limit STM concurrency.
+- `TxSubscriptionRef` - `packages/effect/src/TxSubscriptionRef.ts` - Transactional subscribable ref. Use: observe committed STM changes.
+- `Types` - `packages/effect/src/Types.ts` - Type-level utility aliases. Use: shape complex TypeScript types.
+- `UndefinedOr` - `packages/effect/src/UndefinedOr.ts` - Helpers for `A | undefined`. Use: model lightweight optional values.
+- `Unify` - `packages/effect/src/Unify.ts` - Type unification helpers. Use: simplify inferred types.
+- `Utils` - `packages/effect/src/Utils.ts` - Generator and HKT internals. Use: support yieldable APIs.
+
+### `effect/testing`
+
+- `FastCheck` - `packages/effect/src/testing/FastCheck.ts` - Re-export of fast-check for property testing. Use: generate random test cases.
+- `TestClock` - `packages/effect/src/testing/TestClock.ts` - Controllable clock for tests. Use: advance time deterministically.
+- `TestConsole` - `packages/effect/src/testing/TestConsole.ts` - Test console implementation. Use: assert console output.
+- `TestSchema` - `packages/effect/src/testing/TestSchema.ts` - Schema assertion helpers. Use: verify decode/encode behavior.
+
+### `effect/unstable/ai`
+
+- `AiError` - `packages/effect/src/unstable/ai/AiError.ts` - AI-related error types. Use: handle model failures.
+- `AnthropicStructuredOutput` - `packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts` - Anthropic structured-output codec helpers. Use: parse structured model responses.
+- `Chat` - `packages/effect/src/unstable/ai/Chat.ts` - Stateful AI conversation API. Use: manage chat sessions.
+- `EmbeddingModel` - `packages/effect/src/unstable/ai/EmbeddingModel.ts` - Provider-agnostic embedding API. Use: generate text vectors.
+- `IdGenerator` - `packages/effect/src/unstable/ai/IdGenerator.ts` - Pluggable ID generation. Use: issue stable request IDs.
+- `LanguageModel` - `packages/effect/src/unstable/ai/LanguageModel.ts` - AI text generation with tools. Use: call LLMs.
+- `McpSchema` - `packages/effect/src/unstable/ai/McpSchema.ts` - MCP schema helpers. Use: type MCP messages.
+- `McpServer` - `packages/effect/src/unstable/ai/McpServer.ts` - MCP server support. Use: expose model context tools.
+- `Model` - `packages/effect/src/unstable/ai/Model.ts` - Unified AI provider interface. Use: swap AI backends.
+- `OpenAiStructuredOutput` - `packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts` - OpenAI structured-output codecs. Use: decode typed model output.
+- `Prompt` - `packages/effect/src/unstable/ai/Prompt.ts` - Prompt-building data structures. Use: compose prompts.
+- `Response` - `packages/effect/src/unstable/ai/Response.ts` - AI response data structures. Use: inspect completions.
+- `ResponseIdTracker` - `packages/effect/src/unstable/ai/ResponseIdTracker.ts` - Response ID tracking utilities. Use: correlate model replies.
+- `Telemetry` - `packages/effect/src/unstable/ai/Telemetry.ts` - OpenTelemetry integration for AI operations. Use: trace model calls.
+- `Tokenizer` - `packages/effect/src/unstable/ai/Tokenizer.ts` - Tokenization and truncation utilities. Use: enforce token budgets.
+- `Tool` - `packages/effect/src/unstable/ai/Tool.ts` - Tool definition and management. Use: expose callable tools.
+- `Toolkit` - `packages/effect/src/unstable/ai/Toolkit.ts` - Collection of tools. Use: bundle tool implementations.
+
+### `effect/unstable/cli`
+
+- `Argument` - `packages/effect/src/unstable/cli/Argument.ts` - CLI argument definitions. Use: positional arguments.
+- `CliError` - `packages/effect/src/unstable/cli/CliError.ts` - CLI error types. Use: report parse failures.
+- `CliOutput` - `packages/effect/src/unstable/cli/CliOutput.ts` - CLI rendering/output helpers. Use: format command output.
+- `Command` - `packages/effect/src/unstable/cli/Command.ts` - CLI command definitions. Use: build subcommands.
+- `Completions` - `packages/effect/src/unstable/cli/Completions.ts` - Shell completion generation. Use: generate completion scripts.
+- `Flag` - `packages/effect/src/unstable/cli/Flag.ts` - CLI flag definitions. Use: parse options.
+- `GlobalFlag` - `packages/effect/src/unstable/cli/GlobalFlag.ts` - Global CLI flags. Use: shared top-level options.
+- `HelpDoc` - `packages/effect/src/unstable/cli/HelpDoc.ts` - CLI help document model. Use: render usage text.
+- `Param` - `packages/effect/src/unstable/cli/Param.ts` - CLI parameter helpers. Use: define typed params.
+- `Primitive` - `packages/effect/src/unstable/cli/Primitive.ts` - Primitive CLI parsers. Use: parse numbers or strings.
+- `Prompt` - `packages/effect/src/unstable/cli/Prompt.ts` - Interactive CLI prompts. Use: ask users for input.
+
+### `effect/unstable/cluster`
+
+- `ClusterCron` - `packages/effect/src/unstable/cluster/ClusterCron.ts` - Cluster cron scheduling. Use: distributed recurring jobs.
+- `ClusterError` - `packages/effect/src/unstable/cluster/ClusterError.ts` - Cluster error types. Use: classify cluster failures.
+- `ClusterMetrics` - `packages/effect/src/unstable/cluster/ClusterMetrics.ts` - Cluster metrics helpers. Use: observe cluster health.
+- `ClusterSchema` - `packages/effect/src/unstable/cluster/ClusterSchema.ts` - Cluster schema types. Use: encode cluster messages.
+- `ClusterWorkflowEngine` - `packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts` - Workflow engine for clusters. Use: run distributed workflows.
+- `DeliverAt` - `packages/effect/src/unstable/cluster/DeliverAt.ts` - Deferred delivery scheduling. Use: schedule message delivery.
+- `Entity` - `packages/effect/src/unstable/cluster/Entity.ts` - Cluster entity abstraction. Use: model sharded actors.
+- `EntityAddress` - `packages/effect/src/unstable/cluster/EntityAddress.ts` - Entity addressing types. Use: route entity messages.
+- `EntityId` - `packages/effect/src/unstable/cluster/EntityId.ts` - Typed entity identifiers. Use: identify actor instances.
+- `EntityProxy` - `packages/effect/src/unstable/cluster/EntityProxy.ts` - Client proxy for entities. Use: call remote entities.
+- `EntityProxyServer` - `packages/effect/src/unstable/cluster/EntityProxyServer.ts` - Server for entity proxies. Use: serve entity calls.
+- `EntityResource` - `packages/effect/src/unstable/cluster/EntityResource.ts` - Entity-backed resource helpers. Use: manage entity state.
+- `EntityType` - `packages/effect/src/unstable/cluster/EntityType.ts` - Entity type descriptors. Use: register entity kinds.
+- `Envelope` - `packages/effect/src/unstable/cluster/Envelope.ts` - Message envelope types. Use: wrap cluster messages.
+- `HttpRunner` - `packages/effect/src/unstable/cluster/HttpRunner.ts` - HTTP-based runner. Use: transport cluster traffic over HTTP.
+- `K8sHttpClient` - `packages/effect/src/unstable/cluster/K8sHttpClient.ts` - Kubernetes HTTP client helpers. Use: discover cluster peers.
+- `MachineId` - `packages/effect/src/unstable/cluster/MachineId.ts` - Machine identifier utilities. Use: label cluster nodes.
+- `Message` - `packages/effect/src/unstable/cluster/Message.ts` - Cluster message model. Use: send typed payloads.
+- `MessageStorage` - `packages/effect/src/unstable/cluster/MessageStorage.ts` - Message persistence abstraction. Use: durable message storage.
+- `Reply` - `packages/effect/src/unstable/cluster/Reply.ts` - Reply message helpers. Use: respond to cluster requests.
+- `Runner` - `packages/effect/src/unstable/cluster/Runner.ts` - Cluster runner abstraction. Use: host cluster workloads.
+- `RunnerAddress` - `packages/effect/src/unstable/cluster/RunnerAddress.ts` - Runner addressing types. Use: locate a runner.
+- `RunnerHealth` - `packages/effect/src/unstable/cluster/RunnerHealth.ts` - Runner health reporting. Use: track node readiness.
+- `Runners` - `packages/effect/src/unstable/cluster/Runners.ts` - Runner collection utilities. Use: manage active runners.
+- `RunnerServer` - `packages/effect/src/unstable/cluster/RunnerServer.ts` - Runner server implementation. Use: expose runner endpoints.
+- `RunnerStorage` - `packages/effect/src/unstable/cluster/RunnerStorage.ts` - Runner persistence abstraction. Use: store runner metadata.
+- `ShardId` - `packages/effect/src/unstable/cluster/ShardId.ts` - Shard identifier type. Use: map keys to shards.
+- `Sharding` - `packages/effect/src/unstable/cluster/Sharding.ts` - Sharding utilities. Use: distribute entities.
+- `ShardingConfig` - `packages/effect/src/unstable/cluster/ShardingConfig.ts` - Sharding configuration. Use: tune partitioning behavior.
+- `ShardingRegistrationEvent` - `packages/effect/src/unstable/cluster/ShardingRegistrationEvent.ts` - Sharding registration events. Use: observe topology changes.
+- `SingleRunner` - `packages/effect/src/unstable/cluster/SingleRunner.ts` - Single-process runner. Use: local cluster execution.
+- `Singleton` - `packages/effect/src/unstable/cluster/Singleton.ts` - Cluster singleton abstraction. Use: one active service instance.
+- `SingletonAddress` - `packages/effect/src/unstable/cluster/SingletonAddress.ts` - Singleton addressing types. Use: route singleton calls.
+- `Snowflake` - `packages/effect/src/unstable/cluster/Snowflake.ts` - Snowflake-style ID generation. Use: unique distributed IDs.
+- `SocketRunner` - `packages/effect/src/unstable/cluster/SocketRunner.ts` - Socket-based runner. Use: cluster transport over sockets.
+- `SqlMessageStorage` - `packages/effect/src/unstable/cluster/SqlMessageStorage.ts` - SQL-backed message storage. Use: persist cluster messages.
+- `SqlRunnerStorage` - `packages/effect/src/unstable/cluster/SqlRunnerStorage.ts` - SQL-backed runner storage. Use: persist runner state.
+- `TestRunner` - `packages/effect/src/unstable/cluster/TestRunner.ts` - Test runner utilities. Use: simulate cluster execution.
+
+### `effect/unstable/devtools`
+
+- `DevTools` - `packages/effect/src/unstable/devtools/DevTools.ts` - Devtools integration. Use: inspect runtime behavior.
+- `DevToolsClient` - `packages/effect/src/unstable/devtools/DevToolsClient.ts` - Devtools client API. Use: connect to devtools server.
+- `DevToolsSchema` - `packages/effect/src/unstable/devtools/DevToolsSchema.ts` - Devtools message schemas. Use: type devtools payloads.
+- `DevToolsServer` - `packages/effect/src/unstable/devtools/DevToolsServer.ts` - Devtools server API. Use: expose inspection endpoints.
+
+### `effect/unstable/encoding`
+
+- `Msgpack` - `packages/effect/src/unstable/encoding/Msgpack.ts` - MessagePack encoding helpers. Use: compact binary serialization.
+- `Ndjson` - `packages/effect/src/unstable/encoding/Ndjson.ts` - NDJSON encoding helpers. Use: stream JSON lines.
+- `Sse` - `packages/effect/src/unstable/encoding/Sse.ts` - Server-sent event encoding helpers. Use: emit SSE streams.
+
+### `effect/unstable/eventlog`
+
+- `Event` - `packages/effect/src/unstable/eventlog/Event.ts` - Event model types. Use: represent domain events.
+- `EventGroup` - `packages/effect/src/unstable/eventlog/EventGroup.ts` - Event grouping helpers. Use: batch related events.
+- `EventJournal` - `packages/effect/src/unstable/eventlog/EventJournal.ts` - Event journal abstraction. Use: append and read events.
+- `EventLog` - `packages/effect/src/unstable/eventlog/EventLog.ts` - Event log API. Use: stream recorded events.
+- `EventLogEncryption` - `packages/effect/src/unstable/eventlog/EventLogEncryption.ts` - Event log encryption helpers. Use: protect event payloads.
+- `EventLogMessage` - `packages/effect/src/unstable/eventlog/EventLogMessage.ts` - Event log message types. Use: transport log entries.
+- `EventLogRemote` - `packages/effect/src/unstable/eventlog/EventLogRemote.ts` - Remote event log client/server helpers. Use: access remote logs.
+- `EventLogServer` - `packages/effect/src/unstable/eventlog/EventLogServer.ts` - Event log server support. Use: host event streams.
+- `EventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts` - Encrypted event log server. Use: secure event serving.
+- `EventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts` - Unencrypted event log server. Use: plain local serving.
+- `EventLogSessionAuth` - `packages/effect/src/unstable/eventlog/EventLogSessionAuth.ts` - Event log session auth helpers. Use: authorize event sessions.
+- `SqlEventJournal` - `packages/effect/src/unstable/eventlog/SqlEventJournal.ts` - SQL-backed event journal. Use: persist events in SQL.
+- `SqlEventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts` - SQL-backed encrypted event server. Use: secure persisted logs.
+- `SqlEventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts` - SQL-backed plain event server. Use: simple persisted logs.
+
+### `effect/unstable/http`
+
+- `Cookies` - `packages/effect/src/unstable/http/Cookies.ts` - HTTP cookie helpers. Use: parse and set cookies.
+- `Etag` - `packages/effect/src/unstable/http/Etag.ts` - ETag utilities. Use: cache validation headers.
+- `FetchHttpClient` - `packages/effect/src/unstable/http/FetchHttpClient.ts` - Fetch-based HTTP client. Use: run requests in browsers.
+- `FindMyWay` - `packages/effect/src/unstable/http/FindMyWay.ts` - `find-my-way` router integration. Use: path routing.
+- `Headers` - `packages/effect/src/unstable/http/Headers.ts` - HTTP header utilities. Use: manage request headers.
+- `HttpBody` - `packages/effect/src/unstable/http/HttpBody.ts` - HTTP body representations. Use: send JSON or bytes.
+- `HttpClient` - `packages/effect/src/unstable/http/HttpClient.ts` - Effect HTTP client API. Use: perform outbound requests.
+- `HttpClientError` - `packages/effect/src/unstable/http/HttpClientError.ts` - HTTP client error types. Use: handle request failures.
+- `HttpClientRequest` - `packages/effect/src/unstable/http/HttpClientRequest.ts` - HTTP client request builders. Use: construct requests.
+- `HttpClientResponse` - `packages/effect/src/unstable/http/HttpClientResponse.ts` - HTTP client response utilities. Use: read status and body.
+- `HttpEffect` - `packages/effect/src/unstable/http/HttpEffect.ts` - HTTP-specific effect helpers. Use: compose HTTP workflows.
+- `HttpIncomingMessage` - `packages/effect/src/unstable/http/HttpIncomingMessage.ts` - Incoming message abstraction. Use: read request bodies.
+- `HttpMethod` - `packages/effect/src/unstable/http/HttpMethod.ts` - HTTP method helpers. Use: branch on verbs.
+- `HttpMiddleware` - `packages/effect/src/unstable/http/HttpMiddleware.ts` - HTTP middleware utilities. Use: add auth or logging.
+- `HttpPlatform` - `packages/effect/src/unstable/http/HttpPlatform.ts` - Platform HTTP integration. Use: supply runtime adapters.
+- `HttpRouter` - `packages/effect/src/unstable/http/HttpRouter.ts` - HTTP routing abstraction. Use: define endpoints.
+- `HttpServer` - `packages/effect/src/unstable/http/HttpServer.ts` - HTTP server API. Use: serve requests.
+- `HttpServerError` - `packages/effect/src/unstable/http/HttpServerError.ts` - HTTP server error types. Use: render server failures.
+- `HttpServerRequest` - `packages/effect/src/unstable/http/HttpServerRequest.ts` - Server request utilities. Use: inspect inbound requests.
+- `HttpServerRespondable` - `packages/effect/src/unstable/http/HttpServerRespondable.ts` - Response conversion protocol. Use: return custom response types.
+- `HttpServerResponse` - `packages/effect/src/unstable/http/HttpServerResponse.ts` - Server response builders. Use: send JSON or text.
+- `HttpStaticServer` - `packages/effect/src/unstable/http/HttpStaticServer.ts` - Static file serving helpers. Use: serve assets.
+- `HttpTraceContext` - `packages/effect/src/unstable/http/HttpTraceContext.ts` - HTTP trace-context propagation. Use: carry tracing headers.
+- `Multipart` - `packages/effect/src/unstable/http/Multipart.ts` - Multipart form-data helpers. Use: file uploads.
+- `Multipasta` - `packages/effect/src/unstable/http/Multipasta.ts` - Multipasta integration. Use: parse multipart streams.
+- `Template` - `packages/effect/src/unstable/http/Template.ts` - HTTP templating helpers. Use: generate responses from templates.
+- `Url` - `packages/effect/src/unstable/http/Url.ts` - URL utilities. Use: parse and build URLs.
+- `UrlParams` - `packages/effect/src/unstable/http/UrlParams.ts` - URL parameter helpers. Use: encode query strings.
+
+### `effect/unstable/httpapi`
+
+- `HttpApi` - `packages/effect/src/unstable/httpapi/HttpApi.ts` - Typed HTTP API description. Use: define an API contract.
+- `HttpApiBuilder` - `packages/effect/src/unstable/httpapi/HttpApiBuilder.ts` - Build servers from `HttpApi`. Use: implement typed endpoints.
+- `HttpApiClient` - `packages/effect/src/unstable/httpapi/HttpApiClient.ts` - Client generation for `HttpApi`. Use: call typed APIs.
+- `HttpApiEndpoint` - `packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts` - Endpoint descriptors. Use: define route inputs/outputs.
+- `HttpApiError` - `packages/effect/src/unstable/httpapi/HttpApiError.ts` - HTTP API error types. Use: model typed API failures.
+- `HttpApiGroup` - `packages/effect/src/unstable/httpapi/HttpApiGroup.ts` - Group API endpoints. Use: organize related routes.
+- `HttpApiMiddleware` - `packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts` - API middleware helpers. Use: add auth policies.
+- `HttpApiScalar` - `packages/effect/src/unstable/httpapi/HttpApiScalar.ts` - Scalar UI/integration helpers. Use: expose API docs tooling.
+- `HttpApiSchema` - `packages/effect/src/unstable/httpapi/HttpApiSchema.ts` - Schema annotations for HTTP metadata. Use: tag schema fields for APIs.
+- `HttpApiSecurity` - `packages/effect/src/unstable/httpapi/HttpApiSecurity.ts` - Security scheme helpers. Use: define auth requirements.
+- `HttpApiSwagger` - `packages/effect/src/unstable/httpapi/HttpApiSwagger.ts` - Swagger/OpenAPI integration. Use: serve interactive docs.
+- `HttpApiTest` - `packages/effect/src/unstable/httpapi/HttpApiTest.ts` - HttpApi test helpers. Use: test typed endpoints.
+- `OpenApi` - `packages/effect/src/unstable/httpapi/OpenApi.ts` - OpenAPI generation helpers. Use: export API specs.
+
+### `effect/unstable/observability`
+
+- `Otlp` - `packages/effect/src/unstable/observability/Otlp.ts` - OTLP integration entrypoint. Use: configure OTLP telemetry.
+- `OtlpExporter` - `packages/effect/src/unstable/observability/OtlpExporter.ts` - OTLP exporter utilities. Use: send telemetry externally.
+- `OtlpLogger` - `packages/effect/src/unstable/observability/OtlpLogger.ts` - OTLP log export support. Use: ship structured logs.
+- `OtlpMetrics` - `packages/effect/src/unstable/observability/OtlpMetrics.ts` - OTLP metrics export support. Use: export counters and histograms.
+- `OtlpResource` - `packages/effect/src/unstable/observability/OtlpResource.ts` - OTLP resource metadata helpers. Use: tag service identity.
+- `OtlpSerialization` - `packages/effect/src/unstable/observability/OtlpSerialization.ts` - OTLP serialization helpers. Use: encode telemetry payloads.
+- `OtlpTracer` - `packages/effect/src/unstable/observability/OtlpTracer.ts` - OTLP tracing export support. Use: export spans.
+- `PrometheusMetrics` - `packages/effect/src/unstable/observability/PrometheusMetrics.ts` - Prometheus metrics exporter. Use: expose scrape endpoint.
+
+### `effect/unstable/persistence`
+
+- `KeyValueStore` - `packages/effect/src/unstable/persistence/KeyValueStore.ts` - Key-value storage abstraction. Use: persist simple state.
+- `Persistable` - `packages/effect/src/unstable/persistence/Persistable.ts` - Persistable type helpers. Use: encode stored values.
+- `PersistedCache` - `packages/effect/src/unstable/persistence/PersistedCache.ts` - Durable cache. Use: cache across restarts.
+- `PersistedQueue` - `packages/effect/src/unstable/persistence/PersistedQueue.ts` - Durable queue. Use: persist work items.
+- `Persistence` - `packages/effect/src/unstable/persistence/Persistence.ts` - Persistence service APIs. Use: back durable components.
+- `RateLimiter` - `packages/effect/src/unstable/persistence/RateLimiter.ts` - Persistent rate limiter. Use: enforce cross-process limits.
+- `Redis` - `packages/effect/src/unstable/persistence/Redis.ts` - Redis-backed persistence helpers. Use: store state in Redis.
+
+### `effect/unstable/process`
+
+- `ChildProcess` - `packages/effect/src/unstable/process/ChildProcess.ts` - Child process abstractions. Use: manage spawned commands.
+- `ChildProcessSpawner` - `packages/effect/src/unstable/process/ChildProcessSpawner.ts` - Generic child-process spawning service. Use: launch subprocesses.
+
+### `effect/unstable/reactivity`
+
+- `AsyncResult` - `packages/effect/src/unstable/reactivity/AsyncResult.ts` - Reactive async result type. Use: represent loading/error/data.
+- `Atom` - `packages/effect/src/unstable/reactivity/Atom.ts` - Reactive atom state primitive. Use: local reactive state.
+- `AtomHttpApi` - `packages/effect/src/unstable/reactivity/AtomHttpApi.ts` - HttpApi integration for atoms. Use: sync state over HTTP.
+- `AtomRef` - `packages/effect/src/unstable/reactivity/AtomRef.ts` - Ref-backed atom helpers. Use: bridge refs to reactivity.
+- `AtomRegistry` - `packages/effect/src/unstable/reactivity/AtomRegistry.ts` - Atom registry utilities. Use: track application atoms.
+- `AtomRpc` - `packages/effect/src/unstable/reactivity/AtomRpc.ts` - RPC integration for atoms. Use: sync state over RPC.
+- `Hydration` - `packages/effect/src/unstable/reactivity/Hydration.ts` - Hydration helpers. Use: restore reactive state.
+- `Reactivity` - `packages/effect/src/unstable/reactivity/Reactivity.ts` - Core reactivity utilities. Use: compose reactive computations.
+
+### `effect/unstable/rpc`
+
+- `Rpc` - `packages/effect/src/unstable/rpc/Rpc.ts` - Typed RPC description. Use: define RPC contracts.
+- `RpcClient` - `packages/effect/src/unstable/rpc/RpcClient.ts` - RPC client API. Use: call remote procedures.
+- `RpcClientError` - `packages/effect/src/unstable/rpc/RpcClientError.ts` - RPC client error types. Use: handle transport failures.
+- `RpcGroup` - `packages/effect/src/unstable/rpc/RpcGroup.ts` - Group RPC endpoints. Use: organize procedures.
+- `RpcMessage` - `packages/effect/src/unstable/rpc/RpcMessage.ts` - RPC message model. Use: encode request/response payloads.
+- `RpcMiddleware` - `packages/effect/src/unstable/rpc/RpcMiddleware.ts` - RPC middleware helpers. Use: add auth or tracing.
+- `RpcSchema` - `packages/effect/src/unstable/rpc/RpcSchema.ts` - Schema helpers for RPC. Use: type RPC payloads.
+- `RpcSerialization` - `packages/effect/src/unstable/rpc/RpcSerialization.ts` - RPC serialization helpers. Use: encode wire formats.
+- `RpcServer` - `packages/effect/src/unstable/rpc/RpcServer.ts` - RPC server API. Use: expose procedures.
+- `RpcTest` - `packages/effect/src/unstable/rpc/RpcTest.ts` - RPC testing helpers. Use: test RPC handlers.
+- `RpcWorker` - `packages/effect/src/unstable/rpc/RpcWorker.ts` - Worker integration for RPC. Use: run RPC over workers.
+- `Utils` - `packages/effect/src/unstable/rpc/Utils.ts` - Shared RPC utilities. Use: support custom RPC plumbing.
+
+### `effect/unstable/schema`
+
+- `Model` - `packages/effect/src/unstable/schema/Model.ts` - Unstable schema model helpers. Use: define schema-backed models.
+- `VariantSchema` - `packages/effect/src/unstable/schema/VariantSchema.ts` - Variant/discriminated schema helpers. Use: model tagged unions.
+
+### `effect/unstable/socket`
+
+- `Socket` - `packages/effect/src/unstable/socket/Socket.ts` - Socket abstractions. Use: connect stream transports.
+- `SocketServer` - `packages/effect/src/unstable/socket/SocketServer.ts` - Socket server helpers. Use: accept socket clients.
+
+### `effect/unstable/sql`
+
+- `Migrator` - `packages/effect/src/unstable/sql/Migrator.ts` - SQL migration helpers. Use: run schema migrations.
+- `SqlClient` - `packages/effect/src/unstable/sql/SqlClient.ts` - SQL client API. Use: execute queries.
+- `SqlConnection` - `packages/effect/src/unstable/sql/SqlConnection.ts` - SQL connection abstraction. Use: manage DB sessions.
+- `SqlError` - `packages/effect/src/unstable/sql/SqlError.ts` - SQL error types. Use: classify database failures.
+- `SqlModel` - `packages/effect/src/unstable/sql/SqlModel.ts` - SQL-backed model helpers. Use: map tables to models.
+- `SqlResolver` - `packages/effect/src/unstable/sql/SqlResolver.ts` - SQL request resolution helpers. Use: batch DB-backed requests.
+- `SqlSchema` - `packages/effect/src/unstable/sql/SqlSchema.ts` - Schema helpers for SQL. Use: type query values.
+- `SqlStream` - `packages/effect/src/unstable/sql/SqlStream.ts` - Streaming SQL query helpers. Use: consume large result sets.
+- `Statement` - `packages/effect/src/unstable/sql/Statement.ts` - SQL statement builders/types. Use: prepare typed statements.
+
+### `effect/unstable/workers`
+
+- `Transferable` - `packages/effect/src/unstable/workers/Transferable.ts` - Transferable value helpers. Use: send data between workers.
+- `Worker` - `packages/effect/src/unstable/workers/Worker.ts` - Worker abstractions. Use: run isolated tasks.
+- `WorkerError` - `packages/effect/src/unstable/workers/WorkerError.ts` - Worker error types. Use: handle worker failures.
+- `WorkerRunner` - `packages/effect/src/unstable/workers/WorkerRunner.ts` - Worker runner utilities. Use: host jobs in workers.
+
+### `effect/unstable/workflow`
+
+- `Activity` - `packages/effect/src/unstable/workflow/Activity.ts` - Workflow activity helpers. Use: define durable steps.
+- `DurableClock` - `packages/effect/src/unstable/workflow/DurableClock.ts` - Durable clock API. Use: schedule workflow time.
+- `DurableDeferred` - `packages/effect/src/unstable/workflow/DurableDeferred.ts` - Durable deferred primitive. Use: await external completion.
+- `DurableQueue` - `packages/effect/src/unstable/workflow/DurableQueue.ts` - Durable queue primitive. Use: persist workflow worklists.
+- `Workflow` - `packages/effect/src/unstable/workflow/Workflow.ts` - Workflow definition API. Use: declare durable workflows.
+- `WorkflowEngine` - `packages/effect/src/unstable/workflow/WorkflowEngine.ts` - Workflow engine runtime. Use: execute workflows.
+- `WorkflowProxy` - `packages/effect/src/unstable/workflow/WorkflowProxy.ts` - Workflow client proxy. Use: call workflow instances.
+- `WorkflowProxyServer` - `packages/effect/src/unstable/workflow/WorkflowProxyServer.ts` - Workflow proxy server. Use: expose workflow endpoints.
+
+## `@effect/opentelemetry` Package
+
+Package path: `packages/opentelemetry`
+
+- `Logger` - `packages/opentelemetry/src/Logger.ts` - OpenTelemetry logging integration. Use: export structured logs.
+- `Metrics` - `packages/opentelemetry/src/Metrics.ts` - OpenTelemetry metrics integration. Use: publish application metrics.
+- `NodeSdk` - `packages/opentelemetry/src/NodeSdk.ts` - Node OpenTelemetry SDK wiring. Use: bootstrap telemetry in Node.
+- `Resource` - `packages/opentelemetry/src/Resource.ts` - OpenTelemetry resource helpers. Use: describe service metadata.
+- `Tracer` - `packages/opentelemetry/src/Tracer.ts` - OpenTelemetry tracing integration. Use: create and export spans.
+- `WebSdk` - `packages/opentelemetry/src/WebSdk.ts` - Web OpenTelemetry SDK wiring. Use: bootstrap telemetry in browsers.
+
+## `@effect/platform-browser` Package
+
+Package path: `packages/platform-browser`
+
+- `BrowserHttpClient` - `packages/platform-browser/src/BrowserHttpClient.ts` - Browser HTTP client implementation. Use: make fetch-based requests.
+- `BrowserKeyValueStore` - `packages/platform-browser/src/BrowserKeyValueStore.ts` - Browser key-value storage adapter. Use: persist small client values.
+- `BrowserPersistence` - `packages/platform-browser/src/BrowserPersistence.ts` - Browser persistence services. Use: store app state locally.
+- `BrowserRuntime` - `packages/platform-browser/src/BrowserRuntime.ts` - Browser runtime entrypoints. Use: run Effect apps in browsers.
+- `BrowserSocket` - `packages/platform-browser/src/BrowserSocket.ts` - Browser socket implementation. Use: open WebSocket-style connections.
+- `BrowserStream` - `packages/platform-browser/src/BrowserStream.ts` - Browser stream adapters. Use: bridge web streams.
+- `BrowserWorker` - `packages/platform-browser/src/BrowserWorker.ts` - Browser worker integration. Use: communicate with web workers.
+- `BrowserWorkerRunner` - `packages/platform-browser/src/BrowserWorkerRunner.ts` - Worker-side runtime helpers. Use: run Effect code inside workers.
+- `Clipboard` - `packages/platform-browser/src/Clipboard.ts` - Clipboard API wrappers. Use: read or write clipboard data.
+- `Geolocation` - `packages/platform-browser/src/Geolocation.ts` - Geolocation API wrappers. Use: access device location.
+- `IndexedDb` - `packages/platform-browser/src/IndexedDb.ts` - IndexedDB integration. Use: build browser databases.
+- `IndexedDbDatabase` - `packages/platform-browser/src/IndexedDbDatabase.ts` - IndexedDB database helpers. Use: define database handles.
+- `IndexedDbQueryBuilder` - `packages/platform-browser/src/IndexedDbQueryBuilder.ts` - IndexedDB query builder. Use: compose indexed queries.
+- `IndexedDbTable` - `packages/platform-browser/src/IndexedDbTable.ts` - IndexedDB table helpers. Use: work with object stores.
+- `IndexedDbVersion` - `packages/platform-browser/src/IndexedDbVersion.ts` - IndexedDB versioning helpers. Use: manage schema upgrades.
+- `Permissions` - `packages/platform-browser/src/Permissions.ts` - Permissions API wrappers. Use: query browser permissions.
+
+## `@effect/platform-bun` Package
+
+Package path: `packages/platform-bun`
+
+- `BunChildProcessSpawner` - `packages/platform-bun/src/BunChildProcessSpawner.ts` - Bun child-process spawner. Use: launch subprocesses.
+- `BunClusterHttp` - `packages/platform-bun/src/BunClusterHttp.ts` - Bun clustered HTTP helpers. Use: scale HTTP servers.
+- `BunClusterSocket` - `packages/platform-bun/src/BunClusterSocket.ts` - Bun clustered socket helpers. Use: scale socket servers.
+- `BunFileSystem` - `packages/platform-bun/src/BunFileSystem.ts` - Bun file system implementation. Use: do Bun-based file I/O.
+- `BunHttpClient` - `packages/platform-bun/src/BunHttpClient.ts` - Bun HTTP client implementation. Use: make outbound HTTP requests.
+- `BunHttpPlatform` - `packages/platform-bun/src/BunHttpPlatform.ts` - Bun HTTP platform services. Use: provide HTTP runtime pieces.
+- `BunHttpServer` - `packages/platform-bun/src/BunHttpServer.ts` - Bun HTTP server implementation. Use: serve HTTP endpoints.
+- `BunHttpServerRequest` - `packages/platform-bun/src/BunHttpServerRequest.ts` - Bun request adapters. Use: read incoming HTTP requests.
+- `BunMultipart` - `packages/platform-bun/src/BunMultipart.ts` - Bun multipart parsing. Use: handle form uploads.
+- `BunPath` - `packages/platform-bun/src/BunPath.ts` - Bun path service. Use: resolve filesystem paths.
+- `BunRedis` - `packages/platform-bun/src/BunRedis.ts` - Bun Redis integration. Use: talk to Redis.
+- `BunRuntime` - `packages/platform-bun/src/BunRuntime.ts` - Bun runtime entrypoints. Use: run Effect apps on Bun.
+- `BunServices` - `packages/platform-bun/src/BunServices.ts` - Bun service bundle. Use: provide common Bun services.
+- `BunSink` - `packages/platform-bun/src/BunSink.ts` - Bun sink adapters. Use: write streamed output.
+- `BunSocket` - `packages/platform-bun/src/BunSocket.ts` - Bun socket implementation. Use: manage socket connections.
+- `BunSocketServer` - `packages/platform-bun/src/BunSocketServer.ts` - Bun socket server implementation. Use: accept socket clients.
+- `BunStdio` - `packages/platform-bun/src/BunStdio.ts` - Bun stdio integration. Use: access stdin/stdout/stderr.
+- `BunStream` - `packages/platform-bun/src/BunStream.ts` - Bun stream adapters. Use: bridge Bun streams.
+- `BunTerminal` - `packages/platform-bun/src/BunTerminal.ts` - Bun terminal integration. Use: build CLI terminal interactions.
+- `BunWorker` - `packages/platform-bun/src/BunWorker.ts` - Bun worker integration. Use: communicate with workers.
+- `BunWorkerRunner` - `packages/platform-bun/src/BunWorkerRunner.ts` - Bun worker runtime helpers. Use: run Effect code in workers.
+
+## `@effect/platform-node` Package
+
+Package path: `packages/platform-node`
+
+- `Mime` - `packages/platform-node/src/Mime.ts` - MIME type helpers. Use: detect or assign content types.
+- `NodeChildProcessSpawner` - `packages/platform-node/src/NodeChildProcessSpawner.ts` - Node child-process spawner. Use: launch subprocesses.
+- `NodeClusterHttp` - `packages/platform-node/src/NodeClusterHttp.ts` - Node clustered HTTP helpers. Use: scale HTTP servers.
+- `NodeClusterSocket` - `packages/platform-node/src/NodeClusterSocket.ts` - Node clustered socket helpers. Use: scale socket servers.
+- `NodeFileSystem` - `packages/platform-node/src/NodeFileSystem.ts` - Node file system implementation. Use: do Node-based file I/O.
+- `NodeHttpClient` - `packages/platform-node/src/NodeHttpClient.ts` - Node HTTP client implementation. Use: make outbound HTTP requests.
+- `NodeHttpIncomingMessage` - `packages/platform-node/src/NodeHttpIncomingMessage.ts` - Node incoming message adapters. Use: read raw Node HTTP messages.
+- `NodeHttpPlatform` - `packages/platform-node/src/NodeHttpPlatform.ts` - Node HTTP platform services. Use: provide HTTP runtime pieces.
+- `NodeHttpServer` - `packages/platform-node/src/NodeHttpServer.ts` - Node HTTP server implementation. Use: serve HTTP endpoints.
+- `NodeHttpServerRequest` - `packages/platform-node/src/NodeHttpServerRequest.ts` - Node request adapters. Use: read incoming HTTP requests.
+- `NodeMultipart` - `packages/platform-node/src/NodeMultipart.ts` - Node multipart parsing. Use: handle form uploads.
+- `NodePath` - `packages/platform-node/src/NodePath.ts` - Node path service. Use: resolve filesystem paths.
+- `NodeRedis` - `packages/platform-node/src/NodeRedis.ts` - Node Redis integration. Use: talk to Redis.
+- `NodeRuntime` - `packages/platform-node/src/NodeRuntime.ts` - Node runtime entrypoints. Use: run Effect apps on Node.
+- `NodeServices` - `packages/platform-node/src/NodeServices.ts` - Node service bundle. Use: provide common Node services.
+- `NodeSink` - `packages/platform-node/src/NodeSink.ts` - Node sink adapters. Use: write streamed output.
+- `NodeSocket` - `packages/platform-node/src/NodeSocket.ts` - Node socket implementation. Use: manage socket connections.
+- `NodeSocketServer` - `packages/platform-node/src/NodeSocketServer.ts` - Node socket server implementation. Use: accept socket clients.
+- `NodeStdio` - `packages/platform-node/src/NodeStdio.ts` - Node stdio integration. Use: access stdin/stdout/stderr.
+- `NodeStream` - `packages/platform-node/src/NodeStream.ts` - Node stream adapters. Use: bridge Node streams.
+- `NodeTerminal` - `packages/platform-node/src/NodeTerminal.ts` - Node terminal integration. Use: build CLI terminal interactions.
+- `NodeWorker` - `packages/platform-node/src/NodeWorker.ts` - Node worker integration. Use: communicate with worker threads.
+- `NodeWorkerRunner` - `packages/platform-node/src/NodeWorkerRunner.ts` - Node worker runtime helpers. Use: run Effect code in workers.
+- `Undici` - `packages/platform-node/src/Undici.ts` - Undici integration helpers. Use: use Undici-based HTTP features.
+
+## `@effect/platform-node-shared` Package
+
+Package path: `packages/platform-node-shared`
+
+- No public `src/index.ts` barrel is present in this vendored repo, so there are no barrel exports to inventory here.
+
+## `@effect/vitest` Package
+
+Package path: `packages/vitest`
+
+- `vitest` - `packages/vitest/src/index.ts` - Re-export of `vitest` APIs. Use: use standard Vitest APIs.
+- `API` - `packages/vitest/src/index.ts` - Test API type alias. Use: type custom test helpers.
+- `Vitest` - `packages/vitest/src/index.ts` - Effect-aware Vitest namespace types. Use: type Effect-based tests.
+- `addEqualityTesters` - `packages/vitest/src/index.ts` - Installs equality testers. Use: compare Effect values in assertions.
+- `effect` - `packages/vitest/src/index.ts` - Effect-aware `it` variant. Use: write scoped Effect tests.
+- `live` - `packages/vitest/src/index.ts` - Live-service test variant. Use: run tests with live services.
+- `layer` - `packages/vitest/src/index.ts` - Share a `Layer` across tests. Use: provide services to test groups.
+- `flakyTest` - `packages/vitest/src/index.ts` - Flaky-test wrapper. Use: stabilize eventually consistent checks.
+- `prop` - `packages/vitest/src/index.ts` - Property-test helper. Use: generate property-based cases.
+- `it` - `packages/vitest/src/index.ts` - Extended Vitest `it`. Use: mix regular and Effect tests.
+- `makeMethods` - `packages/vitest/src/index.ts` - Build extended test methods. Use: wrap a custom test API.
+- `describeWrapped` - `packages/vitest/src/index.ts` - `describe` helper with Effect methods. Use: define grouped Effect test suites.

--- a/.claude/skills/effect-ts/references/guide-effect.md
+++ b/.claude/skills/effect-ts/references/guide-effect.md
@@ -1,0 +1,447 @@
+# Effect Guide
+
+This guide is based on common usage patterns in the vendored repo at `./.repos/effect`.
+
+Key source areas:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/tools/`
+- `./.repos/effect/packages/platform-*`
+- `./.repos/effect/packages/opentelemetry/`
+- `./.repos/effect/packages/vitest/`
+
+## Mental Model
+
+`Effect<A, E, R>` is the default way to represent application work.
+
+It describes a computation that:
+
+- succeeds with `A`
+- fails with `E`
+- requires services `R`
+
+The repo consistently uses `Effect` as the main abstraction for:
+
+- business workflows
+- service methods
+- platform integrations
+- resource lifecycles
+- tests
+
+## Most Common Patterns In The Repo
+
+The dominant usage pattern is:
+
+1. use `Effect.gen` for workflows and orchestration
+2. use `Effect.fn` for reusable effectful functions
+3. use precise constructors such as `succeed`, `fail`, `sync`, `try`, and `tryPromise`
+4. use `map`, `flatMap`, and `tap` for local transformations
+5. access services in implementations and `provide*` only at edges
+6. use `acquireRelease` and `scoped` for owned resources
+7. use `catchTag` and `match` for typed recovery
+8. use `run*` only at runtime boundaries
+
+## Prefer `Effect.fn` For Reusable Operations
+
+For reusable effectful operations, prefer `Effect.fn`.
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Use `Effect.fn` when:
+
+- the operation is reusable
+- the operation takes parameters
+- the operation is part of business logic or a module API
+- you want consistent tracing and stack frames
+
+Do not treat `Effect.fnUntraced` as the default. If you do not want an explicit named span, use `Effect.fn` without a span name.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+
+## Use `Effect.gen` For Workflows
+
+Use `Effect.gen` for orchestration and sequential workflows, especially when there are multiple `yield*` steps.
+
+```ts
+const program = Effect.gen(function*() {
+  const config = yield* Config
+  const repo = yield* UserRepo
+  const user = yield* repo.getById("u_123")
+  return { config, user }
+})
+```
+
+Use `Effect.gen` when:
+
+- the body is a workflow
+- you are reading multiple services
+- you have branching or multiple sequential steps
+- you are implementing a layer, handler, or orchestration
+
+Repo examples:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+
+## `Effect.fn` vs `Effect.gen`
+
+Use this rule:
+
+- reusable operation: `Effect.fn`
+- inline workflow block: `Effect.gen`
+
+Good split:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+
+const program = Effect.gen(function*() {
+  const user = yield* loadUser("u_123")
+  yield* Effect.logInfo("loaded user", user)
+})
+```
+
+## `Effect.fnUntraced` Is An Escape Hatch
+
+For application and business code, `Effect.fnUntraced` is not the default.
+
+Use it only when:
+
+- the function is an internal low-level helper
+- observability is intentionally being traded away
+- there is a concrete performance or tracing reason
+
+If the only goal is to avoid an explicit named span, prefer:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Instead of:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+## Constructor Functions
+
+The repo uses constructor functions very deliberately.
+
+### `Effect.succeed`
+
+Use for pure successful values.
+
+```ts
+const ok = Effect.succeed(42)
+```
+
+### `Effect.fail`
+
+Use for expected typed failures.
+
+```ts
+const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }))
+```
+
+### `Effect.sync`
+
+Use for synchronous side effects or pure synchronous construction that should live inside `Effect`.
+
+```ts
+const buildConfig = Effect.sync(() => ({ retries: 3 }))
+```
+
+### `Effect.try`
+
+Use for synchronous code that may throw.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
+  cause: Schema.Defect
+}) {}
+
+const parseJson = (input: string) =>
+  Effect.try({
+    try: () => JSON.parse(input),
+    catch: (cause) => ParseError.make({ cause })
+  })
+```
+
+### `Effect.tryPromise`
+
+Use for Promise-returning APIs.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class FetchError extends Schema.TaggedErrorClass<FetchError>()("FetchError", {
+  cause: Schema.Defect
+}) {}
+
+const fetchText = (url: string) =>
+  Effect.tryPromise({
+    try: () => fetch(url).then((response) => response.text()),
+    catch: (cause) => FetchError.make({ cause })
+  })
+```
+
+Preferred rule:
+
+- pure value: `succeed`
+- expected failure: `fail`
+- synchronous non-throwing effect: `sync`
+- synchronous throwing boundary: `try`
+- Promise boundary: `tryPromise`
+
+## Local Composition
+
+The repo uses `map`, `flatMap`, and `tap` constantly for small local transformations.
+
+### `Effect.map`
+
+Use to transform successful values.
+
+```ts
+const userName = loadUser("u_123").pipe(
+  Effect.map((user) => user.name)
+)
+```
+
+### `Effect.flatMap`
+
+Use when the next step returns another `Effect`.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.flatMap((user) => saveAudit(user.id))
+)
+```
+
+### `Effect.tap`
+
+Use for side effects that should preserve the main value.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.tap((user) => Effect.logDebug("loaded user", { userId: user.id }))
+)
+```
+
+Preferred rule:
+
+- outer workflow: `Effect.gen`
+- local transformation: `map`, `flatMap`, `tap`
+
+## Services And Provisioning
+
+Repo style is:
+
+- access services in implementation code
+- provide them at boundaries
+
+### Access services in implementations
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+```
+
+or:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.service(UserRepo).pipe(
+    Effect.flatMap((repo) => repo.getById(userId))
+  )
+```
+
+### Provide at the edge
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Use `provideService` and `provideServiceEffect` for targeted overrides, especially in tests or framework boundaries.
+
+Do not default to exporting thin accessor functions that just fetch a service and forward to one service method. Prefer real business operations or direct service usage within the owning workflow.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/bin.ts`
+- `./.repos/effect/packages/tools/openapi-generator/test/`
+
+## Error Handling
+
+Common repo patterns:
+
+- `catchTag` for expected tagged errors
+- `match` for totalizing an effect into a value
+- `catchCause` for full-cause infra handling
+
+### `Effect.catchTag`
+
+Use for targeted typed recovery.
+
+```ts
+const safe = loadUser("u_123").pipe(
+  Effect.catchTag("UserNotFound", () => Effect.succeed(null))
+)
+```
+
+### `Effect.match`
+
+Use when the caller wants a value either way.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.match({
+    onFailure: () => null,
+    onSuccess: (user) => user
+  })
+)
+```
+
+For deeper guidance, see `./references/guide-error-handling.md`.
+
+## Resource Management
+
+One of the strongest repo patterns is explicit resource ownership.
+
+### `Effect.acquireRelease`
+
+Use for resources that must be cleaned up.
+
+```ts
+const connection = Effect.acquireRelease(
+  openConnection,
+  (conn) => closeConnection(conn)
+)
+```
+
+### `Effect.scoped`
+
+Use when a workflow consumes scoped resources and should tie cleanup to scope lifetime.
+
+```ts
+const program = Effect.scoped(
+  Effect.gen(function*() {
+    const conn = yield* connection
+    return yield* conn.query("select 1")
+  })
+)
+```
+
+Repo examples:
+
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+
+## SQL And Runtime Integrations
+
+When Effect already provides a domain module for a capability, prefer that module over direct raw runtime client usage in business code.
+
+Important example:
+
+- prefer Effect SQL modules from `effect/unstable/sql/*` over embedding a native SQL driver directly in domain services
+
+Why:
+
+- transactions, spans, and typed errors stay inside the Effect model
+- layering stays cleaner
+- migrations and query conventions stay consistent
+
+For SQL-specific guidance, see `./references/guide-sql.md`.
+
+## Observability
+
+The repo uses observability around meaningful boundaries, not every tiny helper.
+
+Common patterns:
+
+- `Effect.fn` for named operations
+- `Effect.withSpan` for nested span boundaries
+- `Effect.log*` for operational events
+- `Effect.track` for metrics
+
+For detailed guidance, see `./references/guide-observability.md`.
+
+## Runtime Boundaries
+
+The repo keeps `run*` APIs at true runtime boundaries.
+
+### `Effect.runPromise`
+
+Use when leaving Effect world into Promise-based hosts.
+
+### `Effect.runFork`
+
+Use for background fibers or long-running integration hooks.
+
+### `Effect.runSync`
+
+Use sparingly, mostly in specialized internals where synchrony is guaranteed.
+
+Preferred rule:
+
+- library/business code should return `Effect`
+- entrypoints and integration boundaries should run `Effect`
+
+If you have multiple external entrypoints, prefer `ManagedRuntime`.
+
+## Commonly Used Effect APIs In This Repo
+
+These are the most practically important `Effect` functions to know first:
+
+- `Effect.fn`
+- `Effect.gen`
+- `Effect.succeed`
+- `Effect.fail`
+- `Effect.sync`
+- `Effect.try`
+- `Effect.tryPromise`
+- `Effect.map`
+- `Effect.flatMap`
+- `Effect.tap`
+- `Effect.service`
+- `Effect.provide`
+- `Effect.provideService`
+- `Effect.catchTag`
+- `Effect.match`
+- `Effect.acquireRelease`
+- `Effect.scoped`
+- `Effect.withSpan`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.runPromise`
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/vitest/src/index.ts`

--- a/.claude/skills/effect-ts/references/guide-error-handling.md
+++ b/.claude/skills/effect-ts/references/guide-error-handling.md
@@ -1,0 +1,540 @@
+# Error Handling Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Mental Model
+
+Effect distinguishes three failure modes:
+
+- failure: expected, typed errors in the `E` channel of `Effect<A, E, R>`
+- defect: unexpected unchecked failures, represented as `Cause.Die`
+- interrupt: cooperative cancellation, represented as `Cause.Interrupt`
+
+This distinction is explicit in `Cause`.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Error Definition Styles
+
+Preference order:
+
+1. use schema-based errors when possible
+2. fall back to `Data.TaggedError` only when the error payload is not meaningfully serializable or schema-shaped
+
+Schema-based errors are strictly more powerful because they give you:
+
+- typed yieldable errors
+- schema-defined fields
+- encode/decode support
+- better protocol and boundary interoperability
+- stronger documentation and tooling hooks
+
+### 1. `Schema.TaggedErrorClass` for schema-backed tagged errors
+
+Use `Schema.TaggedErrorClass` by default when the error can be described with schemas.
+
+Why:
+
+- it creates a yieldable tagged error
+- fields are defined with `Schema`
+- the error shape can participate in schema-based tooling and encode/decode flows
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()(
+  "InvalidPayload",
+  {
+    field: Schema.String,
+    reason: Schema.String
+  }
+) {}
+
+const validate = Effect.fail(
+  InvalidPayload.make({
+    field: "email",
+    reason: "missing"
+  })
+)
+```
+
+Use this when:
+
+- the error is part of a protocol or transport boundary
+- the error needs a precise schema representation
+- the error should be serializable or documented structurally
+
+This is also a good default for domain errors when their payload is schema-friendly.
+
+### 2. `Schema.ErrorClass` for schema-backed errors without `_tag` routing
+
+Use `Schema.ErrorClass` when you want schema-defined error objects but do not specifically need tag-based pattern matching.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- examples across `./.repos/effect/packages/effect/src/unstable/*`
+
+Example shape from the vendored repo:
+
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+
+### 3. `Data.TaggedError` for non-serializable or lightweight domain errors
+
+Use `Data.TaggedError` when schema-based errors are not a good fit.
+
+This is mainly the fallback for:
+
+- non-serializable payloads
+- ad hoc in-memory-only errors
+- cases where schema shape would be artificial or misleading
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+
+Example:
+
+```ts
+import { Data, Effect } from "effect"
+
+class UserNotFound extends Data.TaggedError("UserNotFound")<{
+  readonly userId: string
+}> {}
+
+const loadUser = (userId: string) =>
+  Effect.fail(new UserNotFound({ userId }))
+
+const program = Effect.gen(function*() {
+  yield* loadUser("u_123")
+})
+```
+
+## When To Prefer `Data.TaggedError` vs `Schema.TaggedErrorClass`
+
+Prefer `Schema.TaggedErrorClass` when:
+
+- the error can be expressed as a schema
+- the error payload must be described by schemas
+- the error crosses process, protocol, persistence, or serialization boundaries
+- you want the error type to participate in schema tooling
+
+Prefer `Data.TaggedError` when:
+
+- the payload is not meaningfully serializable
+- the payload cannot reasonably be modeled as a schema
+- the error is intentionally local and in-memory only
+
+## Schema-Based Error Workflows
+
+### Boundary validation should fail with `SchemaError`
+
+When validating external input, Effect's schema APIs return `SchemaError` in the error channel.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownEffect`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = Schema.decodeUnknownEffect(UserPayload)
+```
+
+This gives you:
+
+- success: validated typed data
+- failure: `Schema.SchemaError`
+
+### Normalize `SchemaError` at the boundary
+
+For application code, it is often better to convert `SchemaError` into a domain error near the boundary.
+
+Example:
+
+```ts
+import { Data, Effect, Schema } from "effect"
+
+class InvalidRequestBody extends Data.TaggedError("InvalidRequestBody")<{
+  readonly message: string
+}> {}
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = (input: unknown) =>
+  Schema.decodeUnknownEffect(UserPayload)(input).pipe(
+    Effect.catchTag("SchemaError", (error) =>
+      Effect.fail(new InvalidRequestBody({ message: error.message }))
+    )
+  )
+```
+
+Why:
+
+- transport validation stays close to the transport layer
+- the rest of the application can work with domain-specific errors
+
+### Use schema-backed errors for protocol errors
+
+The vendored repo uses schema-backed errors in places like SQL, RPC, sockets, and HTTP APIs.
+
+Strong examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/eventlog/EventLogMessage.ts`
+
+These are good reference points when the error contract matters externally.
+
+## Wrapping Foreign Or Generic Errors
+
+When an error comes from a library, runtime API, or generic `Error`, prefer wrapping it in a typed error instead of leaking the foreign error directly through your domain or protocol boundary.
+
+This is a very common pattern in the vendored repo.
+
+Good examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Redis.ts`
+
+### Preferred Pattern
+
+Wrap the foreign error in a schema-backed typed error and preserve the original error in a `cause` field.
+
+Prefer using:
+
+- `Schema.Defect` when you want to preserve a generic encoded defect
+- `Schema.DefectWithStack` when the stack should be preserved in the schema contract
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class TodoStorageError extends Schema.TaggedErrorClass<TodoStorageError>()(
+  "TodoStorageError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect
+  }
+) {}
+
+const makeStorageError = (operation: string) => (cause: unknown) =>
+  TodoStorageError.make({
+    operation,
+    cause
+  })
+
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: makeStorageError("loadTodo")
+  })
+```
+
+When stack preservation matters in the encoded schema, prefer:
+
+```ts
+class WorkerFailure extends Schema.TaggedErrorClass<WorkerFailure>()(
+  "WorkerFailure",
+  {
+    cause: Schema.DefectWithStack
+  }
+) {}
+```
+
+### Why This Is Preferred
+
+- the application still exposes a typed error contract
+- the original foreign failure is preserved for diagnostics
+- schema-aware transports can encode and decode the failure shape
+- business code does not become coupled to a raw library error type
+
+### When To Use This Pattern
+
+Use it when:
+
+- a third-party library throws or rejects with `Error`
+- a runtime API returns generic failures
+- a lower-level subsystem failure should be surfaced through a typed domain or protocol error
+- you need to preserve the underlying failure for debugging without leaking the foreign type as the public error contract
+
+### `Schema.Defect` vs `Schema.DefectWithStack`
+
+Prefer `Schema.Defect` by default.
+
+Use `Schema.DefectWithStack` when:
+
+- stack information is part of the intended encoded error contract
+- the error is primarily infrastructural or diagnostic
+- the downstream consumer benefits from the preserved stack
+
+### Avoid This Anti-Pattern
+
+Avoid exposing raw generic errors directly as the application error contract.
+
+Bad:
+
+```ts
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: (cause) => cause as Error
+  })
+```
+
+Why this is bad:
+
+- the error channel loses a stable typed contract
+- the code depends on unsafe assertions
+- transport and schema integration become weaker
+- callers must understand foreign error shapes instead of your own typed error model
+
+## Handling Failures
+
+### Handle specific tagged errors with `Effect.catchTag`
+
+Use `catchTag` when your error type has `_tag` and you want focused recovery.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+Example:
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTag("UserNotFound", (error) =>
+    Effect.succeed({ id: error.userId, guest: true })
+  )
+)
+```
+
+### Handle several tagged errors with `Effect.catchTags`
+
+Use `catchTags` when multiple domain errors should be handled together.
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTags({
+    UserNotFound: () => Effect.succeed(null),
+    InvalidPayload: (error) => Effect.succeed({ error: error.reason })
+  })
+)
+```
+
+### Handle predicate-based subsets with `Effect.catchIf`
+
+Use `catchIf` when matching on a predicate or refinement, not just `_tag`.
+
+### Turn failure into a value with `Effect.match`
+
+Use `match` when you want to fully fold the typed error channel into a success value.
+
+```ts
+const outcome = program.pipe(
+  Effect.match({
+    onFailure: (error) => ({ ok: false as const, error }),
+    onSuccess: (value) => ({ ok: true as const, value })
+  })
+)
+```
+
+## Handling Defects
+
+Defects are not normal domain failures.
+
+They come from:
+
+- `Effect.die`
+- unchecked exceptions in effectful code
+- invariants that were broken
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Preferred rule
+
+Do not model expected business failures as defects.
+
+Use defects for:
+
+- impossible states
+- programmer errors
+- unrecoverable infrastructure corruption
+
+### Inspect defects with `sandbox`, `catchCause`, or `matchCause`
+
+Use `sandbox` to expose `Cause<E>` in the error channel.
+
+```ts
+import { Cause, Effect } from "effect"
+
+const diagnosed = program.pipe(
+  Effect.sandbox,
+  Effect.catchCause((cause) => {
+    if (Cause.hasDies(cause)) {
+      return Effect.succeed("defect")
+    }
+    return Effect.failCause(cause)
+  })
+)
+```
+
+Use `matchCause` or `matchCauseEffect` when you need to distinguish:
+
+- typed failures
+- defects
+- interrupts
+
+### Boundary-only recovery for defects
+
+If you recover from defects at all, do it only at clear boundaries.
+
+Examples:
+
+- worker or RPC boundary
+- CLI top-level runner
+- HTTP server adapter
+
+Typical pattern:
+
+- log or report defect details
+- translate to a safe external error
+- avoid continuing as if it were a normal domain failure
+
+### `Effect.orDie`
+
+Use `orDie` when an error channel should be treated as unrecoverable from this point onward.
+
+That is appropriate when:
+
+- a failure has already been validated elsewhere as impossible
+- continuing with typed recovery would only obscure a broken invariant
+
+Do not use `orDie` just to silence a type you do not want to handle.
+
+## Handling Interrupts
+
+Interrupts are cancellation, not business failure.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Use `Effect.interrupt` to stop work cooperatively
+
+Interrupts signal that the fiber should stop. They should not usually be translated into a domain error.
+
+### Use `Effect.onInterrupt` for cleanup
+
+If interrupted work needs special cleanup, use `onInterrupt`.
+
+```ts
+import { Console, Effect } from "effect"
+
+const program = longRunningTask.pipe(
+  Effect.onInterrupt(() => Console.log("cleaning up after interrupt"))
+)
+```
+
+### Use `Cause` inspection when interrupts must be distinguished
+
+When handling full causes, use `Cause.isInterruptReason`, `Cause.hasInterrupts`, or filtering over `cause.reasons`.
+
+This is useful for:
+
+- deciding whether to suppress logs for normal cancellation
+- keeping retries for failure but not for cancellation
+- distinguishing timeout/cancel flows from real errors
+
+### Do not treat interrupts as ordinary failures
+
+Avoid patterns that collapse all causes into a single error value too early. Interrupts often need different operational behavior.
+
+## Recommended Patterns
+
+### Pattern: domain errors inside the app, schema errors at the edge
+
+- decode external input with `Schema.decodeUnknownEffect`
+- convert `SchemaError` into a domain or transport error near the boundary
+- keep the rest of the application on domain errors
+
+### Pattern: tagged errors for recovery
+
+- define domain failures with `Data.TaggedError`
+- recover with `catchTag` or `catchTags`
+- keep `_tag` names stable and descriptive
+
+### Pattern: schema-backed errors for protocols
+
+- use `Schema.TaggedErrorClass` or `Schema.ErrorClass` when the error contract itself matters
+- follow examples in SQL, socket, RPC, and HTTP modules
+
+### Pattern: only inspect `Cause` when you really need the full failure structure
+
+Use `catchCause`, `matchCause`, or `sandbox` when you must distinguish:
+
+- expected failures
+- defects
+- interrupts
+
+Otherwise prefer the simpler typed error operators.
+
+## Anti-Patterns
+
+- using defects for expected validation or business-rule failures
+- converting every error immediately to `unknown` or `string`
+- using `orDie` to avoid proper handling of expected errors
+- treating interrupts as ordinary business failures
+- leaking `SchemaError` deep into domain code when it should be normalized at the boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpServerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`

--- a/.claude/skills/effect-ts/references/guide-layers.md
+++ b/.claude/skills/effect-ts/references/guide-layers.md
@@ -1,0 +1,1018 @@
+# Layers Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## Mental Model
+
+A service is a typed dependency.
+
+A layer is a recipe for building one or more services, possibly using other services as dependencies.
+
+Effect's model is:
+
+- define service identifiers with `Context.Service` or `Context.Service(...)`
+- require services from effects with `Effect.service` or by yielding the service key directly
+- build implementations with `Layer`
+- provide layers at the program boundary or subsystem boundary
+
+`Layer<ROut, E, RIn>` means:
+
+- `ROut`: services produced by the layer
+- `E`: possible failures while constructing the layer
+- `RIn`: dependencies required to build it
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+
+## Services
+
+## What A Service Is
+
+A service is a typed key plus its implementation shape.
+
+In Effect, services are values in `Context`, not global singletons.
+
+This gives you:
+
+- explicit dependencies
+- easy substitution in tests
+- layer-based composition
+- multiple implementations for the same interface
+
+## Preferred Service Definition Style
+
+Prefer the class syntax with `Context.Service`.
+
+This matches the vendored repo's current style.
+
+There are two good definition styles:
+
+- explicit service shape in the `Context.Service<...>` generic
+- inferred service shape from the `make` argument
+
+Example:
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserRepoError>
+}>()("UserRepo") {}
+```
+
+Why this style is preferred:
+
+- the service identifier and shape live in one place
+- it works naturally with `yield* UserRepo`
+- it matches the patterns used across `.repos/effect`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+## Service Shape Inference With `make`
+
+When the implementation shape is clearer than the interface declaration, prefer using the `make` argument so the service shape is inferred from the implementation.
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo>()("UserRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("UserRepo.getById")(function*(id: string) {
+      return yield* Effect.fail(
+        UserRepoError.make({ message: `User ${id} not found` })
+      )
+    })
+  })
+}) {}
+```
+
+Why this style is useful:
+
+- the implementation and inferred API stay together
+- TypeScript derives the service shape automatically
+- it avoids repeating the same method signatures twice
+
+Prefer this style when:
+
+- the implementation is small and obvious
+- the explicit service shape would only duplicate the implementation
+
+Prefer the explicit generic shape when:
+
+- you want the contract stated before the implementation
+- the API surface should be emphasized separately from the implementation
+
+## Service Example
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
+  "UserNotFound",
+  {
+    userId: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserNotFound>
+}>()("UserRepo") {}
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+```
+
+Key points:
+
+- `UserRepo` is both the identifier and a value you can yield from `Effect.gen`
+- the implementation shape is explicit in the service definition
+- the effect that uses it stays abstract over the implementation
+
+## When To Use `Context.Reference`
+
+Use `Context.Reference` for contextual values with defaults, not for full service APIs.
+
+Good use cases:
+
+- current configuration knobs
+- current request metadata
+- feature flags or tracing flags with defaults
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+Use a full service instead when:
+
+- behavior matters more than data
+- you need multiple methods
+- you want a concrete test double or alternate implementation
+
+## Accessing Services
+
+Common patterns:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+})
+```
+
+or:
+
+```ts
+const program = Effect.service(UserRepo).pipe(
+  Effect.flatMap((repo) => repo.getById("u_123"))
+)
+```
+
+Best practice:
+
+- use `yield* Service` or `Effect.service(Service)` inside business logic
+- do not manually thread service implementations through function arguments when they are real application dependencies
+
+## Service Encapsulation
+
+Prefer keeping service access inside the business operation that needs it rather than exporting thin accessor wrappers for every method.
+
+Avoid this pattern:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoService
+  return yield* todos.create(title)
+})
+```
+
+Why this is usually a bad pattern:
+
+- it leaks the service dependency into a second public API layer
+- it encourages a redundant accessor function per service method
+- it spreads dependency access patterns across the codebase
+- it weakens service encapsulation instead of improving it
+
+Prefer one of these patterns instead:
+
+1. Put the real business logic in a function that uses the service internally because it adds behavior beyond simple forwarding.
+2. Expose the service itself and call its methods from the module that owns the workflow.
+3. If you need a public operation, make it a real business operation, not a trivial alias of one service method.
+
+Good:
+
+```ts
+export const completeTodo = Effect.fn("completeTodo")(function*(id: number) {
+  const todos = yield* TodoService
+  const todo = yield* todos.getById(id)
+  if (todo.completed) {
+    return todo
+  }
+  return yield* todos.setCompleted(id, true)
+})
+```
+
+This is good because:
+
+- the exported function represents a business operation
+- the service remains an internal dependency of that operation
+- the function adds behavior rather than just forwarding one method call
+
+## Layers
+
+## What A Layer Is
+
+A layer constructs services from dependencies.
+
+Use a layer when:
+
+- service construction is effectful
+- the service depends on other services
+- the service owns resources that must be acquired and released safely
+- you want composition and reuse across modules
+
+## Preferred Layer Constructors
+
+### `Layer.succeed`
+
+Use for pure, already-constructed implementations.
+
+```ts
+const UserRepoTest = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test User" })
+})
+```
+
+Use this when:
+
+- construction is pure
+- no dependencies are needed
+- no scoped resources are involved
+
+### `Layer.effect`
+
+Use when constructing a service requires effects, other services, or scoped resource acquisition.
+
+```ts
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Fetched from ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+```
+
+Use this when:
+
+- construction is effectful
+- construction depends on other services
+- construction needs `Scope` and finalization
+- you want typed construction failure
+
+This is also the correct constructor for services that own resources with acquisition and release semantics. In this repo, `Layer.effect` replaces the old `Layer.scoped` API.
+
+Typical examples:
+
+- database pools
+- sockets
+- background worker processes
+- long-lived subscriptions
+
+### `Layer.effectDiscard`
+
+Use `Layer.effectDiscard` for scoped startup effects that do not provide a service.
+
+Good use cases:
+
+- starting background fibers in a layer
+- one-time scoped initialization side effects
+- subsystem startup hooks
+
+### `Layer.effectContext`
+
+Use when one effect constructs a full `Context` containing multiple services.
+
+This is useful for subsystem builders that provide several related services together.
+
+## Layer Composition
+
+These operators do different things. Do not treat them as interchangeable.
+
+### Composition Cheat Sheet
+
+- `Layer.mergeAll(a, b, ...)`: combine outputs of multiple layers
+- `Layer.provide(target, dependencies)`: feed dependency outputs into `target` and keep only `target` outputs
+- `Layer.provideMerge(target, dependencies)`: feed dependency outputs into `target` and keep both dependency outputs and target outputs
+- `Layer.flatMap(layer, f)`: choose the next layer based on the built service value
+
+### Example Services
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class Logger extends Context.Service<Logger, {
+  readonly log: (message: string) => Effect.Effect<void>
+}>()("Logger") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const LoggerLayer = Layer.succeed(Logger)({
+  log: (message) => Effect.sync(() => console.log(message))
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+    const logger = yield* Logger
+
+    return {
+      getById: (id) =>
+        Effect.gen(function*() {
+          yield* logger.log(`loading ${id} from ${config.apiBaseUrl}`)
+          return { id, name: "Ada" }
+        })
+    }
+  })
+)
+```
+
+### `Layer.mergeAll`
+
+Use `Layer.mergeAll` to combine outputs of independent layers.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+Use this when:
+
+- the layers provide different services
+- neither needs to transform the other directly
+
+Semantics:
+
+- inputs are combined
+- outputs are combined
+- no dependency feeding happens automatically
+
+Important:
+
+- `Layer.mergeAll(ConfigLayer, UserRepoLayer)` is wrong if `UserRepoLayer` requires `Config` and `Logger`
+- `mergeAll` does not satisfy `UserRepoLayer`'s requirements
+- it only places both layers side by side in the output graph
+
+Correct pattern:
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+### `Layer.provide`
+
+Use `Layer.provide` to satisfy a target layer's dependencies with another layer, while keeping only the target layer's outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserRepoLayerReady = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` requires `Config` and `Logger`
+- `Dependencies` provides those dependencies
+- the resulting layer provides only `UserRepo`
+- `Config` and `Logger` are used for construction but are not kept in the final output
+
+This is the operator to use when you want to hide construction dependencies behind a narrower public layer.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+### `Layer.provideMerge`
+
+Use `provideMerge` when you want to satisfy dependencies and retain both the dependency outputs and the target outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const AppLayer = Layer.provideMerge(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` still gets `Config` and `Logger`
+- the resulting layer provides `UserRepo`, `Config`, and `Logger`
+
+This is useful for assembling larger application layers incrementally, especially when downstream code still needs access to the dependencies.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  const logger = yield* Logger
+
+  const user = yield* repo.getById("u_123")
+  yield* logger.log(user.name)
+  return user
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Preferred rule:
+
+- use `provide` when you want to hide dependency details
+- use `provideMerge` when you want to keep dependency services available downstream
+
+### `Layer.mergeAll` vs `Layer.provide` vs `Layer.provideMerge`
+
+Think of them like this:
+
+- `mergeAll`: put layers next to each other
+- `provide`: plug one layer into another, expose only the target
+- `provideMerge`: plug one layer into another, expose both sides
+
+### Composition Style Best Practice
+
+Layers should almost always be fully composed locally before they are assembled into the final application layer.
+
+Preferred style:
+
+- define each service layer separately
+- define local subsystem dependency bundles separately
+- fully compose each subsystem locally with `Layer.provide` or `Layer.provideMerge`
+- assemble the final application layer with `Layer.mergeAll(...)`
+- apply top-level cross-cutting provisioning in a small number of explicit trailing steps
+
+Good pattern:
+
+```ts
+const UserDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserLayer = Layer.provide(UserRepoLayer, UserDependencies)
+
+const BillingDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer,
+  DatabaseLayer
+)
+
+const BillingLayer = Layer.provide(BillingServiceLayer, BillingDependencies)
+
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why this style is preferred:
+
+- subsystem wiring stays local to the subsystem
+- the final application layer reads as a high-level composition map
+- cross-cutting concerns such as telemetry stay visible at the top level
+- it avoids deeply nested inline layer expressions
+
+Avoid this style when a clearer local name would help:
+
+```ts
+const AppLayer = Layer.provide(
+  Layer.mergeAll(
+    Layer.provide(UserRepoLayer, Layer.mergeAll(ConfigLayer, LoggerLayer)),
+    Layer.provide(BillingServiceLayer, Layer.mergeAll(ConfigLayer, LoggerLayer, DatabaseLayer)),
+    HttpLayer
+  ),
+  Telemetry
+).pipe(Layer.provide(NodeSdk))
+```
+
+That style is harder to read because:
+
+- subsystem composition is hidden inside the final assembly
+- shared dependencies are harder to spot
+- it is harder to refactor or reuse subsystem layers
+
+### `Layer.flatMap`
+
+Use `flatMap` when the next layer depends on the actual constructed service value, not just its type-level requirement.
+
+Example:
+
+```ts
+const UserRepoLayerFromConfig = Layer.flatMap(ConfigLayer, (config) =>
+  Layer.succeed(UserRepo)({
+    getById: (id) => Effect.succeed({ id, name: config.apiBaseUrl })
+  })
+)
+```
+
+This is more specialized than `merge` or `provide`.
+
+Prefer simpler composition first:
+
+- `merge` for combining
+- `provide` for dependency satisfaction
+- `flatMap` only when construction logic truly depends on the built value
+
+## Providing Layers To Effects
+
+## Preferred Rule
+
+Provide layers at boundaries.
+
+Usually that means:
+
+- the application entrypoint
+- a subsystem entrypoint
+- a test boundary
+
+Avoid repeatedly providing layers deep inside business logic unless you are deliberately isolating a subsystem.
+
+### Anti-Pattern: Local `Effect.provide`
+
+`Effect.provide` should be used only once at the entry of your program in normal application code.
+
+Bad pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  }).pipe(
+    Effect.provide(UserRepoLayer)
+  )
+```
+
+Why this is an anti-pattern:
+
+- it hides dependency wiring inside business logic
+- it makes implementations harder to swap in tests
+- it prevents clean top-level composition
+- it encourages many small local runtimes instead of one coherent application graph
+- it makes shared cross-cutting services harder to reason about
+
+Preferred pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Rule of thumb:
+
+- business logic should require services
+- composition should happen in layers
+- `Effect.provide` should happen at the outermost entry boundary
+
+### Multiple Entry Points
+
+If your code integrates with a framework and has multiple entry points, prefer `ManagedRuntime` instead of repeatedly calling `Effect.provide` at many call sites.
+
+Typical examples:
+
+- HTTP handlers registered separately
+- queue consumers
+- cron jobs
+- framework lifecycle hooks
+- RPC handlers or worker callbacks
+
+Preferred pattern:
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (id: string) =>
+  runtime.runPromise(loadUser(id))
+```
+
+Why:
+
+- the layer graph is still composed once
+- services remain shared according to layer semantics
+- the framework integration gets a stable runtime boundary
+- resource lifecycle is explicit through `ManagedRuntime`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## `Effect.provide`
+
+Use `Effect.provide` to satisfy an effect's dependencies with a layer or context.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+This is the main boundary provisioning operator.
+
+## `Effect.provideService`
+
+Use `provideService` for a single ad hoc implementation.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provideService(UserRepo, {
+    getById: (id) => Effect.succeed({ id, name: "Inline User" })
+  })
+)
+```
+
+Good use cases:
+
+- small tests
+- one-off overrides
+- local customization
+
+Do not use this as the default replacement for real application layers.
+
+## `Effect.provideServiceEffect`
+
+Use `provideServiceEffect` when one service instance must be built effectfully without creating a reusable layer.
+
+This is useful for targeted overrides, but if the construction is reusable or part of application wiring, prefer a named `Layer.effect`.
+
+## Best Practices
+
+## 1. Keep service interfaces small and focused
+
+Prefer cohesive services over giant "everything" services.
+
+Good:
+
+- `UserRepo`
+- `Mailer`
+- `Clock`-like configuration or time abstractions
+
+Avoid:
+
+- large service shapes that mix unrelated responsibilities
+
+## 2. Prefer layers over manual wiring
+
+If construction has dependencies or effects, represent it as a layer.
+
+Avoid manually grabbing dependencies and assembling concrete objects all over the codebase.
+
+## 2.5 Prefer Effect-native integrations over raw runtime clients
+
+When Effect already provides a module for a capability, prefer the Effect-native integration over directly embedding a raw runtime client in service code.
+
+Examples:
+
+- prefer `effect/unstable/sql` modules over directly coupling business services to native SQL driver APIs
+- prefer Effect HTTP modules over direct ad hoc request clients when the project is already using Effect HTTP abstractions
+
+Why:
+
+- resource handling, tracing, and errors stay inside the Effect model
+- integrations compose better with layers and services
+- observability and transactions are easier to keep consistent
+
+## 3. Keep business logic abstract over implementations
+
+Business functions should require services, not construct them.
+
+Good:
+
+```ts
+const sendWelcomeEmail = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    const user = yield* repo.getById(userId)
+    return user
+  })
+```
+
+Avoid constructing `UserRepo` inside `sendWelcomeEmail`.
+
+## 4. Use `Layer.succeed` only for pure values
+
+Do not hide effectful initialization inside supposedly pure service objects.
+
+If initialization can fail, depends on effects, or needs scoped acquisition, use `Layer.effect`.
+
+## 5. Use `Layer.effect` for owned resources
+
+If the service opens something that must later close, model that lifecycle explicitly.
+
+This is one of the main reasons layers exist.
+
+## 6. Prefer top-level composition
+
+Compose major application layers once near the boundary.
+
+Good pattern:
+
+- define `ConfigLayer`
+- define `UserRepoLayer`
+- define `Dependencies = Layer.mergeAll(...)`
+- define `AppLayer` separately with `Layer.provide(...)` or `Layer.provideMerge(...)`
+- provide `AppLayer` to the top-level program
+
+## 7. Use `Layer.fresh` only when you really need a new instance
+
+Layers are shared by default.
+
+That is usually what you want.
+
+Use `Layer.fresh` only when you intentionally need to bypass sharing and rebuild the layer.
+
+## 7.5 Understand Layer Memoization
+
+Layers are memoized by reference.
+
+That means:
+
+- reusing the same layer value preserves memoization and sharing
+- creating a new layer value creates a new memoization identity
+
+Because of this, functions that return layers should be avoided unless they are absolutely necessary.
+
+Prefer plain named layer constants over layer factory functions.
+
+Only use a function returning a layer when:
+
+- the layer genuinely depends on runtime parameters
+- the caller truly needs distinct configurations or instances
+- a constant layer value cannot express the construction cleanly
+
+Even in those cases, call the function once during construction and reuse the resulting layer value.
+
+### Function Dependencies Should Stay Unprovided
+
+If a dependency of a layer is itself represented by a function that returns a layer, do not call that function locally just to satisfy the dependency.
+
+Instead, leave that dependency unprovided and let it be supplied at the edge.
+
+Bad pattern:
+
+```ts
+const UserLayer = Layer.provide(UserRepoLayer, makeDatabaseLayer(config))
+```
+
+Why this is bad:
+
+- it creates a fresh layer reference locally
+- it breaks or weakens memoization and sharing assumptions
+- it hides an important construction dependency inside subsystem wiring
+- it makes the final application graph harder to understand
+
+Preferred pattern:
+
+```ts
+const UserLayer = UserRepoLayer
+
+const DatabaseLayer = makeDatabaseLayer(config)
+
+const AppLayer = Layer.provideMerge(UserLayer, DatabaseLayer)
+```
+
+More generally:
+
+- if a layer depends on a parameterized layer factory, keep that dependency in the required environment when possible
+- construct the concrete parameterized layer once at the outer boundary
+- provide it only at the edge where the full application graph is assembled
+
+Rule:
+
+- do not call layer-producing dependency functions deep inside subsystem composition
+- keep those dependencies unprovided until the edge
+- provide the concrete layer once in the final top-level assembly
+
+Bad pattern:
+
+```ts
+const makeDatabaseLayer = () => Layer.effect(DatabaseService)(/* ... */)
+
+const AppLayer = Layer.mergeAll(
+  makeDatabaseLayer(),
+  makeDatabaseLayer()
+)
+```
+
+Why this is bad:
+
+- each call creates a distinct layer reference
+- memoization does not apply across those distinct references
+- the underlying resource or service may be constructed more than once
+- sharing assumptions become incorrect
+
+Preferred pattern:
+
+```ts
+const DatabaseLayer = makeDatabaseLayer()
+
+const AppLayer = Layer.mergeAll(
+  DatabaseLayer,
+  OtherLayer
+)
+```
+
+Rule:
+
+- avoid layer-producing functions unless they are truly necessary
+- if a function returns a layer, call it once during construction and bind the result to a named constant
+- reuse that layer value everywhere else
+
+This is especially important for:
+
+- database layers
+- HTTP client layers
+- telemetry layers
+- queues, workers, and other resource-owning services
+
+If you intentionally need a distinct instance, make that explicit with a new layer value or `Layer.fresh`, rather than accidentally creating multiple instances by repeatedly calling a layer factory.
+
+## 8. Treat `Layer.orDie` carefully
+
+`Layer.orDie` converts layer construction failures into defects.
+
+Only use it when failure is truly unrecoverable at that boundary.
+
+Do not use it to hide legitimate configuration or infrastructure failures.
+
+## 9. Use `ManagedRuntime.make` at true runtime boundaries
+
+If you need a reusable runtime built from a layer, `ManagedRuntime.make` is the edge tool for that.
+
+Good use cases:
+
+- embedding Effect into external frameworks
+- scripts or hosts that repeatedly run Effect programs
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## 10. Prefer explicit test layers
+
+For tests, prefer:
+
+- `Layer.succeed` for simple fakes
+- `Layer.mock` for partial mocks when appropriate
+
+This keeps test wiring explicit and close to production composition style.
+
+## Recommended Patterns
+
+## Pattern: service definition plus live layer
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Loaded via ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+
+const Dependencies = Layer.mergeAll(ConfigLayer)
+
+const AppLayer = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+## Pattern: provide at the top level
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+## Pattern: single-service override in tests
+
+```ts
+const TestRepo = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test" })
+})
+```
+
+## Anti-Patterns
+
+- constructing live services directly inside business logic
+- using `Layer.succeed` for values that actually require effectful initialization
+- providing the same large layer repeatedly throughout the call graph
+- collapsing unrelated responsibilities into one service
+- using `Layer.orDie` to hide normal initialization failures
+- bypassing layers entirely for resource-owning services
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+- `./.repos/effect/packages/effect/src/Stream.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Persistence.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcSerialization.ts`
+- `./.repos/effect/packages/effect/src/unstable/reactivity/Reactivity.ts`

--- a/.claude/skills/effect-ts/references/guide-observability.md
+++ b/.claude/skills/effect-ts/references/guide-observability.md
@@ -1,0 +1,724 @@
+# Observability Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+## Mental Model
+
+Observable Effect code should make business operations visible by default.
+
+That means:
+
+- business logic should show up clearly in stack traces
+- important operations should produce spans
+- logs should inherit execution context
+- metrics should be attached at meaningful boundaries
+
+The most important best practice is:
+
+- prefer `Effect.fn(...)` whenever possible for business logic
+
+Why:
+
+- it adds stack frames
+- it creates spans automatically
+- it gives you better tracing and debugging for free
+- it keeps business logic observable without extra boilerplate
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Rule
+
+Use `Effect.fn` as the default constructor for business-logic functions that return `Effect`.
+
+Prefer this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Over this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+The second version works, but it throws away useful observability structure that `Effect.fn` gives you automatically.
+
+## Prefer `Effect.fn` Over Raw `Effect.gen`
+
+For business-logic definitions, prefer `Effect.fn` over writing raw `Effect.gen` directly, even when the operation takes no arguments.
+
+Prefer this:
+
+```ts
+const refreshCache = Effect.fn("refreshCache")(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Over this:
+
+```ts
+const refreshCache = Effect.gen(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Why:
+
+- `Effect.fn` gives the operation a clear observable identity
+- stack traces are better
+- tracing is more consistent
+- the codebase gets a uniform shape for business operations
+
+Use raw `Effect.gen` when necessary, for example:
+
+- inline effect blocks inside another `Effect.fn`
+- small one-off composition at call sites
+- top-level assembly code where you are not defining a reusable business operation
+
+Rule of thumb:
+
+- reusable business operation: `Effect.fn`
+- inline composition block: `Effect.gen`
+
+## `Effect.fn` vs `Effect.fnUntraced`
+
+### `Effect.fn`
+
+Use `Effect.fn` for almost all business logic.
+
+It is the preferred default because it adds:
+
+- stack frames
+- tracing spans
+- optional post-processing of the produced effect
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const createUser = Effect.fn("createUser")(function*(name: string) {
+  return { id: "u_123", name }
+})
+```
+
+Use this for:
+
+- domain operations
+- application services
+- handlers
+- workflows
+- orchestrations
+- repository calls
+
+### `Effect.fnUntraced`
+
+Use `Effect.fnUntraced` only for edge cases.
+
+The vendored Effect repo itself uses `fnUntraced` in a number of low-level internals and integration helpers. That does not make it the default recommendation for downstream application or business code.
+
+If you do not want an explicit named span, prefer `Effect.fn` without a span name so you still keep stack traces and the normal traced-function behavior.
+
+Prefer this:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Over this:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Typical cases:
+
+- extremely hot low-level internal helpers
+- very small internal combinators
+- tight loops where you have measured overhead and need to reduce it
+
+Preferred rule:
+
+- `Effect.fn` by default
+- `Effect.fn` without a span name when you want to avoid an explicit named span
+- `Effect.fnUntraced` only with a concrete measured reason
+
+## Business Logic Patterns
+
+### Pattern: one named `Effect.fn` per meaningful operation
+
+Good:
+
+```ts
+const parseCommand = Effect.fn("parseCommand")(function*(input: string) {
+  return input.trim()
+})
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+
+const sendWelcomeEmail = Effect.fn("sendWelcomeEmail")(function*(userId: string) {
+  const user = yield* loadUser(userId)
+  return user.email
+})
+```
+
+Why this is good:
+
+- each operation has a clear span name
+- traces reflect business concepts
+- stack traces reflect the actual workflow
+
+### Pattern: use meaningful names
+
+Span names created through `Effect.fn` should represent business operations, not generic implementation detail.
+
+Prefer:
+
+- `loadUser`
+- `chargeInvoice`
+- `syncGithubInstallation`
+
+Avoid:
+
+- `helper`
+- `run`
+- `process`
+- `step1`
+
+## Explicit Spans
+
+### `Effect.withSpan`
+
+Use `withSpan` when you need an explicit span around an effect that is not already naturally represented by a named `Effect.fn`, or when you want a nested sub-operation span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchProfile(userId).pipe(
+    Effect.withSpan("fetchProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+Use this when:
+
+- you want a nested span inside a larger operation
+- you are instrumenting an existing effect pipeline
+- you need more detailed trace structure than `Effect.fn` alone provides
+
+### `Effect.withSpanScoped`
+
+Use `withSpanScoped` when the span should remain open for the lifetime of a scope.
+
+This is less common in business logic and more common in long-lived resource or streaming workflows.
+
+### `Effect.withParentSpan`
+
+Use `withParentSpan` when integrating with an externally created span or continuing a parent span manually.
+
+This is useful in framework or interoperability boundaries.
+
+## Span Enrichment
+
+### `Effect.annotateCurrentSpan`
+
+Use `annotateCurrentSpan` to attach important structured fields to the current span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+Good span annotations:
+
+- stable identifiers
+- domain-relevant keys
+- request or resource identifiers
+- small structured values
+
+Avoid:
+
+- giant payloads
+- secrets
+- noisy transient data with little diagnostic value
+
+## Logging Patterns
+
+### Use Effect logging inside effects
+
+Prefer:
+
+- `Effect.log`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.logWarning`
+- `Effect.logError`
+
+These integrate with the current Effect execution context.
+
+Example:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.logDebug("loading user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### `Effect.withLogSpan`
+
+Use `withLogSpan` when you want log messages to carry a local logical span label even when you are not creating a full tracing span.
+
+Example:
+
+```ts
+const program = Effect.logInfo("starting sync").pipe(
+  Effect.withLogSpan("user-sync")
+)
+```
+
+This is useful for:
+
+- log grouping
+- quick local context
+- correlation in plain log output
+
+### Logging Best Practices
+
+- log at business boundaries, not every tiny helper
+- prefer structured values over concatenated strings
+- keep logs high-signal
+- avoid duplicate logs at every layer of the stack
+- rely on spans plus a few well-placed logs, not log spam
+
+## Metrics Patterns
+
+### Track effects at meaningful boundaries
+
+Use metric tracking on meaningful operations such as:
+
+- requests
+- jobs
+- retries
+- external calls
+- queue handlers
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `Effect.track`
+
+Example:
+
+```ts
+import { Effect, Metric } from "effect"
+
+const requests = Metric.counter("user_load_requests").pipe(
+  Metric.withConstantInput(1)
+)
+
+const loadUser = Effect.fn("loadUser")(
+  function*(userId: string) {
+    return { id: userId, name: "Ada" }
+  },
+  Effect.track(requests)
+)
+```
+
+### Prefer boundary metrics over micro-metrics
+
+Good metrics are usually attached to:
+
+- endpoint handlers
+- queue/job handlers
+- repository operations
+- external API boundaries
+
+Avoid putting a metric on every tiny internal helper.
+
+## OpenTelemetry Integration
+
+For real application observability, compose telemetry at the layer level.
+
+The vendored repo provides `@effect/opentelemetry` layers such as:
+
+- `NodeSdk.layer`
+- `Tracer.layer`
+- `Logger.layer`
+- `Metrics.layer`
+
+Repo references:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+Preferred composition style:
+
+```ts
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why:
+
+- business code stays observability-agnostic
+- observability is configured once at the boundary
+- spans, logs, and metrics remain consistent across the app
+
+## OpenTelemetry JS Framework Integration
+
+The vendored repo includes a real integration layer for the OpenTelemetry JavaScript ecosystem in `@effect/opentelemetry`.
+
+This is the preferred integration path when the application needs to participate in the standard OpenTelemetry JS framework, exporters, and SDKs.
+
+Relevant modules:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/opentelemetry/src/Metrics.ts`
+- `./.repos/effect/packages/opentelemetry/src/Logger.ts`
+- `./.repos/effect/packages/opentelemetry/src/Resource.ts`
+- `./.repos/effect/packages/opentelemetry/src/WebSdk.ts`
+
+### Preferred Integration Model
+
+Use `@effect/opentelemetry` layers to bridge Effect observability into OpenTelemetry JS.
+
+Do not manually wire OpenTelemetry SDK objects inside business code.
+
+Prefer:
+
+- configuring tracer, metrics, logger, and resource layers once
+- composing them into the application layer graph
+- keeping business code written against Effect tracing, logging, and metrics APIs
+
+This means:
+
+- application code should keep using `Effect.fn`, `Effect.withSpan`, `Effect.log*`, and Effect metrics
+- OpenTelemetry JS should be introduced at the infrastructure layer, not inside domain operations
+
+### `NodeSdk.layer`
+
+`NodeSdk.layer(...)` is the main Node.js integration entrypoint.
+
+From the vendored source, it accepts a configuration that can include:
+
+- span processors
+- tracer config
+- metric readers
+- temporality preference
+- log record processors
+- logger provider config
+- resource information such as service name and version
+- shutdown timeout
+
+It then builds and merges:
+
+- resource layer
+- tracer layer
+- metrics layer
+- logger layer
+
+This makes it the preferred high-level integration for Node applications.
+
+### Resource Configuration
+
+OpenTelemetry JS integration should define resource metadata explicitly.
+
+From `NodeSdk.layer`, the supported resource configuration includes:
+
+- `serviceName`
+- `serviceVersion`
+- additional attributes
+
+This is important because tracer and logger setup depend on the configured resource.
+
+Best practice:
+
+- always provide a meaningful service name
+- provide service version when available
+- use resource attributes for stable deployment or environment metadata
+
+### Tracing Integration
+
+The `Tracer` module bridges Effect spans into OpenTelemetry spans.
+
+Important integration points from the vendored source:
+
+- `Tracer.layer`
+- `Tracer.layerGlobal`
+- `Tracer.layerGlobalProvider`
+- `Tracer.currentOtelSpan`
+- `Tracer.makeExternalSpan`
+
+Use these when:
+
+- you need Effect tracing to export through OpenTelemetry JS
+- you need to continue or bridge external trace context
+- you need access to the current OpenTelemetry span object
+
+Best practice:
+
+- keep creating spans with Effect APIs in application code
+- use the OpenTelemetry tracer layer to export and bridge them
+- use `makeExternalSpan` or parent-span wiring only at integration boundaries
+
+### Metrics Integration
+
+The `Metrics` module connects Effect metrics to OpenTelemetry JS metric readers.
+
+Important details from the vendored implementation:
+
+- `Metrics.layer(...)` registers a producer against one or more metric readers
+- it supports temporality preferences:
+  - `cumulative`
+  - `delta`
+- it handles shutdown through scoped layer cleanup
+
+Best practice:
+
+- choose temporality based on the backend
+- configure metric readers in the telemetry layer
+- keep application code focused on recording Effect metrics, not exporter mechanics
+
+### Logger Integration
+
+The `Logger` module connects Effect logging to OpenTelemetry JS logs.
+
+Important details from the vendored implementation:
+
+- it maps Effect log levels to OpenTelemetry severity numbers
+- it includes fiber ID, span context, log annotations, and log span timing in emitted attributes
+- `Logger.layer({ mergeWithExisting })` can merge with or replace existing application loggers
+
+Best practice:
+
+- prefer merging with existing loggers unless there is a strong reason to replace them
+- use Effect log annotations and log spans so the OpenTelemetry logger receives structured context automatically
+
+### Shutdown And Lifecycle
+
+The vendored layers use scoped acquisition and release for tracer providers, metric readers, and logger providers.
+
+This is the correct lifecycle model.
+
+Do not manually call provider shutdown methods from arbitrary business logic.
+
+Instead:
+
+- let the OpenTelemetry layers own provider lifecycle
+- compose them into the application layer graph
+- let the runtime or outer layer scope manage shutdown
+
+### External Trace Context
+
+When integrating with frameworks or inbound protocols that already carry trace context, prefer using the OpenTelemetry integration helpers rather than hand-rolling context propagation.
+
+The vendored tracer module provides:
+
+- `makeExternalSpan`
+- `currentOtelSpan`
+
+Use these only at integration boundaries such as:
+
+- HTTP adapters
+- RPC adapters
+- worker or queue adapters
+
+Keep business operations oblivious to propagation mechanics.
+
+### Recommended Pattern
+
+Preferred architecture:
+
+1. business code uses Effect observability APIs
+2. infrastructure composes `@effect/opentelemetry` layers
+3. the final app layer provides telemetry once at the top level
+
+Example shape:
+
+```ts
+const TelemetryLayer = NodeSdk.layer(() => ({
+  resource: {
+    serviceName: "todo-service",
+    serviceVersion: "1.0.0"
+  },
+  spanProcessor: mySpanProcessor,
+  metricReader: myMetricReader,
+  logRecordProcessor: myLogProcessor
+}))
+
+const AppLayer = Layer.mergeAll(
+  DomainLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(TelemetryLayer)
+)
+```
+
+This keeps:
+
+- app code portable
+- OTel JS setup centralized
+- shutdown semantics correct
+- exported spans, logs, and metrics aligned
+
+### Anti-Patterns
+
+- constructing OpenTelemetry SDK clients directly inside business services
+- mixing manual exporter setup into domain code
+- bypassing Effect logging and tracing APIs in normal business operations
+- scattering provider shutdown logic across the application
+- configuring telemetry separately in many subsystems instead of one top-level layer
+
+## Anti-Patterns
+
+### Anti-Pattern: business logic built from anonymous `Effect.gen` functions everywhere
+
+Bad:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+Why this is bad:
+
+- weaker tracing structure
+- poorer stack traces
+- less consistent naming in debugging output
+
+Preferred:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Anti-Pattern: using `Effect.fnUntraced` by default
+
+This throws away free observability.
+
+If you just do not want an explicit span name, use `Effect.fn` without a name instead.
+
+Only use `fnUntraced` when you have a specific low-level reason.
+
+### Anti-Pattern: logging without structure or context
+
+Bad:
+
+- giant interpolated strings
+- duplicate logs at every layer
+- logs with no business identifiers
+
+Prefer:
+
+- named operations via `Effect.fn`
+- structured logs with IDs and context
+- a few high-value logs at operation boundaries
+
+### Anti-Pattern: hand-instrumenting every helper with spans
+
+Do not create explicit spans everywhere just because you can.
+
+Preferred order:
+
+1. start with `Effect.fn`
+2. add `Effect.withSpan` only where extra detail is actually useful
+3. add metrics at meaningful boundaries
+
+## Recommended Patterns
+
+### Pattern: observable business operation
+
+```ts
+import { Effect } from "effect"
+
+const fetchUser = Effect.fn("fetchUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  yield* Effect.logDebug("fetching user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Pattern: orchestration with nested spans
+
+```ts
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchRemoteProfile(userId).pipe(
+    Effect.withSpan("fetchRemoteProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+### Pattern: framework boundary with runtime
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (userId: string) =>
+  runtime.runPromise(fetchUser(userId))
+```
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`

--- a/.claude/skills/effect-ts/references/guide-retries.md
+++ b/.claude/skills/effect-ts/references/guide-retries.md
@@ -1,0 +1,433 @@
+# Retries Guide
+
+This guide is based on retry patterns and `ExecutionPlan` usage in the vendored Effect repo.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+Retries in Effect are not just loops.
+
+The repo uses three increasingly powerful levels:
+
+1. simple `Effect.retry` options for bounded or condition-based retries
+2. `Schedule` for timing-aware retry policies
+3. `ExecutionPlan` for fallback across different provided resources or layers
+
+Choose the smallest model that correctly expresses the retry policy.
+
+## Preferred Rule
+
+Prefer structured retry policies over ad hoc retry loops.
+
+Use:
+
+- simple `Effect.retry({ ... })` for straightforward conditions
+- `Effect.retry(schedule)` when timing matters
+- `ExecutionPlan` when retries should escalate across different layers or resources
+
+Avoid:
+
+- hand-written loops with mutable counters
+- inline `catch` plus recursive retry logic
+- resource fallback logic encoded as nested `catch` chains when `ExecutionPlan` is a better fit
+
+## `Effect.retry`
+
+`Effect.retry` is the main retry operator.
+
+The vendored tests show several important supported forms.
+
+## Retry On Success vs Failure
+
+`Effect.retry` only retries failures.
+
+If the effect succeeds, nothing is retried.
+
+This is explicitly covered in the module tests.
+
+## Simple Retry Options
+
+### `{ times: n }`
+
+Use this for the simplest bounded retry case.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+Use this when:
+
+- timing does not matter
+- you only need a fixed retry count
+
+### `{ until: predicate }`
+
+Use `until` when retries should stop once the failure value satisfies a condition.
+
+The module tests show:
+
+- pure `until`
+- effectful `until`
+- that `until` is still evaluated at least once
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ until: (error) => error._tag === "Done" })
+)
+```
+
+### `{ while: predicate }`
+
+Use `while` when retries should continue only while the failure value satisfies a condition.
+
+The tests also show pure and effectful `while` variants.
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ while: (error) => error._tag === "Retryable" })
+)
+```
+
+## Retry With Schedule
+
+Use a `Schedule` whenever timing matters.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry(Schedule.recurs(3))
+)
+```
+
+Or with the richer object form:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: Schedule.recurs(3),
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+This is a very important repo pattern because it lets you combine:
+
+- retry timing
+- retry limits
+- retry predicates
+
+## Current Schedule Metadata During Retries
+
+The module tests show that retry execution updates `Schedule.CurrentMetadata`.
+
+This means retry policies and retry-aware effects can inspect:
+
+- attempt number
+- elapsed time
+- previous delay timing
+- schedule output
+
+Use this when:
+
+- logging retry behavior
+- building retry-aware diagnostics
+- implementing advanced adaptive retry behavior
+
+## When To Use Simple Options Vs Schedule
+
+Prefer simple options when:
+
+- only the retry count matters
+- retry timing does not matter
+- the retry rule is just a condition on the error
+
+Prefer a schedule when:
+
+- retry timing matters
+- backoff matters
+- jitter matters
+- the policy should evolve over time
+
+## Common Retry Schedules In The Repo
+
+The vendored repo repeatedly uses these patterns:
+
+### Fixed retry count
+
+```ts
+Schedule.recurs(3)
+```
+
+### Exponential backoff
+
+```ts
+Schedule.exponential(500, 1.5)
+```
+
+### Exponential plus steady fallback spacing
+
+```ts
+Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This appears in production modules such as RPC and workflow code.
+
+### Error-sensitive delay policy
+
+```ts
+Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+The OTLP exporter uses this shape to derive delays from actual HTTP failure details such as rate limits.
+
+## Retry Only For Specific Failures
+
+The workflow `Activity` module shows an important advanced pattern:
+
+- sandbox the effect
+- retry only when the `Cause` matches a specific retryable category
+- fail or die differently once retries are exhausted
+
+Example shape from the repo:
+
+```ts
+effect.pipe(
+  Effect.sandbox,
+  Effect.retry(policy),
+  Effect.catch((cause) => {
+    if (!Cause.hasInterrupts(cause)) {
+      return Effect.failCause(cause)
+    }
+    return Effect.die("interrupted and retries exhausted")
+  })
+)
+```
+
+Use this when:
+
+- retryability depends on the full cause, not just typed failures
+- interrupt-specific retry behavior is required
+- infrastructure policy is more nuanced than a simple tagged error rule
+
+## Retry Observability
+
+Retry logic should be observable.
+
+Good patterns:
+
+- keep retries inside named `Effect.fn` operations
+- use `Schedule.CurrentMetadata` for diagnostics when needed
+- log or annotate retry attempts at meaningful boundaries
+- prefer central retry policies over duplicating timing logic everywhere
+
+Do not spread retry behavior across many small helpers where it becomes hard to see the operational policy.
+
+## `ExecutionPlan`
+
+Use `ExecutionPlan` when retries should escalate across different provided resources or layers.
+
+This is not just about retry timing. It is about retrying the same operation under different provided environments.
+
+The core use case from `ExecutionPlan.ts` is:
+
+- try one layer some number of times
+- possibly with a schedule and conditions
+- then fall back to another layer
+- then possibly fall back again
+
+### What `ExecutionPlan` Solves
+
+`ExecutionPlan` is the right tool when:
+
+- the same effect should be retried against multiple alternative providers
+- fallback should move across tiers, regions, models, or implementations
+- retry policy includes both attempt counts and provider changes
+
+Examples:
+
+- fail over between multiple language model providers
+- try one upstream cluster, then another
+- fall back from a fast but unreliable service to a slower but more reliable one
+
+## `ExecutionPlan.make`
+
+Use `ExecutionPlan.make(...)` to define ordered retry/fallback steps.
+
+Each step can include:
+
+- `provide`
+- `attempts`
+- `while`
+- `schedule`
+
+Example shape:
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: FastLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("3 seconds")
+  },
+  {
+    provide: SafeLayer,
+    attempts: 3,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+### Step Semantics
+
+For each step:
+
+- `provide` is the context or layer to use
+- `attempts` bounds how many times that step is tried
+- `while` can stop retries for that step based on the input
+- `schedule` defines the timing policy for retries within that step
+
+If `attempts` is omitted, the step attempts once unless a schedule is involved in a way that causes further retries.
+
+## `Effect.withExecutionPlan` And `Stream.withExecutionPlan`
+
+Use:
+
+- `Effect.withExecutionPlan` for effects
+- `Stream.withExecutionPlan` for streams
+
+The vendored tests focus on `Stream.withExecutionPlan` and demonstrate:
+
+- fallback from one provider to another
+- fallback after partial stream failure
+- the ability to prevent fallback on partial streams
+
+This is a strong signal that `ExecutionPlan` is particularly useful for long-running or streaming integrations where failure can happen after partial success.
+
+## `ExecutionPlan.CurrentMetadata`
+
+`ExecutionPlan` exposes metadata with:
+
+- `attempt`
+- `stepIndex`
+
+This is useful for:
+
+- diagnostics
+- logging which fallback tier is being used
+- understanding which plan step ultimately succeeded
+
+## `captureRequirements`
+
+`ExecutionPlan.captureRequirements` converts a plan with requirements into one whose requirements are satisfied from the current context.
+
+Use this when the plan should be frozen with the current environment before being applied later.
+
+## `ExecutionPlan.merge`
+
+Use `ExecutionPlan.merge(...)` when you need to concatenate multiple plans into one ordered plan.
+
+This is useful for assembling more complex fallback policies out of smaller ones.
+
+## When To Use `ExecutionPlan` Instead Of `Schedule`
+
+Use `Schedule` when:
+
+- only timing and retry conditions change
+- the same environment/provider is used for every retry
+
+Use `ExecutionPlan` when:
+
+- the provider or layer should change across retry phases
+- retries are tied to alternative resources, not just delays
+- fallback is part of dependency provisioning strategy
+
+## Recommended Patterns
+
+### Pattern: simple bounded retry
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+### Pattern: retryable-error backoff
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: retryPolicy,
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+### Pattern: fallback across providers
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: PrimaryLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: SecondaryLayer,
+    attempts: 3,
+    schedule: Schedule.exponential(500, 1.5)
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+## Anti-Patterns
+
+- hand-writing retry recursion instead of using `Effect.retry`
+- embedding sleep and counters directly in business logic
+- using `ExecutionPlan` when a simple `Schedule` is enough
+- encoding provider fallback as a maze of nested `catch` branches
+- retrying indiscriminately without checking whether the failure is actually retryable
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`

--- a/.claude/skills/effect-ts/references/guide-schedule.md
+++ b/.claude/skills/effect-ts/references/guide-schedule.md
@@ -1,0 +1,379 @@
+# Schedule Guide
+
+This guide is based on the vendored `Schedule` module and its usage across `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+`Schedule` is the standard Effect abstraction for:
+
+- retries
+- repeats
+- polling
+- backoff
+- cadence and timing policies
+
+A schedule describes when the next step should happen and when execution should stop.
+
+The repo uses schedules heavily for:
+
+- retry policies
+- recurring work
+- time-window alignment
+- cron-based triggering
+- bounded flaky test retries
+
+## Preferred Rule
+
+When the timing behavior of an effect matters, prefer expressing it with `Schedule` rather than ad hoc loops, counters, sleeps, or manual retry recursion.
+
+Prefer:
+
+- `Effect.retry(schedule)`
+- `Effect.repeat(schedule)`
+- `Effect.schedule(schedule)`
+- `Stream.fromSchedule(schedule)`
+
+Over:
+
+- custom retry loops with mutable counters
+- `Effect.forever` plus hand-written `Effect.sleep`
+- manual backoff code scattered across business logic
+
+## Common Repo Patterns
+
+The most common patterns in the vendored repo are:
+
+1. `Schedule.recurs(n)` for bounded retries or repeats
+2. `Schedule.spaced(...)` for simple fixed spacing
+3. `Schedule.fixed(...)` or `Schedule.windowed(...)` for interval-aligned work
+4. `Schedule.exponential(...)` for backoff
+5. `Schedule.either(...)` or sequencing combinators to combine retry policies
+6. `Schedule.while(...)` to stop based on metadata or input
+7. `Schedule.addDelay(...)` for custom backoff logic
+8. `Schedule.jittered(...)` to avoid retry stampedes
+
+## Retry Vs Repeat
+
+Use schedules with the right operator:
+
+- `Effect.retry(schedule)` for failures
+- `Effect.repeat(schedule)` for successes
+- `Effect.schedule(schedule)` when you want to delay/reschedule an effect directly
+
+Good rule of thumb:
+
+- failing workflow: `retry`
+- recurring successful workflow: `repeat`
+- one effect that should run on a cadence: `schedule`
+
+## Core Constructors
+
+### `Schedule.recurs`
+
+Use `recurs(n)` for a bounded number of additional runs.
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+This is one of the most common repo retry policies.
+
+### `Schedule.forever`
+
+Use `forever` when the schedule should never terminate on its own.
+
+```ts
+const retryForever = Schedule.forever
+```
+
+This is common in infrastructure code and long-running retry loops.
+
+### `Schedule.spaced`
+
+Use `spaced(duration)` for simple constant spacing.
+
+```ts
+const pollEverySecond = Schedule.spaced("1 second")
+```
+
+This is the most straightforward schedule for polling or retry spacing.
+
+### `Schedule.fixed`
+
+Use `fixed(duration)` when work should align to fixed interval boundaries.
+
+The tests show that this differs from simple spacing when the action itself takes time.
+
+Use it when interval alignment matters more than naïve spacing.
+
+### `Schedule.windowed`
+
+Use `windowed(duration)` when you want delays to align to the nearest window boundary.
+
+This is useful for periodic flush or batching behavior.
+
+### `Schedule.duration`
+
+Use `duration(duration)` for a one-shot delay schedule.
+
+```ts
+const onceAfterOneSecond = Schedule.duration("1 second")
+```
+
+### `Schedule.cron`
+
+Use `cron(...)` for calendar-based scheduling.
+
+The module tests cover:
+
+- minute-level cron
+- second-level cron
+- calendar matching for specific weekdays and month days
+
+Use this for:
+
+- jobs that should follow wall-clock time
+- operational schedules
+- calendar-driven execution
+
+## Backoff Patterns
+
+### `Schedule.exponential`
+
+Use `exponential(base, factor)` for retry backoff.
+
+This is a dominant repo pattern.
+
+Examples from production code:
+
+- `WorkflowEngine`
+- `RpcClient`
+- persistence and eventlog modules
+
+Typical pattern:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5)
+```
+
+Use this for:
+
+- network retries
+- external system retries
+- contention or lock retries
+
+### Combine exponential with a cap or fallback spacing
+
+The repo often combines exponential backoff with a more stable spaced fallback using `Schedule.either(...)`.
+
+Example pattern from production modules:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This keeps early retries responsive without letting delays grow without bound.
+
+### `Schedule.jittered`
+
+Use `jittered(...)` to randomize timing within safe bounds.
+
+The module tests verify jittered delays remain within a bounded percentage of the original schedule.
+
+Use it when:
+
+- many workers or clients may retry at once
+- you want to avoid synchronized retry storms
+- the system would suffer from coordinated polling spikes
+
+## Combinators
+
+### `Schedule.while`
+
+Use `while(...)` to continue only while a predicate on schedule metadata holds.
+
+The repo uses this for:
+
+- stopping after a number of attempts
+- filtering retries based on the input error or cause
+- bounding retry windows by elapsed time
+
+Example pattern:
+
+```ts
+const bounded = Schedule.spaced("1 second").pipe(
+  Schedule.while(({ attempt }) => Effect.succeed(attempt <= 5))
+)
+```
+
+### `Schedule.andThenResult`
+
+Use `andThenResult(left, right)` when one schedule should run to completion and then another should take over.
+
+The module tests show this clearly.
+
+Use this when:
+
+- you want an initial aggressive policy followed by a slower steady-state policy
+- you want phase-based retry or repeat timing
+
+### `Schedule.either`
+
+Use `either` to combine two schedules so both policies influence the resulting timing.
+
+This appears frequently in repo retry policies that combine exponential growth with a stable fallback cadence.
+
+### `Schedule.addDelay`
+
+Use `addDelay` when the delay should depend on the schedule input or output.
+
+This is a strong fit for custom retry behavior based on the actual error.
+
+The OTLP exporter uses this style to honor `retry-after` behavior and otherwise fall back to a default delay.
+
+Example shape:
+
+```ts
+const policy = Schedule.forever.pipe(
+  Schedule.addDelay((error) =>
+    Effect.succeed("1 second")
+  )
+)
+```
+
+Use this when:
+
+- the delay should depend on the error
+- upstream metadata such as rate-limit headers matters
+- you need custom backoff without leaving the Schedule model
+
+## Metadata
+
+Schedules expose rich metadata including:
+
+- input
+- attempt count
+- start time
+- current time
+- elapsed time
+- elapsed since previous run
+- output
+- duration
+
+This is one of the reasons schedules are better than ad hoc retry loops.
+
+Use metadata when:
+
+- retry behavior depends on the input error
+- stop conditions depend on elapsed time
+- you want to log or collect retry state
+
+## Collection And Inspection Helpers
+
+The module tests highlight several useful helpers:
+
+- `Schedule.collectInputs(...)`
+- `Schedule.collectOutputs(...)`
+- `Schedule.collectWhile(...)`
+- `Schedule.delays(...)`
+- `Schedule.reduce(...)`
+
+Use these when:
+
+- you need to inspect or test a schedule
+- you want to accumulate state across schedule steps
+- you are building a more specialized scheduling policy
+
+These are especially useful in tests and low-level policy construction.
+
+## Typical Policies
+
+### Simple bounded retry
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+### Spaced polling
+
+```ts
+const pollPolicy = Schedule.spaced("5 seconds")
+```
+
+### Exponential retry with a stable fallback cadence
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced("5 seconds"))
+)
+```
+
+### Retry forever with custom delay logic
+
+```ts
+const retryPolicy = Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+### Cron-driven recurring job
+
+```ts
+const nightly = Schedule.cron("0 0 * * *")
+```
+
+## Testing Schedules
+
+The repo tests schedules with `TestClock` and controlled stepping.
+
+Preferred pattern:
+
+- use `TestClock`
+- advance time explicitly
+- inspect emitted delays or outputs
+
+This keeps schedule tests deterministic.
+
+The module tests also use helpers built on `Schedule.toStepWithSleep(...)` to inspect schedule behavior precisely.
+
+## Best Practices
+
+1. Prefer `Schedule` over ad hoc retry loops.
+2. Prefer `Schedule.recurs(...)` for simple bounded retries.
+3. Prefer `Schedule.exponential(...)` for backoff.
+4. Prefer `Schedule.either(...)` or sequencing combinators to compose retry phases.
+5. Prefer `Schedule.addDelay(...)` when delay depends on the actual error.
+6. Prefer `Schedule.jittered(...)` for distributed retry behavior.
+7. Prefer metadata-driven stop conditions over mutable counters.
+8. Prefer testing schedules with `TestClock`.
+
+## Anti-Patterns
+
+- hand-writing retry loops with mutable counters and sleeps
+- putting backoff logic directly in business code instead of in a schedule
+- using `Effect.forever` with embedded `sleep` as a substitute for a schedule
+- scattering retry timing logic across many call sites
+- ignoring jitter when many clients or workers retry concurrently
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`

--- a/.claude/skills/effect-ts/references/guide-schema.md
+++ b/.claude/skills/effect-ts/references/guide-schema.md
@@ -1,0 +1,624 @@
+# Schema Guide
+
+This guide is based on the vendored Schema module and common repo usage in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/SchemaTransformation.ts`
+- `./.repos/effect/packages/effect/src/SchemaGetter.ts`
+- `./.repos/effect/packages/effect/src/SchemaIssue.ts`
+- `./.repos/effect/packages/effect/src/JsonSchema.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/`
+
+## Mental Model
+
+Schema is the standard way to:
+
+- define data shapes
+- validate unknown input
+- encode typed values back to serialized form
+- transform between encoded and decoded representations
+- attach metadata and constraints
+
+The repo uses Schema pervasively for:
+
+- protocol payloads
+- configuration
+- HTTP and RPC contracts
+- database row decoding
+- error types
+- derived tooling such as JSON Schema and arbitrary generation
+
+## Preferred Rule
+
+Prefer Schema-based types whenever data crosses a boundary or should be validated, transformed, documented, or encoded.
+
+Typical boundaries:
+
+- HTTP requests and responses
+- RPC payloads
+- database rows
+- config files
+- worker messages
+- persisted data
+- domain errors
+
+## What A Schema Actually Is
+
+A schema is not just a static shape.
+
+It is a contract between:
+
+- the decoded in-memory value you want to work with
+- the encoded representation that comes from or goes to some boundary
+
+This is the most important thing many implementations get wrong.
+
+Do not think of Schema as “a typed struct definition.”
+Think of it as:
+
+- validation
+- decoding
+- encoding
+- transformation
+- metadata
+- reuse across boundaries
+
+Because of that, schemas should not be duplicated unless there is a real semantic difference.
+
+If two schemas describe the same logical model but differ only because one boundary encodes a field differently, prefer one schema with transformations instead of two parallel schemas.
+
+## Avoid Duplicating Schemas
+
+Do not create multiple parallel schemas for the same logical entity unless they truly represent different models.
+
+Bad pattern:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const TodoSql = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.BooleanFromBit
+})
+```
+
+This is usually a sign that transformations are not being used properly.
+
+If the model is still “Todo”, do not define a second schema just because one boundary stores `completed` as a bit.
+
+Prefer deriving or transforming the representation instead.
+
+Why duplication is bad:
+
+- the same model is now maintained in multiple places
+- fields drift over time
+- boundary logic gets copied instead of centralized
+- refactors become error-prone
+
+Only duplicate schemas when there is a real semantic difference, for example:
+
+- a creation payload really is a different model from a persisted entity
+- a public API contract intentionally differs from an internal domain model
+- a projection or partial view is intentionally a different type
+
+If the difference is only encoding, use a transformation.
+
+## Prefer `Class` Variants Over `Struct` Variants When Possible
+
+When a schema represents a named domain model, reusable payload, or long-lived API shape, prefer `Schema.Class`, `Schema.TaggedClass`, or `Schema.TaggedErrorClass` over a bare `Schema.Struct`.
+
+Prefer:
+
+```ts
+import { Schema } from "effect"
+
+export class User extends Schema.Class<User>("User")({
+  id: Schema.String,
+  name: Schema.String
+}) {}
+```
+
+Over:
+
+```ts
+import { Schema } from "effect"
+
+export const User = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String
+})
+```
+
+Why `Class` variants are usually better:
+
+- the schema has a stable, named identity
+- reusable models are easier to recognize in code and traces
+- constructors and validation are packaged together
+- extension patterns are clearer
+- named schemas read better in contracts and tooling output
+
+Use `Struct` when:
+
+- the shape is local and anonymous
+- it is a small inline request or response shape
+- introducing a class would add unnecessary ceremony
+- the schema is primarily a one-off composition fragment
+
+Good rule of thumb:
+
+- reusable named model: `Class`
+- reusable tagged union member: `TaggedClass`
+- reusable error payload: `TaggedErrorClass`
+- small inline object shape: `Struct`
+
+## One Logical Model, Multiple Representations
+
+The right Schema mindset is:
+
+- one logical model
+- multiple encoded forms when needed
+- transformations connecting them
+
+For example, a `Todo` may be:
+
+- a boolean in memory
+- a bit in SQL
+- a string in some external API
+
+That does not automatically mean you need three separate top-level schemas.
+
+Prefer:
+
+- one main schema for the logical model
+- transformed field schemas or transformed object schemas for boundary-specific encoding
+- derived request/result schemas when the shape is actually different
+
+## Common Schema Building Blocks
+
+Common primitives and collections used throughout the repo:
+
+- `Schema.String`
+- `Schema.Number`
+- `Schema.Boolean`
+- `Schema.BigInt`
+- `Schema.Array(...)`
+- `Schema.Record(key, value)`
+- `Schema.Tuple([...])`
+- `Schema.Struct({...})`
+- `Schema.Union([...])`
+
+Example:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+```
+
+## `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+### `Schema.Class`
+
+Use for named reusable schema-backed models.
+
+```ts
+class Product extends Schema.Class<Product>("Product")({
+  id: Schema.String,
+  price: Schema.Number
+}) {}
+```
+
+### Constructor Rule
+
+When constructing schema classes, prefer `X.make(...)` over `new X(...)`.
+
+Prefer:
+
+```ts
+const todo = Todo.make({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Over:
+
+```ts
+const todo = new Todo({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Why:
+
+- it is the intended schema-class construction style
+- it makes schema-backed construction explicit
+- it keeps the codebase consistent
+- it reads better across `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+Use this rule consistently for:
+
+- `Schema.Class`
+- `Schema.TaggedClass`
+- `Schema.TaggedErrorClass`
+
+### `Schema.TaggedClass`
+
+Use for members of tagged unions.
+
+```ts
+class Circle extends Schema.TaggedClass<Circle>()("Circle", {
+  radius: Schema.Number
+}) {}
+
+class Rectangle extends Schema.TaggedClass<Rectangle>()("Rectangle", {
+  width: Schema.Number,
+  height: Schema.Number
+}) {}
+```
+
+### `Schema.TaggedErrorClass`
+
+Use for schema-backed typed errors.
+
+```ts
+class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  id: Schema.String
+}) {}
+```
+
+## Optional Fields
+
+Be precise about optionality.
+
+Important rule from the vendored docs:
+
+- `Schema.optional(schema)` means `T | undefined`
+- `Schema.optionalKey(schema)` means an exact optional property in a struct
+
+Prefer `optionalKey` for object fields.
+
+Prefer:
+
+```ts
+const Query = Schema.Struct({
+  search: Schema.optionalKey(Schema.String)
+})
+```
+
+Use `optional` when the value itself should be `A | undefined`, not just an omitted field.
+
+## Unions
+
+Use `Schema.Union([...])` for ordinary unions.
+
+```ts
+const Id = Schema.Union([
+  Schema.String,
+  Schema.Number
+])
+```
+
+Prefer tagged unions for domain variants.
+
+```ts
+class Created extends Schema.TaggedClass<Created>()("Created", {
+  id: Schema.String
+}) {}
+
+class Deleted extends Schema.TaggedClass<Deleted>()("Deleted", {
+  id: Schema.String
+}) {}
+
+const TodoEvent = Schema.Union([Created, Deleted])
+```
+
+Why:
+
+- decoding and branching are clearer
+- `_tag`-based matching aligns with Effect code style
+
+## Recursive Schemas
+
+Use `Schema.suspend` for recursive schemas.
+
+```ts
+type Tree = {
+  readonly name: string
+  readonly children: ReadonlyArray<Tree>
+}
+
+const Tree: Schema.Schema<Tree> = Schema.Struct({
+  name: Schema.String,
+  children: Schema.Array(Schema.suspend((): Schema.Schema<Tree> => Tree))
+})
+```
+
+Use it whenever a schema refers to itself, directly or indirectly.
+
+Without `suspend`, recursive definitions will not work correctly.
+
+## Transformations
+
+Transformations are one of the most important Schema features.
+
+Use them when decoded and encoded shapes differ.
+
+This is the main tool that avoids needless schema duplication.
+
+If your instinct is “I need another schema because this boundary encodes the same value differently”, stop and first ask whether this should be one schema with a transformation instead.
+
+### `Schema.decodeTo`
+
+Use `decodeTo` when you want one schema to decode into another schema's type.
+
+```ts
+const TrimmedString = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: (value) => value.trim(),
+    encode: (value) => value
+  })
+)
+```
+
+The vendored docs explicitly note that `decodeTo` is curried and should be used with `pipe`.
+
+### `Schema.encodeTo`
+
+Use `encodeTo` when the reverse direction reads more clearly.
+
+### `SchemaTransformation.transformOrFail`
+
+Use `transformOrFail` when the transformation itself is effectful or may fail.
+
+```ts
+import * as Effect from "effect/Effect"
+import * as SchemaTransformation from "effect/SchemaTransformation"
+
+const VerifiedString = Schema.String.pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transformOrFail({
+      decode: (value) => Effect.succeed(value.trim()),
+      encode: (value) => Effect.succeed(value)
+    })
+  )
+)
+```
+
+Use this when:
+
+- validation depends on services or effects
+- decoding can fail with structured issues
+- encoding also needs logic beyond identity
+
+## Field-Level Transformations
+
+Very often, the right answer is not a second object schema but a transformed field schema.
+
+Example shape:
+
+```ts
+const Completed = Schema.BooleanFromBit
+
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Completed
+})
+```
+
+In this pattern:
+
+- the logical model still has `completed: boolean`
+- the encoded SQL-facing representation can still be a bit
+- the transformation lives at the field where it belongs
+
+This is usually better than defining `Todo` and `TodoSql` as separate object schemas.
+
+## Object-Level Transformations
+
+Use object-level transformations when the whole object encoding differs, not just one field.
+
+Good use cases:
+
+- external keys differ from internal keys
+- several fields need coordinated transformation
+- the encoded shape is a structurally different representation of the same model
+
+Still prefer a single logical schema plus a transformation pipeline over maintaining multiple duplicated top-level schemas.
+
+## Rename Keys
+
+Schema supports key renaming through struct transformations.
+
+The vendored `Schema.ts` implements key renaming by mapping fields and using decode/encode transformations with renamed key maps.
+
+Use key renaming when:
+
+- external payload keys differ from internal keys
+- you want stable internal names while honoring external contract names
+
+Preferred pattern:
+
+- keep the internal decoded shape idiomatic
+- use schema-level transformation or field-mapping to adapt external keys
+
+This is another example of avoiding duplication. If the only difference is key naming, do not define a second schema just to rename fields manually later.
+
+In practice, use struct field mapping helpers and transformation composition rather than manual post-parse object rewriting.
+
+## Opaque And Branded Types
+
+Use opaque or branded schemas when a value should stay distinct from its structural base type.
+
+### `Schema.brand`
+
+Use `brand` for refined nominal distinctions.
+
+```ts
+const UserId = Schema.String.pipe(
+  Schema.brand("UserId")
+)
+```
+
+This is useful for:
+
+- IDs
+- validated domain scalars
+- preventing accidental interchange of same-shaped values
+
+### `Schema.Opaque`
+
+Use `Opaque` when you want an opaque schema-backed type with the same structure as its underlying schema.
+
+This is especially useful when the type should remain distinct at the type level without changing its runtime shape.
+
+## Picking, Omitting, Partial Shapes, And Mutability
+
+Common struct operations include:
+
+- `pick`
+- `omit`
+- `partial`
+- `mutable`
+
+Use them to derive variations instead of redefining near-identical schemas manually.
+
+Good examples:
+
+- request subset from a domain model
+- patch/update payloads
+- mutable representations for specific adapters
+
+Prefer deriving from one source schema rather than maintaining parallel copies.
+
+This is the second major tool for avoiding duplication:
+
+- use transformations when encoded and decoded representations differ
+- use derivation when one schema is a subset, superset, or variation of another
+
+## Constraints And Validation
+
+Use schema checks and filters for validation.
+
+Examples from the module docs include:
+
+- `isMinLength`
+- `isGreaterThan`
+- `isPattern`
+- `isUUID`
+
+Attach them with `.check(...)`.
+
+Use this when:
+
+- the validation is intrinsic to the schema
+- the rule belongs to the data contract
+
+For business-rule validation that depends on services or current state, prefer effectful logic outside the schema or use effectful transformations.
+
+## Decoding And Encoding
+
+Common operations:
+
+- `Schema.decodeUnknownSync`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownSync`
+- `Schema.encodeUnknownEffect`
+
+Preferred rule:
+
+- use `decodeUnknownEffect` and `encodeUnknownEffect` in Effect code
+- avoid throwing sync decode APIs in application flows unless you are intentionally at a sync boundary
+
+Good pattern:
+
+```ts
+const decodeUser = Schema.decodeUnknownEffect(User)
+```
+
+## Schema Metadata And Derived Tooling
+
+Schema is also used for:
+
+- annotations and documentation metadata
+- JSON Schema generation
+- arbitrary generation for tests
+- derived equivalence
+
+Useful operations from the module docs:
+
+- `.annotate(...)`
+- `Schema.toJsonSchemaDocument(...)`
+- `Schema.toArbitrary(...)`
+- `Schema.toEquivalence(...)`
+
+Use annotations when the schema participates in:
+
+- API docs
+- codegen
+- contract generation
+
+## Common Repo Patterns
+
+Patterns visible in the vendored repo:
+
+- `Schema.Class` for named reusable contract types
+- `Schema.Struct` for inline shapes and anonymous fragments
+- `Schema.Union` for alternative payloads
+- `Schema.optionalKey` for request/query/body optional fields
+- `Schema.suspend` for recursive generated schemas
+- `Schema.decodeTo` and `transformOrFail` for non-trivial decode/encode logic
+- `Schema.TaggedErrorClass` for typed error payloads
+
+## Best Practices
+
+1. Prefer `Class` variants over plain `Struct` for named reusable schemas.
+2. Prefer tagged variants for unions and errors.
+3. Prefer `optionalKey` for optional object properties.
+4. Do not duplicate schemas unless there is a real semantic difference.
+5. Prefer schema-level transformations over ad hoc post-parse object rewriting.
+6. Prefer deriving schema variants with `pick`, `omit`, `partial`, and `mutable` instead of duplicating definitions.
+7. Prefer field-level transformations when only a field encoding differs.
+8. Prefer branded or opaque types for important domain identifiers.
+9. Prefer `decodeUnknownEffect` in application code.
+10. Keep internal decoded shapes idiomatic and use schema transforms for external representation differences.
+
+## Anti-Patterns
+
+- using plain `Struct` for every reusable domain model even when `Class` would give a clearer named type
+- duplicating whole schemas when only one field encoding differs
+- creating `Foo` and `FooSql` schemas for the same logical model when a transformation would do
+- using `optional` when you actually want an optional key
+- duplicating near-identical schemas instead of deriving variants
+- rewriting keys manually after decode instead of using schema transformations
+- hand-validating external data after decode when the constraint belongs in the schema
+- exposing unvalidated external payloads deep into business logic
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`

--- a/.claude/skills/effect-ts/references/guide-sql.md
+++ b/.claude/skills/effect-ts/references/guide-sql.md
@@ -1,0 +1,536 @@
+# SQL Guide
+
+This guide is based on the vendored Effect SQL modules in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Preferred Rule
+
+When a project uses Effect, prefer the Effect SQL modules over directly coupling business code to a native SQL driver API.
+
+Prefer:
+
+- `effect/unstable/sql/SqlClient`
+- `effect/unstable/sql/Migrator`
+- `effect/unstable/sql/SqlResolver`
+- `effect/unstable/sql/SqlSchema`
+- `effect/unstable/sql/SqlModel`
+
+Over:
+
+- embedding raw driver calls directly in business services
+- hand-rolling transactions in service methods
+- ad hoc migration scripts disconnected from the Effect runtime
+
+Why:
+
+- transactions are integrated into the Effect model
+- spans and SQL observability are built in
+- SQL errors stay typed and consistent
+- schema decoding and request resolution compose better
+- layers and services stay portable across runtimes and tests
+
+## Mental Model
+
+The Effect SQL stack is organized around:
+
+- `SqlClient` as the main database capability
+- `withTransaction` for transaction boundaries
+- `SqlResolver` for request-style batched and validated access
+- `SqlSchema` and `SqlModel` for schema-aware query/model patterns
+- `Migrator` for managed migrations
+
+The business layer should depend on Effect SQL abstractions, not on a raw driver object.
+
+## `SqlClient`
+
+`SqlClient` is the primary service for executing SQL.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Use it when:
+
+- you need to execute queries
+- you need transactions
+- you want SQL operations to participate in Effect spans and context
+
+Important capabilities from the repo:
+
+- transaction support with `withTransaction`
+- connection reservation with `reserve`
+- reactive queries
+- integration with transaction-scoped context
+
+## Typed Queries
+
+Prefer typed SQL queries instead of leaving row shapes implicit.
+
+The repo uses typed query literals like:
+
+```ts
+const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM test`
+```
+
+This is the first level of typed SQL usage and is already better than untyped row access.
+
+Use typed query literals when:
+
+- the row shape is small and obvious
+- the query is local and does not justify a reusable schema
+- you want immediate row typing without introducing extra helpers
+
+Avoid:
+
+- leaving query results untyped and then recovering shape with unsafe assertions
+- using `as` on rows after query execution
+
+## Schema Integration
+
+Prefer integrating SQL with Schema whenever the row shape matters or the query result crosses a meaningful boundary.
+
+Why:
+
+- Schema validates the shape rather than trusting the database blindly
+- row decoding stays explicit and typed
+- the same schema can often be reused for transport, domain, or contract layers
+- this avoids unsafe row assertions such as `as TodoRow`
+
+### Prefer schema-decoded results over `as`-based rows
+
+Avoid this pattern:
+
+```ts
+const row = yield* sql`SELECT id, title FROM todos WHERE id = ${id}`
+const todo = row[0] as TodoRow
+```
+
+Prefer:
+
+- a typed SQL query plus Schema decoding
+- or a SQL helper such as `SqlResolver`, `SqlSchema`, or `SqlModel` when appropriate
+
+Example boundary decode:
+
+```ts
+const TodoRow = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const decodeTodoRows = Schema.decodeUnknownEffect(Schema.Array(TodoRow))
+```
+
+Then keep the query and decoding together in one SQL-aware operation.
+
+### `SqlResolver` + Schema
+
+`SqlResolver` is one of the clearest examples of SQL and Schema integration in the vendored repo.
+
+It uses:
+
+- a `Request` schema for validating resolver input
+- a `Result` schema for validating query output
+
+Example shape from the repo tests:
+
+```ts
+const resolver = SqlResolver.findById({
+  Id: Schema.Number,
+  Result: Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+  }),
+  ResultId: (row) => row.id,
+  execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
+})
+```
+
+This is a preferred pattern when:
+
+- multiple IDs are fetched together
+- request batching is useful
+- the query contract should be schema-validated
+
+### `SqlSchema` and `SqlModel`
+
+Use `SqlSchema` and `SqlModel` when you want tighter schema integration with SQL itself.
+
+They are preferred over hand-written row types when:
+
+- the row shape is central to the module
+- you want reusable schema-aware model logic
+- manual row mapping is becoming repetitive
+
+## Prefer SQL Services Over Native Driver Services
+
+Avoid this pattern:
+
+```ts
+class TodoService extends Context.Service<TodoService, { ... }>()("TodoService") {
+  static readonly layer = Layer.effect(this)(
+    Effect.acquireRelease(
+      Effect.try({ try: () => new Database("todos.sqlite") })
+    )
+  )
+}
+```
+
+Why this is usually a bad pattern in an Effect codebase:
+
+- the service is now tightly coupled to one runtime-specific database client
+- you lose the shared SQL abstraction that the Effect repo already provides
+- transaction and query conventions become ad hoc
+- it is easier to drift away from typed SQL errors, SQL tracing, and reusable query helpers
+
+Prefer a layer that provides `SqlClient`, and let domain services depend on that.
+
+## Domain Services Should Depend On `SqlClient`
+
+Good pattern:
+
+```ts
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+
+class TodoRepo extends Context.Service<TodoRepo>()("TodoRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("TodoRepo.getById")(function*(id: number) {
+      const sql = yield* SqlClient.SqlClient
+      return yield* sql`SELECT id, title, completed FROM todos WHERE id = ${id}`
+    })
+  })
+}) {}
+```
+
+Why this is better:
+
+- the domain service depends on an Effect SQL capability
+- SQL stays observable and transactional
+- the SQL client implementation can be provided separately from the business service
+
+## Transactions
+
+Use `SqlClient.withTransaction` for transaction boundaries.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Prefer:
+
+```ts
+const createAndAudit = Effect.fn("TodoRepo.createAndAudit")(function*(title: string) {
+  const sql = yield* SqlClient.SqlClient
+
+  return yield* sql.withTransaction(
+    Effect.gen(function*() {
+      yield* sql`INSERT INTO todos ${sql.insert({ title, completed: false })}`
+      yield* sql`INSERT INTO audit_log ${sql.insert({ event: "todo_created" })}`
+    })
+  )
+})
+```
+
+Avoid:
+
+- manual `BEGIN` / `COMMIT` / `ROLLBACK` in application service code
+- driver-specific transaction logic spread across multiple service methods
+
+## Query Composition
+
+Prefer keeping query logic inside SQL-aware services or repositories.
+
+Good patterns:
+
+- keep queries close to the service that owns the behavior
+- use named business operations for multi-step workflows
+- use small local helpers only when they improve clarity
+
+Avoid exposing one exported accessor function per SQL service method if it only forwards to the service.
+
+Bad:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoRepo
+  return yield* todos.create(title)
+})
+```
+
+Prefer:
+
+- use the service method directly within the owning workflow
+- or export a real business operation that adds behavior beyond simple forwarding
+
+## SQL Resolvers
+
+Use `SqlResolver` when request-style batching or schema-validated request/response handling is useful.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+
+It is especially good for:
+
+- batched lookup patterns
+- `findById`-style resolvers
+- grouped query resolution
+- integrating SQL with request batching patterns
+
+Important repo pattern:
+
+- request schema validates inputs
+- result schema validates outputs
+- execution remains effectful and transactional
+
+This is one of the strongest typed-query patterns in the repo and should be preferred over ad hoc batched row mapping when the query fits the resolver model.
+
+## SQL Schemas And Models
+
+When schema-aware SQL helpers fit the task, prefer them over hand-mapped rows.
+
+Look at:
+
+- `SqlSchema`
+- `SqlModel`
+
+These are good fits when:
+
+- the row shape matters strongly
+- schema-based decode/encode should stay aligned with database access
+- you want to reduce ad hoc row mapping logic
+
+Avoid overusing manual `type Row = { ... }` plus custom conversion if the schema-aware modules already express the shape clearly.
+
+Preferred order for query typing:
+
+1. schema-aware SQL module such as `SqlResolver`, `SqlSchema`, or `SqlModel` when it fits
+2. typed query literals plus Schema decoding when the query is local
+3. only use manual row mapping when the first two options are clearly heavier than the problem
+
+## Migrations
+
+Use `Migrator` for migrations.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+
+The repo shows these best practices:
+
+- maintain a dedicated migrations table
+- load migrations through a managed loader
+- run migrations through the Effect runtime
+- keep migration execution observable with logs and spans
+- use SQL client transaction and locking semantics handled by the migrator
+
+Important behavior in the vendored repo:
+
+- migrations table creation is dialect-aware
+- duplicate migration IDs are detected
+- concurrent migration runs are guarded
+- each migration is logged and wrapped in a span
+
+### Concrete Migration Loader Example
+
+The runtime-specific SQL migrator packages expose `fromRecord(...)` to define migrations from an ordered record.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+import * as Effect from "effect/Effect"
+
+const migrations = SqliteMigrator.fromRecord({
+  "1_create_todos": Effect.gen(function*() {
+    yield* sql`
+      CREATE TABLE todos (
+        id INTEGER PRIMARY KEY NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0
+      )
+    `.withoutTransform
+  }),
+  "2_add_todo_index": Effect.gen(function*() {
+    yield* sql`
+      CREATE INDEX todos_completed_idx ON todos (completed)
+    `.withoutTransform
+  })
+})
+```
+
+This matches the model used by the vendored migrator implementation:
+
+- each migration has a numeric prefix and descriptive name
+- each migration resolves to an `Effect`
+- migrations are ordered by ID
+
+### Running Migrations Directly
+
+Use the runtime-specific `run(...)` helper when you want a startup effect that runs migrations explicitly.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const runMigrations = SqliteMigrator.run({
+  loader: migrations
+})
+```
+
+This is a good fit when:
+
+- startup explicitly runs migrations before launching the main app
+- deployment tooling runs migrations as a separate command
+- you want migration results as an ordinary `Effect`
+
+The return value includes the applied migration IDs and names.
+
+### Running Migrations As A Layer
+
+Use the runtime-specific `layer(...)` helper when migrations should run as part of top-level infrastructure setup.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+```
+
+From the vendored packages, this is implemented as `Layer.effectDiscard(run(options))`.
+
+That means:
+
+- the layer performs the migration effect
+- it does not provide a new service of its own
+- it is intended to be composed into startup infrastructure
+
+### Concrete Startup Composition Example
+
+Preferred shape:
+
+```ts
+const SqlLayer = SqliteClient.layer({ filename: "todos.sqlite" })
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+
+const MigratedSqlLayer = Layer.merge(
+  SqlLayer,
+  MigrationLayer.pipe(Layer.provide(SqlLayer))
+)
+```
+
+This keeps the structure explicit:
+
+- one layer provides the SQL client
+- one layer runs migrations
+- the merged layer represents a migrated SQL environment
+
+If the same migrated SQL environment is reused in tests, create it once and reuse the layer value.
+
+### Migration Best Practices
+
+- use stable numeric migration IDs
+- keep migration files ordered and unique
+- do not hand-roll a separate migrations subsystem if `Migrator` already fits the project
+- keep migration execution at startup or a dedicated operational boundary
+- do not bury migration execution inside arbitrary service construction unless startup is explicitly the right place
+
+### Preferred Migration Boundary
+
+Good pattern:
+
+- construct the SQL layer
+- run migrations once at startup or deployment entry
+- then run the main application
+
+Concrete shapes:
+
+- separate startup effect: `SqliteMigrator.run({ loader })`
+- startup layer: `SqliteMigrator.layer({ loader })`
+- migrated environment layer: merge the SQL client layer with the migration layer provided by that client layer
+
+Avoid:
+
+- opportunistic migrations inside ordinary request handlers
+- schema creation hidden inside unrelated business service constructors
+
+## Errors
+
+Prefer SQL errors that stay inside the Effect SQL model as long as possible.
+
+Use domain-level translation only where it helps the business boundary.
+
+Good:
+
+- SQL layer or repository works with `SqlError` and schema decode failures where appropriate
+- higher-level service translates expected cases into domain errors when needed
+
+Avoid:
+
+- converting every SQL error immediately into a string
+- hiding SQL failure details too early
+
+## Observability
+
+The vendored SQL modules already integrate with spans and transaction context.
+
+This is another reason to prefer them over raw driver usage.
+
+Good pattern:
+
+- use `SqlClient` and `withTransaction`
+- keep business operations wrapped with `Effect.fn`
+- add explicit spans only where business-level detail matters beyond the built-in SQL spans
+
+## Layering Pattern
+
+Preferred layering shape:
+
+1. runtime-specific database layer provides `SqlClient`
+2. migrations run at startup boundary
+3. domain repository/service depends on `SqlClient`
+4. top-level application layer composes the database layer with the business layers
+
+This keeps:
+
+- driver choice at the edge
+- SQL capability in the middle
+- business logic above it
+
+## Anti-Patterns
+
+- embedding a native driver directly in business services when Effect SQL modules are available
+- hand-rolling transactions with raw SQL statements in service methods
+- hiding schema creation inside unrelated service constructors
+- exporting one trivial accessor function per repository/service method
+- converting SQL errors to strings too early
+- bypassing `Migrator` when the project already uses Effect SQL
+- creating ad hoc migration effects without a stable loader shape when `fromRecord(...)` already fits the project
+- scattering migration execution across multiple subsystems instead of one explicit startup boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`

--- a/.claude/skills/effect-ts/references/guide-testing.md
+++ b/.claude/skills/effect-ts/references/guide-testing.md
@@ -1,0 +1,504 @@
+# Testing Guide
+
+This guide is based on the vendored `@effect/vitest` package in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`
+
+## Preferred Rule
+
+When testing Effect code with Vitest, prefer `@effect/vitest` over manually calling `Effect.runPromise`, `Effect.runSync`, or ad hoc runtime setup inside ordinary Vitest tests.
+
+Layer provisioning in tests should follow these rules:
+
+1. If multiple tests should share the same layered setup, use `layer(...)`.
+2. If a nested group needs extra dependencies, use `it.layer(...)`.
+3. If tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls.
+4. Do not default to local `.pipe(Effect.provide(...))` inside test bodies.
+
+Use:
+
+- `it.effect` for Effect-based tests with test services
+- `it.live` for Effect-based tests that should use live services
+- `layer(...)` and `it.layer(...)` for shared layered test setup
+- `it.effect.prop` for Effect-based property tests
+
+Do not default to `.pipe(Effect.provide(SomeLayer))` inside test bodies when `layer(...)` or `it.layer(...)` expresses the setup more clearly.
+
+## Imports
+
+Preferred imports for Effect tests:
+
+```ts
+import { assert, describe, it, layer } from "@effect/vitest"
+import { Effect } from "effect"
+```
+
+`@effect/vitest` re-exports Vitest, so it is the normal entrypoint for test APIs in an Effect codebase.
+
+## Core Test Modes
+
+## `it.effect`
+
+Use `it.effect` for most Effect tests.
+
+It automatically:
+
+- runs the effect
+- scopes it correctly
+- provides the default test environment
+
+The default test environment includes:
+
+- `TestConsole`
+- `TestClock`
+
+This comes directly from the internal implementation.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+it.effect("loads a user", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+    assert.isTrue(true)
+  })
+)
+```
+
+Use `it.effect` when:
+
+- the test uses ordinary Effect code
+- the test benefits from `TestClock`
+- the test benefits from `TestConsole`
+- the test should run in a scoped Effect runtime
+
+## `it.live`
+
+Use `it.live` when the test should use live services instead of the default test environment.
+
+Example:
+
+```ts
+it.live("uses live services", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+  })
+)
+```
+
+Use `it.live` when:
+
+- you need the real `Clock`
+- the test should interact with live runtime services
+- you deliberately do not want the test environment overrides
+
+Rule of thumb:
+
+- default: `it.effect`
+- opt into `it.live` only when you actually need live behavior
+
+## Effect Test Structure
+
+Preferred pattern:
+
+```ts
+it.effect("does something", () =>
+  Effect.gen(function*() {
+    const value = yield* someEffect
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+Prefer `Effect.gen` inside `it.effect` and `it.live` for readability.
+
+Avoid:
+
+- `it("...", async () => ...)` for Effect programs
+- `Effect.runPromise(...)` inside plain Vitest tests
+- manual runtime setup for routine Effect tests
+
+## Assertions
+
+Use `assert` for Effect tests.
+
+The vendored repo also uses `expect` in some tests, but for skill guidance prefer `assert` in Effect-based tests because it keeps tests more uniform and explicit inside Effect programs.
+
+Examples:
+
+```ts
+assert.isTrue(value === 1)
+assert.strictEqual(a + b, b + a)
+assert.include(text, substring)
+```
+
+## Test Context
+
+`it.effect` and `it.live` test functions can receive a Vitest `TestContext`.
+
+Example:
+
+```ts
+it.effect("uses context", (ctx) =>
+  Effect.gen(function*() {
+    ctx.onTestFailed(() => {
+      // cleanup or diagnostics
+    })
+  })
+)
+```
+
+Use this when you need:
+
+- failure hooks
+- abort signals
+- ordinary Vitest test context integration
+
+## `each`, `skip`, `skipIf`, `runIf`, `only`, `fails`
+
+The Effect testers support the standard test variants:
+
+- `it.effect.each(...)`
+- `it.live.each(...)`
+- `it.effect.skip(...)`
+- `it.effect.skipIf(...)`
+- `it.effect.runIf(...)`
+- `it.effect.only(...)`
+- `it.live.fails(...)`
+
+Examples from the vendored tests show these are first-class parts of the API.
+
+Use them exactly as you would with Vitest, but return `Effect` from the test body.
+
+## Property Testing
+
+There are two different property-test entrypoints and they do not have identical behavior.
+
+## Top-level `it.prop`
+
+Use `it.prop` for non-Effect property tests.
+
+Example:
+
+```ts
+import { it } from "@effect/vitest"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a)
+```
+
+Important limitation from the internal implementation:
+
+- top-level `it.prop` does not support `Schema` arbitraries yet
+- if you pass a `Schema`, it throws
+
+So use top-level `it.prop` only with explicit `FastCheck` arbitraries.
+
+## `it.effect.prop`
+
+Use `it.effect.prop` for property tests that return `Effect`.
+
+This is the more powerful property-testing mode for Effect code.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(a + b, b + a)
+  })
+)
+```
+
+Unlike top-level `it.prop`, `it.effect.prop` does support `Schema` inputs by converting them with `Schema.toArbitrary`.
+
+So prefer `it.effect.prop` when:
+
+- the property test needs `Effect`
+- you want to use `Schema` values as arbitraries
+- the test needs Effect services or scope
+
+## `layer(...)`
+
+Use top-level `layer(...)` to share a `Layer` across a group of tests.
+
+Hard rule:
+
+- use `layer(...)` when tests should share one layered setup
+- do not use it when each test needs its own isolated layer instance
+
+This is one of the most important `@effect/vitest` features.
+
+Example:
+
+```ts
+import { describe, it, layer } from "@effect/vitest"
+import { Context, Effect, Layer } from "effect"
+
+class Foo extends Context.Service<Foo, string>()("Foo") {
+  static readonly layer = Layer.succeed(Foo)("foo")
+}
+
+describe("foo", () => {
+  layer(Foo.layer)((it) => {
+    it.effect("gets foo", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        return foo
+      })
+    )
+  })
+})
+```
+
+What it does internally:
+
+- builds the layer once for the test group
+- memoizes the built layer with a `MemoMap`
+- keeps the scope open for the group
+- closes the scope in `afterAll`
+
+This makes it the preferred way to share layer setup across related tests.
+
+This is also the preferred alternative to calling `Effect.provide(...)` inside each individual test body.
+
+## Anti-Pattern: Local `Effect.provide(...)` In Tests
+
+If multiple tests use the same layer, do not write tests like this:
+
+```ts
+it.effect("creates and lists todos", () =>
+  Effect.gen(function*() {
+    const service = yield* TodoService
+    yield* service.create("write tests")
+    yield* service.create("ship feature")
+  }).pipe(
+    Effect.provide(TodoService.inMemoryLayer)
+  )
+)
+```
+
+Why this is the wrong pattern:
+
+- it repeats provisioning in every test
+- it hides the layered test setup inside each test body
+- it fights the `@effect/vitest` layer helpers
+- it makes shared setup and teardown less explicit
+- it bypasses the clearer grouped-layer style that the library is designed for
+
+Prefer:
+
+```ts
+describe("TodoService", () => {
+  layer(TodoService.inMemoryLayer)((it) => {
+    it.effect("creates and lists todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        yield* service.create("write tests")
+        yield* service.create("ship feature")
+      })
+    )
+
+    it.effect("updates completion and deletes todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const todo = yield* service.create("close issue")
+        yield* service.setCompleted(todo.id, true)
+        yield* service.remove(todo.id)
+      })
+    )
+  })
+})
+```
+
+Rule:
+
+- if a test or group of tests depends on a layer, prefer `layer(...)`
+- if a nested group needs extra dependencies, prefer `it.layer(...)`
+- if tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls
+- use local `Effect.provide(...)` in tests only for true one-off edge cases, not as the normal pattern
+
+This matches the general layer guidance: provisioning belongs at the boundary, and in `@effect/vitest` the test boundary should usually be expressed with `layer(...)` rather than ad hoc local provisioning.
+
+## `it.layer(...)`
+
+Use `it.layer(...)` inside an existing layered test group to add nested layer context.
+
+Hard rule:
+
+- use `it.layer(...)` when a specific test or nested test block should get its own isolated layered setup
+- if isolation matters, prefer multiple separate `it.layer(...)` calls over one shared `layer(...)` group
+
+Example:
+
+```ts
+layer(Foo.layer)((it) => {
+  it.layer(Bar.layer)("nested", (it) => {
+    it.effect("gets both", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        const bar = yield* Bar
+        return [foo, bar]
+      })
+    )
+  })
+})
+```
+
+Important behavior from the implementation:
+
+- nested `it.layer(...)` reuses the parent memo map
+- nested `it.layer(...)` does not accept `memoMap` or `excludeTestServices`
+- nested layering is meant to extend the current layered test environment, not redefine its runtime policy
+
+Use multiple `it.layer(...)` blocks when each test should get its own isolated layered setup instead of sharing one top-level `layer(...)` group.
+
+## `layer` Options
+
+The top-level `layer(...)` helper accepts:
+
+- `timeout`
+- `memoMap`
+- `excludeTestServices`
+
+### `excludeTestServices`
+
+By default, `layer(...)` merges your layer with the test environment (`TestClock` and `TestConsole`).
+
+Use `excludeTestServices: true` when you want your layer group to run without those test-service overrides.
+
+This is useful for tests that should keep live runtime behavior.
+
+### `memoMap`
+
+Use `memoMap` only when you have a specific reason to coordinate layer memoization manually across test setups.
+
+Most tests should let `@effect/vitest` manage it.
+
+## Scoped Resources In Tests
+
+`@effect/vitest` is designed to work correctly with scoped effects and layered resources.
+
+The vendored tests explicitly verify resource release through `afterAll`.
+
+Use this normally:
+
+- define scoped services in layers
+- use `layer(...)` to share them
+- let the helper own scope setup and teardown
+
+Avoid manually managing large scopes in test code unless the test specifically needs that control.
+
+## `flakyTest`
+
+Use `flakyTest` for tests that need bounded retrying.
+
+Repo behavior:
+
+- wraps the test in `Effect.scoped`
+- retries using a schedule
+- retries for up to a timeout window
+- converts final failure to defect with `Effect.orDie`
+
+Use this only for truly flaky integration-style conditions, not as a substitute for deterministic tests.
+
+## `makeMethods` And `describeWrapped`
+
+These exist for custom integration and wrapper scenarios.
+
+### `makeMethods`
+
+Use `makeMethods` when you need to extend or wrap a custom Vitest `it` instance while preserving Effect-aware helpers.
+
+### `describeWrapped`
+
+Use `describeWrapped` when you want a `describe` wrapper that hands you the augmented Effect-aware `it` methods directly.
+
+Most test code can just use imported `describe` and `it` from `@effect/vitest`.
+
+## Equality Testers
+
+`addEqualityTesters()` exists as part of the public API.
+
+Use it only when you have a concrete need to install equality testers for your Vitest environment.
+
+It is not needed for ordinary test structure.
+
+## Recommended Patterns
+
+### Pattern: normal Effect test
+
+```ts
+it.effect("does work", () =>
+  Effect.gen(function*() {
+    const value = yield* Effect.succeed(1)
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+### Pattern: shared layer for a test group
+
+```ts
+layer(AppLayer)("app", (it) => {
+  it.effect("uses app services", () =>
+    Effect.gen(function*() {
+      yield* Effect.void
+    })
+  )
+})
+```
+
+### Pattern: property test with Effect
+
+```ts
+it.effect.prop("law", [FastCheck.integer()], ([n]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(n + 0, n)
+  })
+)
+```
+
+### Pattern: use `TestClock`
+
+```ts
+it.effect("uses TestClock", () =>
+  Effect.gen(function*() {
+    const fiber = yield* Effect.forkChild(Effect.sleep("1 second"))
+    yield* TestClock.adjust("1 second")
+    yield* Fiber.join(fiber)
+  })
+)
+```
+
+## Anti-Patterns
+
+- using plain `it(...)` with `Effect.runPromise(...)` for normal Effect tests
+- using `it.live` by default when `it.effect` is sufficient
+- manually building and tearing down large layer graphs instead of using `layer(...)`
+- using top-level `it.prop` with `Schema` inputs
+- using `flakyTest` to hide deterministic failures
+- duplicating runtime setup instead of sharing a layer
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`

--- a/.claude/skills/effect-ts/references/setup.md
+++ b/.claude/skills/effect-ts/references/setup.md
@@ -1,0 +1,89 @@
+# Effect Source Setup
+
+This setup task is required when `./.repos/effect` is missing from the root of the repository where this skill is used.
+
+## Prompt
+
+The local Effect source checkout was not found at `./.repos/effect`.
+
+Choose one of these setup options before continuing:
+
+1. Add `https://github.com/Effect-TS/effect-smol` as a git subtree with squashed history at `./.repos/effect`
+2. Add `https://github.com/Effect-TS/effect-smol` as a git submodule at `./.repos/effect`
+3. Use `git clone` into `./.repos/effect`, ignore it via `.gitignore`, and add a prepare script that bootstraps it when missing
+
+## Supported Options
+
+### 1. Git Subtree
+
+Use this when the repository should vendor the Effect source directly while keeping history compact.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: subtree with squashed history
+
+### 2. Git Submodule
+
+Use this when the repository should track the Effect source explicitly as a separate Git dependency.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: standard Git submodule
+
+### 3. Local Clone + Gitignore + Prepare Task
+
+Use this when the repository should avoid vendoring or submodule management, but still provide a reproducible local setup.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Add `.repos/effect` to the repository `.gitignore`
+- Add a `prepare` task that clones the repo automatically when the directory is missing
+
+#### Concrete Shape
+
+Use this exact shape for the setup. Do not invent a different script.
+
+`package.json`:
+
+```json
+{
+  "scripts": {
+    "prepare": "./scripts/prepare-effect.sh"
+  }
+}
+```
+
+`.gitignore`:
+
+```gitignore
+.repos/effect
+```
+
+`scripts/prepare-effect.sh`:
+
+```sh
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect-smol"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"
+```
+
+#### Notes
+
+- This keeps `./.repos/effect` available for local research without forcing it into version control
+- The script is only responsible for ensuring the checkout exists; it does not update or reset an existing clone
+- If you choose this option, the setup task should add this exact script, wire it via `prepare`, and add `.repos/effect` to `.gitignore`
+
+## Guidance
+
+- Do not continue with Effect-specific work until one of the setup options is chosen.
+- Prefer the option that matches the host repository's dependency management style.

--- a/skills/effect-ts/PROVENANCE.md
+++ b/skills/effect-ts/PROVENANCE.md
@@ -1,0 +1,39 @@
+# Provenance
+
+This skill is **vendored** (copied in) from a third-party repository, per the
+copy-in exception in the repo-root `CLAUDE.md` ("copy-in 例外は skill ディレクトリ内に
+出典 + LICENSE を残す").
+
+- Source: https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+- Upstream repo: https://github.com/Effect-TS/skills
+- Pinned commit: `b5026c68318f395bbfd258182ea6b524ff2be549`
+- Commit date: 2026-05-15
+- Vendored on: 2026-07-05
+- Reason: supply-chain safety — copied verbatim instead of fetching at consume time.
+
+## License status
+
+At the time of vendoring, the upstream `Effect-TS/skills` repository contained
+**no LICENSE file and no explicit license statement** (verified via the GitHub
+API and the upstream README). The Effect project is generally published under the
+MIT License, but this `skills` repository carries no explicit grant. This copy is
+made in good faith for internal use. If upstream adds an explicit license, or
+requests removal, update or remove this vendored copy accordingly.
+
+## Re-syncing from upstream
+
+Re-fetch each file at a chosen commit `<SHA>`:
+
+```sh
+for f in SKILL.md references/features.md references/guide-effect.md \
+  references/guide-error-handling.md references/guide-layers.md \
+  references/guide-observability.md references/guide-retries.md \
+  references/guide-schedule.md references/guide-schema.md \
+  references/guide-sql.md references/guide-testing.md references/setup.md; do
+  gh api "repos/Effect-TS/skills/contents/skills/effect-ts/$f?ref=<SHA>" \
+    --jq '.content' | base64 -d > "skills/effect-ts/$f"
+done
+```
+
+After re-syncing, re-apply the source-attribution comment in SKILL.md and update the
+pinned commit / dates above.

--- a/skills/effect-ts/SKILL.md
+++ b/skills/effect-ts/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: effect-ts
+description: Use this skill whenever working in a repository that uses Effect, even if the current task is in a new file or the user does not explicitly ask for Effect help. Apply it to any work that should follow the repository's Effect patterns, conventions, architecture, or supporting tooling. Also use it for questions about Effect patterns, services, layers, schemas, streams, runtimes, or typed error handling.
+---
+
+<!--
+Vendored from Effect-TS/skills — https://github.com/Effect-TS/skills/tree/main/skills/effect-ts
+Upstream commit: b5026c68318f395bbfd258182ea6b524ff2be549 (2026-05-15)
+Copied verbatim (supply-chain safety). Provenance + re-sync steps: ./PROVENANCE.md
+Do not edit vendored content here; re-sync from upstream instead.
+-->
+
+# Effect Expert
+
+Expert guidance for programming with the Effect library, covering error handling, dependency injection, composability, and testing patterns.
+
+## Prerequisite
+
+Before doing any other Effect-related work, check that `./.repos/effect` exists at the root of the repository where the skill is being used.
+
+If it does not exist, stop and prompt the user with the setup task documented in `./references/setup.md`.
+
+## Research Strategy
+
+Effect has many ways to accomplish the same task. Proactively research best practices when working with Effect patterns, especially for moderate to high complexity tasks.
+
+Use the local guides in `./references/` first. They are the preferred source for best practices, conventions, and common implementation patterns.
+
+Only go directly to the vendored Effect repo when:
+
+- the guides do not cover the question
+- you need exact API details or signatures
+- you need deeper implementation details
+- you need to verify a behavior against the source
+
+### Research Sources
+
+1. Local skill guides first. Start with the relevant files in `./references/` before doing deeper research.
+2. Codebase patterns second. Examine similar patterns in the current project before implementing. If Effect patterns already exist, follow them for consistency. If no patterns exist, skip this step.
+3. Effect source code last. For gaps in the guides, complex type errors, unclear behavior, or implementation details, examine the vendored Effect source at `./.repos/effect/packages/effect/src/`.
+
+### When To Research
+
+- Always research for services, layers, or complex dependency injection.
+- Always research for error handling with multiple error types or complex error hierarchies.
+- Always research for stream-based operations and reactive patterns.
+- Always research for resource management with scoped effects and cleanup.
+- Always research for concurrent or performance-critical code.
+- Always research for unfamiliar testing patterns.
+- Research when needed for complex refactors from promises or try/catch into Effect.
+- Research when needed for new service dependencies or layer restructuring.
+- Research when needed for custom error types or extensions of existing error hierarchies.
+- Research when needed for integrations with external systems such as databases, APIs, or third-party services.
+
+### Research Approach
+
+- Focus on canonical, readable, and maintainable solutions rather than clever optimizations.
+- Verify suggested approaches against existing codebase patterns when those patterns exist.
+- When multiple approaches are possible, prefer the most idiomatic Effect solution supported by the codebase and the vendored source.
+
+### Codebase Pattern Discovery
+
+When working in a project that uses Effect, check for existing patterns before implementing new code:
+
+1. Search for Effect imports and existing module usage to understand current conventions.
+2. Identify how services and layers are structured in the project.
+3. Note how errors are defined and propagated.
+4. Examine how Effect code is tested in the project.
+
+If no Effect patterns exist in the codebase, proceed using canonical patterns from the vendored Effect source and examples. Do not block on missing codebase patterns.
+
+### Feature Discovery
+
+When you need to discover available Effect modules, packages, or capabilities, search `./references/features.md` first.
+
+- Use it to identify the right package or module for a task.
+- Use the listed repo paths to jump directly into the vendored source under `./.repos/effect`.
+- Use it before inventing custom abstractions when Effect may already provide the functionality.
+
+### Guide Discovery
+
+When the task touches one of these areas, consult the matching guide before implementing:
+
+- `./references/guide-effect.md` for core `Effect` usage patterns, common constructors, composition, provisioning, and runtime boundaries
+- `./references/guide-error-handling.md` for defining errors, schema-based errors, failure handling, defects, and interrupts
+- `./references/guide-layers.md` for services, layer construction, composition, and provisioning patterns
+- `./references/guide-observability.md` for `Effect.fn`, spans, logging, metrics, and telemetry wiring
+- `./references/guide-retries.md` for retry policies, retry conditions, fallback strategies, and `ExecutionPlan`
+- `./references/guide-schedule.md` for retries, repeats, backoff, polling, cron, and schedule composition
+- `./references/guide-schema.md` for schema design, transformations, unions, recursion, opaque/branded types, and schema best practices
+- `./references/guide-sql.md` for Effect SQL usage, transactions, resolvers, schema-aware SQL, and migrations
+- `./references/guide-testing.md` for detailed `@effect/vitest` usage, layered test setup, property tests, and test services
+
+These guides should be treated as the default implementation guidance. Do not skip them and jump straight to `./.repos/effect` unless you need source-level confirmation or the guides do not answer the question.
+
+## Effect Principles
+
+Apply these core principles when writing Effect code.
+
+## Installation
+
+When installing Effect packages in a user repository:
+
+- use `effect@beta`
+- keep all `@effect/*` packages on aligned versions
+- install only the packages needed for the user's runtime and actual task
+
+### Version Rules
+
+- `effect` should be installed as `effect@beta`
+- if you install any `@effect/*` package, make sure all `@effect/*` packages use matching versions
+- do not mix unrelated `@effect/*` versions in the same project
+
+### Package Selection
+
+Choose packages based on the runtime and the work being done.
+
+- core library: `effect@beta`
+- Node.js runtime needs: install the matching `@effect/platform-node`
+- browser runtime needs: install the matching `@effect/platform-browser`
+- Bun runtime needs: install the matching `@effect/platform-bun`
+- Vitest integration needs: install the matching `@effect/vitest`
+- OpenTelemetry integration needs: install the matching `@effect/opentelemetry`
+
+Install additional `@effect/*` packages only when the user task actually needs them.
+
+### Practical Rule
+
+- start with `effect@beta`
+- add `@effect/*` packages as needed by runtime and features
+- keep the full installed Effect package set version-aligned
+
+### Error Handling
+
+- Use Effect's typed error system instead of throwing exceptions.
+- Define descriptive error types with proper error propagation.
+- Prefer `Schema.TaggedErrorClass` when the error can be schema-defined.
+- Use `Effect.fail`, `Effect.catchTag`, and `Effect.catch` for error control flow.
+
+### Dependency Injection
+
+- Implement dependency injection using services and layers.
+- Define services with `Context.Tag`.
+- Compose layers with `Layer.merge` and `Layer.provide`.
+- Use `Effect.provide` to inject dependencies at the edge, avoid providing locally.
+- Keep services encapsulated; avoid exporting trivial accessor wrappers that only forward to one service method.
+
+### Composability
+
+- Leverage Effect composability for complex operations.
+- Use appropriate constructors such as `Effect.succeed`, `Effect.fail`, `Effect.tryPromise`, `Effect.try`, and `Effect.sync`.
+- Apply proper resource management with scoped effects.
+- Chain operations with `Effect.flatMap`, `Effect.map`, and `Effect.tap`.
+
+### Business Logic Functions
+
+- Prefer `Effect.fn` for reusable business-logic functions that return `Effect`.
+- Prefer `Effect.fn` over raw `Effect.gen` definitions even when the function takes no arguments.
+- If you do not want an explicit named span, use `Effect.fn` without a span name.
+- Do not use `Effect.fnUntraced` as the default.
+- Use `Effect.fnUntraced` only for edge cases with a concrete low-level reason, such as measured hot-path overhead.
+
+### TypeScript Preferences
+
+- Never use `any`.
+- Never use `as` casts.
+- Never use unsafe type assertions or escape hatches.
+- Never use `namespace`.
+- Prefer correct typing, schema-driven decoding, narrowing, and proper generic constraints instead of forcing types.
+- If a value comes from an external boundary, validate or decode it instead of asserting its type.
+- If a type is hard to express, simplify the design or introduce a properly typed helper instead of using unsafe TypeScript.
+- For layers, do not hide them inside `namespace` blocks. Prefer either `static` members on the service class or plain exported layer constants.
+
+### Code Quality
+
+- Write type-safe code that leverages Effect's type system.
+- Use `Effect.gen` for readable sequential code.
+- Implement proper testing patterns using Effect testing utilities.
+- Prefer existing Effect primitives before introducing custom helpers.
+- Prefer `Schema.Class` / `Schema.TaggedClass` variants over plain `Schema.Struct` for named reusable schemas when possible.
+
+### Explaining Solutions
+
+When providing solutions, explain the Effect concepts being used and why they fit the specific use case. If you encounter patterns not covered in local references, prefer consistency with the codebase when possible and otherwise rely on the vendored Effect source.
+
+## References
+
+- `./references/features.md`
+- `./references/guide-effect.md`
+- `./references/guide-error-handling.md`
+- `./references/guide-layers.md`
+- `./references/guide-observability.md`
+- `./references/guide-retries.md`
+- `./references/guide-schedule.md`
+- `./references/guide-schema.md`
+- `./references/guide-sql.md`
+- `./references/guide-testing.md`
+- `./references/setup.md`

--- a/skills/effect-ts/references/features.md
+++ b/skills/effect-ts/references/features.md
@@ -1,0 +1,504 @@
+# Features
+
+Public package and module surface area to be aware of when researching or implementing a solution. Each module entry includes its vendored repo path so it can be located quickly.
+
+## `effect` Package
+
+Package path: `packages/effect`
+
+- `Array` - `packages/effect/src/Array.ts` - Immutable array utilities. Use: transform arrays immutably.
+- `BigDecimal` - `packages/effect/src/BigDecimal.ts` - Arbitrary-precision decimal arithmetic. Use: avoid floating-point errors.
+- `BigInt` - `packages/effect/src/BigInt.ts` - `bigint` utilities and instances. Use: work with large integers.
+- `Boolean` - `packages/effect/src/Boolean.ts` - Boolean utilities and instances. Use: compose boolean logic.
+- `Brand` - `packages/effect/src/Brand.ts` - Branded type helpers. Use: prevent accidental type mixing.
+- `Cache` - `packages/effect/src/Cache.ts` - Effect cache utilities. Use: memoize effectful lookups.
+- `Cause` - `packages/effect/src/Cause.ts` - Structured effect failure representation. Use: inspect failures and defects.
+- `Channel` - `packages/effect/src/Channel.ts` - Bidirectional streaming I/O abstraction. Use: build stream pipelines.
+- `ChannelSchema` - `packages/effect/src/ChannelSchema.ts` - Schema helpers for channels. Use: type channel protocols.
+- `Chunk` - `packages/effect/src/Chunk.ts` - Immutable high-performance sequence. Use: efficient functional sequences.
+- `Clock` - `packages/effect/src/Clock.ts` - Time service and sleep utilities. Use: schedule and measure time.
+- `Combiner` - `packages/effect/src/Combiner.ts` - Combine two values of one type. Use: merge values consistently.
+- `Config` - `packages/effect/src/Config.ts` - Schema-driven configuration loading. Use: read typed app config.
+- `ConfigProvider` - `packages/effect/src/ConfigProvider.ts` - Configuration data source abstraction. Use: load config from env/files.
+- `Console` - `packages/effect/src/Console.ts` - Effectful console operations. Use: log and debug safely.
+- `Context` - `packages/effect/src/Context.ts` - Dependency injection context table. Use: provide and access services.
+- `Cron` - `packages/effect/src/Cron.ts` - Cron scheduling utilities. Use: express recurring schedules.
+- `Data` - `packages/effect/src/Data.ts` - Immutable data and tagged unions. Use: model domain data and errors.
+- `DateTime` - `packages/effect/src/DateTime.ts` - Date-time utilities. Use: handle timestamps and calendars.
+- `Deferred` - `packages/effect/src/Deferred.ts` - Single-assignment async variable. Use: coordinate concurrent fibers.
+- `Differ` - `packages/effect/src/Differ.ts` - Value diffing utilities. Use: compute incremental updates.
+- `Duration` - `packages/effect/src/Duration.ts` - Precise time span type. Use: represent delays and intervals.
+- `Effect` - `packages/effect/src/Effect.ts` - Core effect type and operators. Use: model async and concurrent work.
+- `Effectable` - `packages/effect/src/Effectable.ts` - Protocols for effect-like values. Use: integrate custom yieldables.
+- `Encoding` - `packages/effect/src/Encoding.ts` - Base64, Base64Url, and Hex codecs. Use: encode binary/text values.
+- `Equal` - `packages/effect/src/Equal.ts` - Structural and custom equality. Use: compare immutable values deeply.
+- `Equivalence` - `packages/effect/src/Equivalence.ts` - Equivalence relation helpers. Use: dedupe or compare with custom rules.
+- `ErrorReporter` - `packages/effect/src/ErrorReporter.ts` - Pluggable error reporting. Use: forward failures to observability tools.
+- `ExecutionPlan` - `packages/effect/src/ExecutionPlan.ts` - Execution plan utilities. Use: inspect planned work.
+- `Exit` - `packages/effect/src/Exit.ts` - Synchronous effect outcome value. Use: inspect success or failure.
+- `Fiber` - `packages/effect/src/Fiber.ts` - Lightweight concurrency primitive. Use: fork and join work.
+- `FiberHandle` - `packages/effect/src/FiberHandle.ts` - Managed fiber handle helpers. Use: control child fibers.
+- `FiberMap` - `packages/effect/src/FiberMap.ts` - Fiber map utilities. Use: track fibers by key.
+- `FiberSet` - `packages/effect/src/FiberSet.ts` - Fiber set utilities. Use: manage groups of fibers.
+- `FileSystem` - `packages/effect/src/FileSystem.ts` - Effectful file system abstraction. Use: read and write files safely.
+- `Filter` - `packages/effect/src/Filter.ts` - Filter result utilities. Use: compose filtering operations.
+- `Formatter` - `packages/effect/src/Formatter.ts` - Human-readable value formatting. Use: pretty-print data for logs.
+- `Function` - `packages/effect/src/Function.ts` - Core function helpers. Use: pipe and compose functions.
+- `Graph` - `packages/effect/src/Graph.ts` - Graph utilities. Use: model dependency graphs.
+- `Hash` - `packages/effect/src/Hash.ts` - Hashing utilities. Use: hash values for collections.
+- `HashMap` - `packages/effect/src/HashMap.ts` - Immutable hash map. Use: keyed immutable storage.
+- `HashRing` - `packages/effect/src/HashRing.ts` - Consistent hashing utilities. Use: distribute keys across nodes.
+- `HashSet` - `packages/effect/src/HashSet.ts` - Immutable hash set. Use: store unique immutable values.
+- `HKT` - `packages/effect/src/HKT.ts` - Higher-kinded type utilities. Use: define generic type classes.
+- `Inspectable` - `packages/effect/src/Inspectable.ts` - Custom inspection helpers. Use: improve debugging output.
+- `Iterable` - `packages/effect/src/Iterable.ts` - Functional iterable utilities. Use: process lazy iterables.
+- `JsonPatch` - `packages/effect/src/JsonPatch.ts` - JSON Patch operations. Use: diff and patch JSON documents.
+- `JsonPointer` - `packages/effect/src/JsonPointer.ts` - JSON Pointer token helpers. Use: escape pointer path segments.
+- `JsonSchema` - `packages/effect/src/JsonSchema.ts` - JSON Schema dialect conversion. Use: convert schemas between formats.
+- `Latch` - `packages/effect/src/Latch.ts` - Latch synchronization primitive. Use: gate concurrent progress.
+- `Layer` - `packages/effect/src/Layer.ts` - Service construction recipes. Use: build and wire dependencies.
+- `LayerMap` - `packages/effect/src/LayerMap.ts` - Layer registry helpers. Use: share and look up layers.
+- `Logger` - `packages/effect/src/Logger.ts` - Structured logging system. Use: emit runtime logs.
+- `LogLevel` - `packages/effect/src/LogLevel.ts` - Log level utilities. Use: filter logs by severity.
+- `ManagedRuntime` - `packages/effect/src/ManagedRuntime.ts` - Managed runtime helpers. Use: own runtime lifecycle.
+- `Match` - `packages/effect/src/Match.ts` - Type-safe pattern matching. Use: replace switch-heavy branching.
+- `Metric` - `packages/effect/src/Metric.ts` - Application metrics system. Use: count, gauge, and histogram events.
+- `MutableHashMap` - `packages/effect/src/MutableHashMap.ts` - Mutable hash map. Use: high-performance mutable key-value storage.
+- `MutableHashSet` - `packages/effect/src/MutableHashSet.ts` - Mutable hash set. Use: high-performance mutable uniqueness checks.
+- `MutableList` - `packages/effect/src/MutableList.ts` - Mutable linked-list-like buffer. Use: efficient append/prepend workloads.
+- `MutableRef` - `packages/effect/src/MutableRef.ts` - Mutable reference container. Use: hold local mutable state.
+- `Newtype` - `packages/effect/src/Newtype.ts` - Zero-cost wrapper types. Use: distinguish same-shaped values.
+- `NonEmptyIterable` - `packages/effect/src/NonEmptyIterable.ts` - Non-empty iterable helpers. Use: require at least one element.
+- `Number` - `packages/effect/src/Number.ts` - Number utilities and instances. Use: do typed numeric operations.
+- `Optic` - `packages/effect/src/Optic.ts` - Immutable data accessors and updaters. Use: read or update nested state.
+- `Option` - `packages/effect/src/Option.ts` - Optional value type. Use: model absence safely.
+- `Order` - `packages/effect/src/Order.ts` - Total ordering type class. Use: sort and compare values.
+- `Ordering` - `packages/effect/src/Ordering.ts` - Comparison result helpers. Use: combine sort outcomes.
+- `PartitionedSemaphore` - `packages/effect/src/PartitionedSemaphore.ts` - Partition-aware semaphore. Use: limit concurrency by key.
+- `Path` - `packages/effect/src/Path.ts` - Path utilities. Use: work with filesystem-style paths.
+- `Pipeable` - `packages/effect/src/Pipeable.ts` - Pipeable protocol helpers. Use: support fluent pipelines.
+- `PlatformError` - `packages/effect/src/PlatformError.ts` - Platform error types. Use: normalize platform-specific failures.
+- `Pool` - `packages/effect/src/Pool.ts` - Resource pool utilities. Use: reuse scarce resources.
+- `Predicate` - `packages/effect/src/Predicate.ts` - Predicate and refinement helpers. Use: filter and narrow values.
+- `PrimaryKey` - `packages/effect/src/PrimaryKey.ts` - Primary key helpers. Use: define stable string identifiers.
+- `PubSub` - `packages/effect/src/PubSub.ts` - Publish-subscribe hub. Use: broadcast messages to subscribers.
+- `Pull` - `packages/effect/src/Pull.ts` - Pull protocol helpers. Use: model pull-based streaming.
+- `Queue` - `packages/effect/src/Queue.ts` - Effect queue utilities. Use: buffer producer-consumer work.
+- `Random` - `packages/effect/src/Random.ts` - Randomness service. Use: generate testable random values.
+- `RcMap` - `packages/effect/src/RcMap.ts` - Reference-counted map. Use: share keyed resources.
+- `RcRef` - `packages/effect/src/RcRef.ts` - Reference-counted ref. Use: share scoped resources.
+- `Record` - `packages/effect/src/Record.ts` - Record utilities. Use: transform string-keyed objects.
+- `Redactable` - `packages/effect/src/Redactable.ts` - Context-aware redaction protocol. Use: mask sensitive values.
+- `Redacted` - `packages/effect/src/Redacted.ts` - Sensitive value wrapper. Use: keep secrets out of logs.
+- `Reducer` - `packages/effect/src/Reducer.ts` - Fold values into one result. Use: aggregate collections.
+- `Ref` - `packages/effect/src/Ref.ts` - Atomic mutable reference. Use: manage concurrent state.
+- `References` - `packages/effect/src/References.ts` - Runtime reference services. Use: tune runtime configuration.
+- `RegExp` - `packages/effect/src/RegExp.ts` - RegExp utilities. Use: work with regular expressions.
+- `Request` - `packages/effect/src/Request.ts` - External request description. Use: batch and cache data fetching.
+- `RequestResolver` - `packages/effect/src/RequestResolver.ts` - Request execution abstraction. Use: resolve batched requests.
+- `Resource` - `packages/effect/src/Resource.ts` - Resource utilities. Use: acquire and release shared resources.
+- `Result` - `packages/effect/src/Result.ts` - Synchronous success/failure type. Use: validate without effects.
+- `Runtime` - `packages/effect/src/Runtime.ts` - Effect runtime helpers. Use: run main programs.
+- `Schedule` - `packages/effect/src/Schedule.ts` - Retry and repetition schedules. Use: control retry timing.
+- `Scheduler` - `packages/effect/src/Scheduler.ts` - Scheduler utilities. Use: control task execution.
+- `Schema` - `packages/effect/src/Schema.ts` - Data schema, validation, and codecs. Use: decode and encode typed data.
+- `SchemaAST` - `packages/effect/src/SchemaAST.ts` - Runtime schema AST. Use: inspect or transform schemas.
+- `SchemaGetter` - `packages/effect/src/SchemaGetter.ts` - One-way schema transformations. Use: decode individual fields.
+- `SchemaIssue` - `packages/effect/src/SchemaIssue.ts` - Structured schema validation errors. Use: inspect parse failures.
+- `SchemaParser` - `packages/effect/src/SchemaParser.ts` - Schema parsing helpers. Use: build parsing workflows.
+- `SchemaRepresentation` - `packages/effect/src/SchemaRepresentation.ts` - Serializable schema IR. Use: round-trip schemas through JSON/codegen.
+- `SchemaTransformation` - `packages/effect/src/SchemaTransformation.ts` - Bidirectional schema transformations. Use: map encoded and decoded forms.
+- `SchemaUtils` - `packages/effect/src/SchemaUtils.ts` - Schema utility helpers. Use: support schema internals.
+- `Scope` - `packages/effect/src/Scope.ts` - Resource lifetime scope. Use: ensure cleanup of acquired resources.
+- `ScopedCache` - `packages/effect/src/ScopedCache.ts` - Scoped cache utilities. Use: cache scoped resources.
+- `ScopedRef` - `packages/effect/src/ScopedRef.ts` - Scoped mutable reference. Use: swap scoped resources safely.
+- `Semaphore` - `packages/effect/src/Semaphore.ts` - Concurrency semaphore. Use: limit parallel access.
+- `Sink` - `packages/effect/src/Sink.ts` - Stream consumer abstraction. Use: fold or write stream inputs.
+- `Stdio` - `packages/effect/src/Stdio.ts` - Standard I/O utilities. Use: access stdin/stdout/stderr.
+- `Stream` - `packages/effect/src/Stream.ts` - Functional stream abstraction. Use: process streaming data.
+- `String` - `packages/effect/src/String.ts` - String utilities and instances. Use: manipulate text functionally.
+- `Struct` - `packages/effect/src/Struct.ts` - Immutable object utilities. Use: transform plain objects.
+- `SubscriptionRef` - `packages/effect/src/SubscriptionRef.ts` - Subscribable reference. Use: observe state changes.
+- `Symbol` - `packages/effect/src/Symbol.ts` - Symbol utilities. Use: work with JavaScript symbols.
+- `SynchronizedRef` - `packages/effect/src/SynchronizedRef.ts` - Effect-synchronized ref. Use: update state with effects.
+- `Take` - `packages/effect/src/Take.ts` - Stream take representation. Use: carry chunk, end, or error.
+- `Terminal` - `packages/effect/src/Terminal.ts` - Terminal interaction utilities. Use: build CLI prompts/output.
+- `Tracer` - `packages/effect/src/Tracer.ts` - Tracing abstractions. Use: create spans and traces.
+- `Trie` - `packages/effect/src/Trie.ts` - Prefix tree for strings. Use: do prefix lookups.
+- `Tuple` - `packages/effect/src/Tuple.ts` - Immutable tuple utilities. Use: transform fixed-length arrays.
+- `TxChunk` - `packages/effect/src/TxChunk.ts` - Transactional chunk. Use: mutate chunk state in STM.
+- `TxDeferred` - `packages/effect/src/TxDeferred.ts` - Transactional deferred cell. Use: coordinate STM completion.
+- `TxHashMap` - `packages/effect/src/TxHashMap.ts` - Transactional hash map. Use: keyed STM state.
+- `TxHashSet` - `packages/effect/src/TxHashSet.ts` - Transactional hash set. Use: unique STM state.
+- `TxPriorityQueue` - `packages/effect/src/TxPriorityQueue.ts` - Transactional priority queue. Use: ordered STM queueing.
+- `TxPubSub` - `packages/effect/src/TxPubSub.ts` - Transactional pub-sub hub. Use: broadcast within STM.
+- `TxQueue` - `packages/effect/src/TxQueue.ts` - Transactional queue. Use: queue data within STM.
+- `TxReentrantLock` - `packages/effect/src/TxReentrantLock.ts` - Transactional reentrant RW lock. Use: coordinate STM access.
+- `TxRef` - `packages/effect/src/TxRef.ts` - Transactional reference. Use: read and write STM state.
+- `TxSemaphore` - `packages/effect/src/TxSemaphore.ts` - Transactional semaphore. Use: limit STM concurrency.
+- `TxSubscriptionRef` - `packages/effect/src/TxSubscriptionRef.ts` - Transactional subscribable ref. Use: observe committed STM changes.
+- `Types` - `packages/effect/src/Types.ts` - Type-level utility aliases. Use: shape complex TypeScript types.
+- `UndefinedOr` - `packages/effect/src/UndefinedOr.ts` - Helpers for `A | undefined`. Use: model lightweight optional values.
+- `Unify` - `packages/effect/src/Unify.ts` - Type unification helpers. Use: simplify inferred types.
+- `Utils` - `packages/effect/src/Utils.ts` - Generator and HKT internals. Use: support yieldable APIs.
+
+### `effect/testing`
+
+- `FastCheck` - `packages/effect/src/testing/FastCheck.ts` - Re-export of fast-check for property testing. Use: generate random test cases.
+- `TestClock` - `packages/effect/src/testing/TestClock.ts` - Controllable clock for tests. Use: advance time deterministically.
+- `TestConsole` - `packages/effect/src/testing/TestConsole.ts` - Test console implementation. Use: assert console output.
+- `TestSchema` - `packages/effect/src/testing/TestSchema.ts` - Schema assertion helpers. Use: verify decode/encode behavior.
+
+### `effect/unstable/ai`
+
+- `AiError` - `packages/effect/src/unstable/ai/AiError.ts` - AI-related error types. Use: handle model failures.
+- `AnthropicStructuredOutput` - `packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts` - Anthropic structured-output codec helpers. Use: parse structured model responses.
+- `Chat` - `packages/effect/src/unstable/ai/Chat.ts` - Stateful AI conversation API. Use: manage chat sessions.
+- `EmbeddingModel` - `packages/effect/src/unstable/ai/EmbeddingModel.ts` - Provider-agnostic embedding API. Use: generate text vectors.
+- `IdGenerator` - `packages/effect/src/unstable/ai/IdGenerator.ts` - Pluggable ID generation. Use: issue stable request IDs.
+- `LanguageModel` - `packages/effect/src/unstable/ai/LanguageModel.ts` - AI text generation with tools. Use: call LLMs.
+- `McpSchema` - `packages/effect/src/unstable/ai/McpSchema.ts` - MCP schema helpers. Use: type MCP messages.
+- `McpServer` - `packages/effect/src/unstable/ai/McpServer.ts` - MCP server support. Use: expose model context tools.
+- `Model` - `packages/effect/src/unstable/ai/Model.ts` - Unified AI provider interface. Use: swap AI backends.
+- `OpenAiStructuredOutput` - `packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts` - OpenAI structured-output codecs. Use: decode typed model output.
+- `Prompt` - `packages/effect/src/unstable/ai/Prompt.ts` - Prompt-building data structures. Use: compose prompts.
+- `Response` - `packages/effect/src/unstable/ai/Response.ts` - AI response data structures. Use: inspect completions.
+- `ResponseIdTracker` - `packages/effect/src/unstable/ai/ResponseIdTracker.ts` - Response ID tracking utilities. Use: correlate model replies.
+- `Telemetry` - `packages/effect/src/unstable/ai/Telemetry.ts` - OpenTelemetry integration for AI operations. Use: trace model calls.
+- `Tokenizer` - `packages/effect/src/unstable/ai/Tokenizer.ts` - Tokenization and truncation utilities. Use: enforce token budgets.
+- `Tool` - `packages/effect/src/unstable/ai/Tool.ts` - Tool definition and management. Use: expose callable tools.
+- `Toolkit` - `packages/effect/src/unstable/ai/Toolkit.ts` - Collection of tools. Use: bundle tool implementations.
+
+### `effect/unstable/cli`
+
+- `Argument` - `packages/effect/src/unstable/cli/Argument.ts` - CLI argument definitions. Use: positional arguments.
+- `CliError` - `packages/effect/src/unstable/cli/CliError.ts` - CLI error types. Use: report parse failures.
+- `CliOutput` - `packages/effect/src/unstable/cli/CliOutput.ts` - CLI rendering/output helpers. Use: format command output.
+- `Command` - `packages/effect/src/unstable/cli/Command.ts` - CLI command definitions. Use: build subcommands.
+- `Completions` - `packages/effect/src/unstable/cli/Completions.ts` - Shell completion generation. Use: generate completion scripts.
+- `Flag` - `packages/effect/src/unstable/cli/Flag.ts` - CLI flag definitions. Use: parse options.
+- `GlobalFlag` - `packages/effect/src/unstable/cli/GlobalFlag.ts` - Global CLI flags. Use: shared top-level options.
+- `HelpDoc` - `packages/effect/src/unstable/cli/HelpDoc.ts` - CLI help document model. Use: render usage text.
+- `Param` - `packages/effect/src/unstable/cli/Param.ts` - CLI parameter helpers. Use: define typed params.
+- `Primitive` - `packages/effect/src/unstable/cli/Primitive.ts` - Primitive CLI parsers. Use: parse numbers or strings.
+- `Prompt` - `packages/effect/src/unstable/cli/Prompt.ts` - Interactive CLI prompts. Use: ask users for input.
+
+### `effect/unstable/cluster`
+
+- `ClusterCron` - `packages/effect/src/unstable/cluster/ClusterCron.ts` - Cluster cron scheduling. Use: distributed recurring jobs.
+- `ClusterError` - `packages/effect/src/unstable/cluster/ClusterError.ts` - Cluster error types. Use: classify cluster failures.
+- `ClusterMetrics` - `packages/effect/src/unstable/cluster/ClusterMetrics.ts` - Cluster metrics helpers. Use: observe cluster health.
+- `ClusterSchema` - `packages/effect/src/unstable/cluster/ClusterSchema.ts` - Cluster schema types. Use: encode cluster messages.
+- `ClusterWorkflowEngine` - `packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts` - Workflow engine for clusters. Use: run distributed workflows.
+- `DeliverAt` - `packages/effect/src/unstable/cluster/DeliverAt.ts` - Deferred delivery scheduling. Use: schedule message delivery.
+- `Entity` - `packages/effect/src/unstable/cluster/Entity.ts` - Cluster entity abstraction. Use: model sharded actors.
+- `EntityAddress` - `packages/effect/src/unstable/cluster/EntityAddress.ts` - Entity addressing types. Use: route entity messages.
+- `EntityId` - `packages/effect/src/unstable/cluster/EntityId.ts` - Typed entity identifiers. Use: identify actor instances.
+- `EntityProxy` - `packages/effect/src/unstable/cluster/EntityProxy.ts` - Client proxy for entities. Use: call remote entities.
+- `EntityProxyServer` - `packages/effect/src/unstable/cluster/EntityProxyServer.ts` - Server for entity proxies. Use: serve entity calls.
+- `EntityResource` - `packages/effect/src/unstable/cluster/EntityResource.ts` - Entity-backed resource helpers. Use: manage entity state.
+- `EntityType` - `packages/effect/src/unstable/cluster/EntityType.ts` - Entity type descriptors. Use: register entity kinds.
+- `Envelope` - `packages/effect/src/unstable/cluster/Envelope.ts` - Message envelope types. Use: wrap cluster messages.
+- `HttpRunner` - `packages/effect/src/unstable/cluster/HttpRunner.ts` - HTTP-based runner. Use: transport cluster traffic over HTTP.
+- `K8sHttpClient` - `packages/effect/src/unstable/cluster/K8sHttpClient.ts` - Kubernetes HTTP client helpers. Use: discover cluster peers.
+- `MachineId` - `packages/effect/src/unstable/cluster/MachineId.ts` - Machine identifier utilities. Use: label cluster nodes.
+- `Message` - `packages/effect/src/unstable/cluster/Message.ts` - Cluster message model. Use: send typed payloads.
+- `MessageStorage` - `packages/effect/src/unstable/cluster/MessageStorage.ts` - Message persistence abstraction. Use: durable message storage.
+- `Reply` - `packages/effect/src/unstable/cluster/Reply.ts` - Reply message helpers. Use: respond to cluster requests.
+- `Runner` - `packages/effect/src/unstable/cluster/Runner.ts` - Cluster runner abstraction. Use: host cluster workloads.
+- `RunnerAddress` - `packages/effect/src/unstable/cluster/RunnerAddress.ts` - Runner addressing types. Use: locate a runner.
+- `RunnerHealth` - `packages/effect/src/unstable/cluster/RunnerHealth.ts` - Runner health reporting. Use: track node readiness.
+- `Runners` - `packages/effect/src/unstable/cluster/Runners.ts` - Runner collection utilities. Use: manage active runners.
+- `RunnerServer` - `packages/effect/src/unstable/cluster/RunnerServer.ts` - Runner server implementation. Use: expose runner endpoints.
+- `RunnerStorage` - `packages/effect/src/unstable/cluster/RunnerStorage.ts` - Runner persistence abstraction. Use: store runner metadata.
+- `ShardId` - `packages/effect/src/unstable/cluster/ShardId.ts` - Shard identifier type. Use: map keys to shards.
+- `Sharding` - `packages/effect/src/unstable/cluster/Sharding.ts` - Sharding utilities. Use: distribute entities.
+- `ShardingConfig` - `packages/effect/src/unstable/cluster/ShardingConfig.ts` - Sharding configuration. Use: tune partitioning behavior.
+- `ShardingRegistrationEvent` - `packages/effect/src/unstable/cluster/ShardingRegistrationEvent.ts` - Sharding registration events. Use: observe topology changes.
+- `SingleRunner` - `packages/effect/src/unstable/cluster/SingleRunner.ts` - Single-process runner. Use: local cluster execution.
+- `Singleton` - `packages/effect/src/unstable/cluster/Singleton.ts` - Cluster singleton abstraction. Use: one active service instance.
+- `SingletonAddress` - `packages/effect/src/unstable/cluster/SingletonAddress.ts` - Singleton addressing types. Use: route singleton calls.
+- `Snowflake` - `packages/effect/src/unstable/cluster/Snowflake.ts` - Snowflake-style ID generation. Use: unique distributed IDs.
+- `SocketRunner` - `packages/effect/src/unstable/cluster/SocketRunner.ts` - Socket-based runner. Use: cluster transport over sockets.
+- `SqlMessageStorage` - `packages/effect/src/unstable/cluster/SqlMessageStorage.ts` - SQL-backed message storage. Use: persist cluster messages.
+- `SqlRunnerStorage` - `packages/effect/src/unstable/cluster/SqlRunnerStorage.ts` - SQL-backed runner storage. Use: persist runner state.
+- `TestRunner` - `packages/effect/src/unstable/cluster/TestRunner.ts` - Test runner utilities. Use: simulate cluster execution.
+
+### `effect/unstable/devtools`
+
+- `DevTools` - `packages/effect/src/unstable/devtools/DevTools.ts` - Devtools integration. Use: inspect runtime behavior.
+- `DevToolsClient` - `packages/effect/src/unstable/devtools/DevToolsClient.ts` - Devtools client API. Use: connect to devtools server.
+- `DevToolsSchema` - `packages/effect/src/unstable/devtools/DevToolsSchema.ts` - Devtools message schemas. Use: type devtools payloads.
+- `DevToolsServer` - `packages/effect/src/unstable/devtools/DevToolsServer.ts` - Devtools server API. Use: expose inspection endpoints.
+
+### `effect/unstable/encoding`
+
+- `Msgpack` - `packages/effect/src/unstable/encoding/Msgpack.ts` - MessagePack encoding helpers. Use: compact binary serialization.
+- `Ndjson` - `packages/effect/src/unstable/encoding/Ndjson.ts` - NDJSON encoding helpers. Use: stream JSON lines.
+- `Sse` - `packages/effect/src/unstable/encoding/Sse.ts` - Server-sent event encoding helpers. Use: emit SSE streams.
+
+### `effect/unstable/eventlog`
+
+- `Event` - `packages/effect/src/unstable/eventlog/Event.ts` - Event model types. Use: represent domain events.
+- `EventGroup` - `packages/effect/src/unstable/eventlog/EventGroup.ts` - Event grouping helpers. Use: batch related events.
+- `EventJournal` - `packages/effect/src/unstable/eventlog/EventJournal.ts` - Event journal abstraction. Use: append and read events.
+- `EventLog` - `packages/effect/src/unstable/eventlog/EventLog.ts` - Event log API. Use: stream recorded events.
+- `EventLogEncryption` - `packages/effect/src/unstable/eventlog/EventLogEncryption.ts` - Event log encryption helpers. Use: protect event payloads.
+- `EventLogMessage` - `packages/effect/src/unstable/eventlog/EventLogMessage.ts` - Event log message types. Use: transport log entries.
+- `EventLogRemote` - `packages/effect/src/unstable/eventlog/EventLogRemote.ts` - Remote event log client/server helpers. Use: access remote logs.
+- `EventLogServer` - `packages/effect/src/unstable/eventlog/EventLogServer.ts` - Event log server support. Use: host event streams.
+- `EventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts` - Encrypted event log server. Use: secure event serving.
+- `EventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts` - Unencrypted event log server. Use: plain local serving.
+- `EventLogSessionAuth` - `packages/effect/src/unstable/eventlog/EventLogSessionAuth.ts` - Event log session auth helpers. Use: authorize event sessions.
+- `SqlEventJournal` - `packages/effect/src/unstable/eventlog/SqlEventJournal.ts` - SQL-backed event journal. Use: persist events in SQL.
+- `SqlEventLogServerEncrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts` - SQL-backed encrypted event server. Use: secure persisted logs.
+- `SqlEventLogServerUnencrypted` - `packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts` - SQL-backed plain event server. Use: simple persisted logs.
+
+### `effect/unstable/http`
+
+- `Cookies` - `packages/effect/src/unstable/http/Cookies.ts` - HTTP cookie helpers. Use: parse and set cookies.
+- `Etag` - `packages/effect/src/unstable/http/Etag.ts` - ETag utilities. Use: cache validation headers.
+- `FetchHttpClient` - `packages/effect/src/unstable/http/FetchHttpClient.ts` - Fetch-based HTTP client. Use: run requests in browsers.
+- `FindMyWay` - `packages/effect/src/unstable/http/FindMyWay.ts` - `find-my-way` router integration. Use: path routing.
+- `Headers` - `packages/effect/src/unstable/http/Headers.ts` - HTTP header utilities. Use: manage request headers.
+- `HttpBody` - `packages/effect/src/unstable/http/HttpBody.ts` - HTTP body representations. Use: send JSON or bytes.
+- `HttpClient` - `packages/effect/src/unstable/http/HttpClient.ts` - Effect HTTP client API. Use: perform outbound requests.
+- `HttpClientError` - `packages/effect/src/unstable/http/HttpClientError.ts` - HTTP client error types. Use: handle request failures.
+- `HttpClientRequest` - `packages/effect/src/unstable/http/HttpClientRequest.ts` - HTTP client request builders. Use: construct requests.
+- `HttpClientResponse` - `packages/effect/src/unstable/http/HttpClientResponse.ts` - HTTP client response utilities. Use: read status and body.
+- `HttpEffect` - `packages/effect/src/unstable/http/HttpEffect.ts` - HTTP-specific effect helpers. Use: compose HTTP workflows.
+- `HttpIncomingMessage` - `packages/effect/src/unstable/http/HttpIncomingMessage.ts` - Incoming message abstraction. Use: read request bodies.
+- `HttpMethod` - `packages/effect/src/unstable/http/HttpMethod.ts` - HTTP method helpers. Use: branch on verbs.
+- `HttpMiddleware` - `packages/effect/src/unstable/http/HttpMiddleware.ts` - HTTP middleware utilities. Use: add auth or logging.
+- `HttpPlatform` - `packages/effect/src/unstable/http/HttpPlatform.ts` - Platform HTTP integration. Use: supply runtime adapters.
+- `HttpRouter` - `packages/effect/src/unstable/http/HttpRouter.ts` - HTTP routing abstraction. Use: define endpoints.
+- `HttpServer` - `packages/effect/src/unstable/http/HttpServer.ts` - HTTP server API. Use: serve requests.
+- `HttpServerError` - `packages/effect/src/unstable/http/HttpServerError.ts` - HTTP server error types. Use: render server failures.
+- `HttpServerRequest` - `packages/effect/src/unstable/http/HttpServerRequest.ts` - Server request utilities. Use: inspect inbound requests.
+- `HttpServerRespondable` - `packages/effect/src/unstable/http/HttpServerRespondable.ts` - Response conversion protocol. Use: return custom response types.
+- `HttpServerResponse` - `packages/effect/src/unstable/http/HttpServerResponse.ts` - Server response builders. Use: send JSON or text.
+- `HttpStaticServer` - `packages/effect/src/unstable/http/HttpStaticServer.ts` - Static file serving helpers. Use: serve assets.
+- `HttpTraceContext` - `packages/effect/src/unstable/http/HttpTraceContext.ts` - HTTP trace-context propagation. Use: carry tracing headers.
+- `Multipart` - `packages/effect/src/unstable/http/Multipart.ts` - Multipart form-data helpers. Use: file uploads.
+- `Multipasta` - `packages/effect/src/unstable/http/Multipasta.ts` - Multipasta integration. Use: parse multipart streams.
+- `Template` - `packages/effect/src/unstable/http/Template.ts` - HTTP templating helpers. Use: generate responses from templates.
+- `Url` - `packages/effect/src/unstable/http/Url.ts` - URL utilities. Use: parse and build URLs.
+- `UrlParams` - `packages/effect/src/unstable/http/UrlParams.ts` - URL parameter helpers. Use: encode query strings.
+
+### `effect/unstable/httpapi`
+
+- `HttpApi` - `packages/effect/src/unstable/httpapi/HttpApi.ts` - Typed HTTP API description. Use: define an API contract.
+- `HttpApiBuilder` - `packages/effect/src/unstable/httpapi/HttpApiBuilder.ts` - Build servers from `HttpApi`. Use: implement typed endpoints.
+- `HttpApiClient` - `packages/effect/src/unstable/httpapi/HttpApiClient.ts` - Client generation for `HttpApi`. Use: call typed APIs.
+- `HttpApiEndpoint` - `packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts` - Endpoint descriptors. Use: define route inputs/outputs.
+- `HttpApiError` - `packages/effect/src/unstable/httpapi/HttpApiError.ts` - HTTP API error types. Use: model typed API failures.
+- `HttpApiGroup` - `packages/effect/src/unstable/httpapi/HttpApiGroup.ts` - Group API endpoints. Use: organize related routes.
+- `HttpApiMiddleware` - `packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts` - API middleware helpers. Use: add auth policies.
+- `HttpApiScalar` - `packages/effect/src/unstable/httpapi/HttpApiScalar.ts` - Scalar UI/integration helpers. Use: expose API docs tooling.
+- `HttpApiSchema` - `packages/effect/src/unstable/httpapi/HttpApiSchema.ts` - Schema annotations for HTTP metadata. Use: tag schema fields for APIs.
+- `HttpApiSecurity` - `packages/effect/src/unstable/httpapi/HttpApiSecurity.ts` - Security scheme helpers. Use: define auth requirements.
+- `HttpApiSwagger` - `packages/effect/src/unstable/httpapi/HttpApiSwagger.ts` - Swagger/OpenAPI integration. Use: serve interactive docs.
+- `HttpApiTest` - `packages/effect/src/unstable/httpapi/HttpApiTest.ts` - HttpApi test helpers. Use: test typed endpoints.
+- `OpenApi` - `packages/effect/src/unstable/httpapi/OpenApi.ts` - OpenAPI generation helpers. Use: export API specs.
+
+### `effect/unstable/observability`
+
+- `Otlp` - `packages/effect/src/unstable/observability/Otlp.ts` - OTLP integration entrypoint. Use: configure OTLP telemetry.
+- `OtlpExporter` - `packages/effect/src/unstable/observability/OtlpExporter.ts` - OTLP exporter utilities. Use: send telemetry externally.
+- `OtlpLogger` - `packages/effect/src/unstable/observability/OtlpLogger.ts` - OTLP log export support. Use: ship structured logs.
+- `OtlpMetrics` - `packages/effect/src/unstable/observability/OtlpMetrics.ts` - OTLP metrics export support. Use: export counters and histograms.
+- `OtlpResource` - `packages/effect/src/unstable/observability/OtlpResource.ts` - OTLP resource metadata helpers. Use: tag service identity.
+- `OtlpSerialization` - `packages/effect/src/unstable/observability/OtlpSerialization.ts` - OTLP serialization helpers. Use: encode telemetry payloads.
+- `OtlpTracer` - `packages/effect/src/unstable/observability/OtlpTracer.ts` - OTLP tracing export support. Use: export spans.
+- `PrometheusMetrics` - `packages/effect/src/unstable/observability/PrometheusMetrics.ts` - Prometheus metrics exporter. Use: expose scrape endpoint.
+
+### `effect/unstable/persistence`
+
+- `KeyValueStore` - `packages/effect/src/unstable/persistence/KeyValueStore.ts` - Key-value storage abstraction. Use: persist simple state.
+- `Persistable` - `packages/effect/src/unstable/persistence/Persistable.ts` - Persistable type helpers. Use: encode stored values.
+- `PersistedCache` - `packages/effect/src/unstable/persistence/PersistedCache.ts` - Durable cache. Use: cache across restarts.
+- `PersistedQueue` - `packages/effect/src/unstable/persistence/PersistedQueue.ts` - Durable queue. Use: persist work items.
+- `Persistence` - `packages/effect/src/unstable/persistence/Persistence.ts` - Persistence service APIs. Use: back durable components.
+- `RateLimiter` - `packages/effect/src/unstable/persistence/RateLimiter.ts` - Persistent rate limiter. Use: enforce cross-process limits.
+- `Redis` - `packages/effect/src/unstable/persistence/Redis.ts` - Redis-backed persistence helpers. Use: store state in Redis.
+
+### `effect/unstable/process`
+
+- `ChildProcess` - `packages/effect/src/unstable/process/ChildProcess.ts` - Child process abstractions. Use: manage spawned commands.
+- `ChildProcessSpawner` - `packages/effect/src/unstable/process/ChildProcessSpawner.ts` - Generic child-process spawning service. Use: launch subprocesses.
+
+### `effect/unstable/reactivity`
+
+- `AsyncResult` - `packages/effect/src/unstable/reactivity/AsyncResult.ts` - Reactive async result type. Use: represent loading/error/data.
+- `Atom` - `packages/effect/src/unstable/reactivity/Atom.ts` - Reactive atom state primitive. Use: local reactive state.
+- `AtomHttpApi` - `packages/effect/src/unstable/reactivity/AtomHttpApi.ts` - HttpApi integration for atoms. Use: sync state over HTTP.
+- `AtomRef` - `packages/effect/src/unstable/reactivity/AtomRef.ts` - Ref-backed atom helpers. Use: bridge refs to reactivity.
+- `AtomRegistry` - `packages/effect/src/unstable/reactivity/AtomRegistry.ts` - Atom registry utilities. Use: track application atoms.
+- `AtomRpc` - `packages/effect/src/unstable/reactivity/AtomRpc.ts` - RPC integration for atoms. Use: sync state over RPC.
+- `Hydration` - `packages/effect/src/unstable/reactivity/Hydration.ts` - Hydration helpers. Use: restore reactive state.
+- `Reactivity` - `packages/effect/src/unstable/reactivity/Reactivity.ts` - Core reactivity utilities. Use: compose reactive computations.
+
+### `effect/unstable/rpc`
+
+- `Rpc` - `packages/effect/src/unstable/rpc/Rpc.ts` - Typed RPC description. Use: define RPC contracts.
+- `RpcClient` - `packages/effect/src/unstable/rpc/RpcClient.ts` - RPC client API. Use: call remote procedures.
+- `RpcClientError` - `packages/effect/src/unstable/rpc/RpcClientError.ts` - RPC client error types. Use: handle transport failures.
+- `RpcGroup` - `packages/effect/src/unstable/rpc/RpcGroup.ts` - Group RPC endpoints. Use: organize procedures.
+- `RpcMessage` - `packages/effect/src/unstable/rpc/RpcMessage.ts` - RPC message model. Use: encode request/response payloads.
+- `RpcMiddleware` - `packages/effect/src/unstable/rpc/RpcMiddleware.ts` - RPC middleware helpers. Use: add auth or tracing.
+- `RpcSchema` - `packages/effect/src/unstable/rpc/RpcSchema.ts` - Schema helpers for RPC. Use: type RPC payloads.
+- `RpcSerialization` - `packages/effect/src/unstable/rpc/RpcSerialization.ts` - RPC serialization helpers. Use: encode wire formats.
+- `RpcServer` - `packages/effect/src/unstable/rpc/RpcServer.ts` - RPC server API. Use: expose procedures.
+- `RpcTest` - `packages/effect/src/unstable/rpc/RpcTest.ts` - RPC testing helpers. Use: test RPC handlers.
+- `RpcWorker` - `packages/effect/src/unstable/rpc/RpcWorker.ts` - Worker integration for RPC. Use: run RPC over workers.
+- `Utils` - `packages/effect/src/unstable/rpc/Utils.ts` - Shared RPC utilities. Use: support custom RPC plumbing.
+
+### `effect/unstable/schema`
+
+- `Model` - `packages/effect/src/unstable/schema/Model.ts` - Unstable schema model helpers. Use: define schema-backed models.
+- `VariantSchema` - `packages/effect/src/unstable/schema/VariantSchema.ts` - Variant/discriminated schema helpers. Use: model tagged unions.
+
+### `effect/unstable/socket`
+
+- `Socket` - `packages/effect/src/unstable/socket/Socket.ts` - Socket abstractions. Use: connect stream transports.
+- `SocketServer` - `packages/effect/src/unstable/socket/SocketServer.ts` - Socket server helpers. Use: accept socket clients.
+
+### `effect/unstable/sql`
+
+- `Migrator` - `packages/effect/src/unstable/sql/Migrator.ts` - SQL migration helpers. Use: run schema migrations.
+- `SqlClient` - `packages/effect/src/unstable/sql/SqlClient.ts` - SQL client API. Use: execute queries.
+- `SqlConnection` - `packages/effect/src/unstable/sql/SqlConnection.ts` - SQL connection abstraction. Use: manage DB sessions.
+- `SqlError` - `packages/effect/src/unstable/sql/SqlError.ts` - SQL error types. Use: classify database failures.
+- `SqlModel` - `packages/effect/src/unstable/sql/SqlModel.ts` - SQL-backed model helpers. Use: map tables to models.
+- `SqlResolver` - `packages/effect/src/unstable/sql/SqlResolver.ts` - SQL request resolution helpers. Use: batch DB-backed requests.
+- `SqlSchema` - `packages/effect/src/unstable/sql/SqlSchema.ts` - Schema helpers for SQL. Use: type query values.
+- `SqlStream` - `packages/effect/src/unstable/sql/SqlStream.ts` - Streaming SQL query helpers. Use: consume large result sets.
+- `Statement` - `packages/effect/src/unstable/sql/Statement.ts` - SQL statement builders/types. Use: prepare typed statements.
+
+### `effect/unstable/workers`
+
+- `Transferable` - `packages/effect/src/unstable/workers/Transferable.ts` - Transferable value helpers. Use: send data between workers.
+- `Worker` - `packages/effect/src/unstable/workers/Worker.ts` - Worker abstractions. Use: run isolated tasks.
+- `WorkerError` - `packages/effect/src/unstable/workers/WorkerError.ts` - Worker error types. Use: handle worker failures.
+- `WorkerRunner` - `packages/effect/src/unstable/workers/WorkerRunner.ts` - Worker runner utilities. Use: host jobs in workers.
+
+### `effect/unstable/workflow`
+
+- `Activity` - `packages/effect/src/unstable/workflow/Activity.ts` - Workflow activity helpers. Use: define durable steps.
+- `DurableClock` - `packages/effect/src/unstable/workflow/DurableClock.ts` - Durable clock API. Use: schedule workflow time.
+- `DurableDeferred` - `packages/effect/src/unstable/workflow/DurableDeferred.ts` - Durable deferred primitive. Use: await external completion.
+- `DurableQueue` - `packages/effect/src/unstable/workflow/DurableQueue.ts` - Durable queue primitive. Use: persist workflow worklists.
+- `Workflow` - `packages/effect/src/unstable/workflow/Workflow.ts` - Workflow definition API. Use: declare durable workflows.
+- `WorkflowEngine` - `packages/effect/src/unstable/workflow/WorkflowEngine.ts` - Workflow engine runtime. Use: execute workflows.
+- `WorkflowProxy` - `packages/effect/src/unstable/workflow/WorkflowProxy.ts` - Workflow client proxy. Use: call workflow instances.
+- `WorkflowProxyServer` - `packages/effect/src/unstable/workflow/WorkflowProxyServer.ts` - Workflow proxy server. Use: expose workflow endpoints.
+
+## `@effect/opentelemetry` Package
+
+Package path: `packages/opentelemetry`
+
+- `Logger` - `packages/opentelemetry/src/Logger.ts` - OpenTelemetry logging integration. Use: export structured logs.
+- `Metrics` - `packages/opentelemetry/src/Metrics.ts` - OpenTelemetry metrics integration. Use: publish application metrics.
+- `NodeSdk` - `packages/opentelemetry/src/NodeSdk.ts` - Node OpenTelemetry SDK wiring. Use: bootstrap telemetry in Node.
+- `Resource` - `packages/opentelemetry/src/Resource.ts` - OpenTelemetry resource helpers. Use: describe service metadata.
+- `Tracer` - `packages/opentelemetry/src/Tracer.ts` - OpenTelemetry tracing integration. Use: create and export spans.
+- `WebSdk` - `packages/opentelemetry/src/WebSdk.ts` - Web OpenTelemetry SDK wiring. Use: bootstrap telemetry in browsers.
+
+## `@effect/platform-browser` Package
+
+Package path: `packages/platform-browser`
+
+- `BrowserHttpClient` - `packages/platform-browser/src/BrowserHttpClient.ts` - Browser HTTP client implementation. Use: make fetch-based requests.
+- `BrowserKeyValueStore` - `packages/platform-browser/src/BrowserKeyValueStore.ts` - Browser key-value storage adapter. Use: persist small client values.
+- `BrowserPersistence` - `packages/platform-browser/src/BrowserPersistence.ts` - Browser persistence services. Use: store app state locally.
+- `BrowserRuntime` - `packages/platform-browser/src/BrowserRuntime.ts` - Browser runtime entrypoints. Use: run Effect apps in browsers.
+- `BrowserSocket` - `packages/platform-browser/src/BrowserSocket.ts` - Browser socket implementation. Use: open WebSocket-style connections.
+- `BrowserStream` - `packages/platform-browser/src/BrowserStream.ts` - Browser stream adapters. Use: bridge web streams.
+- `BrowserWorker` - `packages/platform-browser/src/BrowserWorker.ts` - Browser worker integration. Use: communicate with web workers.
+- `BrowserWorkerRunner` - `packages/platform-browser/src/BrowserWorkerRunner.ts` - Worker-side runtime helpers. Use: run Effect code inside workers.
+- `Clipboard` - `packages/platform-browser/src/Clipboard.ts` - Clipboard API wrappers. Use: read or write clipboard data.
+- `Geolocation` - `packages/platform-browser/src/Geolocation.ts` - Geolocation API wrappers. Use: access device location.
+- `IndexedDb` - `packages/platform-browser/src/IndexedDb.ts` - IndexedDB integration. Use: build browser databases.
+- `IndexedDbDatabase` - `packages/platform-browser/src/IndexedDbDatabase.ts` - IndexedDB database helpers. Use: define database handles.
+- `IndexedDbQueryBuilder` - `packages/platform-browser/src/IndexedDbQueryBuilder.ts` - IndexedDB query builder. Use: compose indexed queries.
+- `IndexedDbTable` - `packages/platform-browser/src/IndexedDbTable.ts` - IndexedDB table helpers. Use: work with object stores.
+- `IndexedDbVersion` - `packages/platform-browser/src/IndexedDbVersion.ts` - IndexedDB versioning helpers. Use: manage schema upgrades.
+- `Permissions` - `packages/platform-browser/src/Permissions.ts` - Permissions API wrappers. Use: query browser permissions.
+
+## `@effect/platform-bun` Package
+
+Package path: `packages/platform-bun`
+
+- `BunChildProcessSpawner` - `packages/platform-bun/src/BunChildProcessSpawner.ts` - Bun child-process spawner. Use: launch subprocesses.
+- `BunClusterHttp` - `packages/platform-bun/src/BunClusterHttp.ts` - Bun clustered HTTP helpers. Use: scale HTTP servers.
+- `BunClusterSocket` - `packages/platform-bun/src/BunClusterSocket.ts` - Bun clustered socket helpers. Use: scale socket servers.
+- `BunFileSystem` - `packages/platform-bun/src/BunFileSystem.ts` - Bun file system implementation. Use: do Bun-based file I/O.
+- `BunHttpClient` - `packages/platform-bun/src/BunHttpClient.ts` - Bun HTTP client implementation. Use: make outbound HTTP requests.
+- `BunHttpPlatform` - `packages/platform-bun/src/BunHttpPlatform.ts` - Bun HTTP platform services. Use: provide HTTP runtime pieces.
+- `BunHttpServer` - `packages/platform-bun/src/BunHttpServer.ts` - Bun HTTP server implementation. Use: serve HTTP endpoints.
+- `BunHttpServerRequest` - `packages/platform-bun/src/BunHttpServerRequest.ts` - Bun request adapters. Use: read incoming HTTP requests.
+- `BunMultipart` - `packages/platform-bun/src/BunMultipart.ts` - Bun multipart parsing. Use: handle form uploads.
+- `BunPath` - `packages/platform-bun/src/BunPath.ts` - Bun path service. Use: resolve filesystem paths.
+- `BunRedis` - `packages/platform-bun/src/BunRedis.ts` - Bun Redis integration. Use: talk to Redis.
+- `BunRuntime` - `packages/platform-bun/src/BunRuntime.ts` - Bun runtime entrypoints. Use: run Effect apps on Bun.
+- `BunServices` - `packages/platform-bun/src/BunServices.ts` - Bun service bundle. Use: provide common Bun services.
+- `BunSink` - `packages/platform-bun/src/BunSink.ts` - Bun sink adapters. Use: write streamed output.
+- `BunSocket` - `packages/platform-bun/src/BunSocket.ts` - Bun socket implementation. Use: manage socket connections.
+- `BunSocketServer` - `packages/platform-bun/src/BunSocketServer.ts` - Bun socket server implementation. Use: accept socket clients.
+- `BunStdio` - `packages/platform-bun/src/BunStdio.ts` - Bun stdio integration. Use: access stdin/stdout/stderr.
+- `BunStream` - `packages/platform-bun/src/BunStream.ts` - Bun stream adapters. Use: bridge Bun streams.
+- `BunTerminal` - `packages/platform-bun/src/BunTerminal.ts` - Bun terminal integration. Use: build CLI terminal interactions.
+- `BunWorker` - `packages/platform-bun/src/BunWorker.ts` - Bun worker integration. Use: communicate with workers.
+- `BunWorkerRunner` - `packages/platform-bun/src/BunWorkerRunner.ts` - Bun worker runtime helpers. Use: run Effect code in workers.
+
+## `@effect/platform-node` Package
+
+Package path: `packages/platform-node`
+
+- `Mime` - `packages/platform-node/src/Mime.ts` - MIME type helpers. Use: detect or assign content types.
+- `NodeChildProcessSpawner` - `packages/platform-node/src/NodeChildProcessSpawner.ts` - Node child-process spawner. Use: launch subprocesses.
+- `NodeClusterHttp` - `packages/platform-node/src/NodeClusterHttp.ts` - Node clustered HTTP helpers. Use: scale HTTP servers.
+- `NodeClusterSocket` - `packages/platform-node/src/NodeClusterSocket.ts` - Node clustered socket helpers. Use: scale socket servers.
+- `NodeFileSystem` - `packages/platform-node/src/NodeFileSystem.ts` - Node file system implementation. Use: do Node-based file I/O.
+- `NodeHttpClient` - `packages/platform-node/src/NodeHttpClient.ts` - Node HTTP client implementation. Use: make outbound HTTP requests.
+- `NodeHttpIncomingMessage` - `packages/platform-node/src/NodeHttpIncomingMessage.ts` - Node incoming message adapters. Use: read raw Node HTTP messages.
+- `NodeHttpPlatform` - `packages/platform-node/src/NodeHttpPlatform.ts` - Node HTTP platform services. Use: provide HTTP runtime pieces.
+- `NodeHttpServer` - `packages/platform-node/src/NodeHttpServer.ts` - Node HTTP server implementation. Use: serve HTTP endpoints.
+- `NodeHttpServerRequest` - `packages/platform-node/src/NodeHttpServerRequest.ts` - Node request adapters. Use: read incoming HTTP requests.
+- `NodeMultipart` - `packages/platform-node/src/NodeMultipart.ts` - Node multipart parsing. Use: handle form uploads.
+- `NodePath` - `packages/platform-node/src/NodePath.ts` - Node path service. Use: resolve filesystem paths.
+- `NodeRedis` - `packages/platform-node/src/NodeRedis.ts` - Node Redis integration. Use: talk to Redis.
+- `NodeRuntime` - `packages/platform-node/src/NodeRuntime.ts` - Node runtime entrypoints. Use: run Effect apps on Node.
+- `NodeServices` - `packages/platform-node/src/NodeServices.ts` - Node service bundle. Use: provide common Node services.
+- `NodeSink` - `packages/platform-node/src/NodeSink.ts` - Node sink adapters. Use: write streamed output.
+- `NodeSocket` - `packages/platform-node/src/NodeSocket.ts` - Node socket implementation. Use: manage socket connections.
+- `NodeSocketServer` - `packages/platform-node/src/NodeSocketServer.ts` - Node socket server implementation. Use: accept socket clients.
+- `NodeStdio` - `packages/platform-node/src/NodeStdio.ts` - Node stdio integration. Use: access stdin/stdout/stderr.
+- `NodeStream` - `packages/platform-node/src/NodeStream.ts` - Node stream adapters. Use: bridge Node streams.
+- `NodeTerminal` - `packages/platform-node/src/NodeTerminal.ts` - Node terminal integration. Use: build CLI terminal interactions.
+- `NodeWorker` - `packages/platform-node/src/NodeWorker.ts` - Node worker integration. Use: communicate with worker threads.
+- `NodeWorkerRunner` - `packages/platform-node/src/NodeWorkerRunner.ts` - Node worker runtime helpers. Use: run Effect code in workers.
+- `Undici` - `packages/platform-node/src/Undici.ts` - Undici integration helpers. Use: use Undici-based HTTP features.
+
+## `@effect/platform-node-shared` Package
+
+Package path: `packages/platform-node-shared`
+
+- No public `src/index.ts` barrel is present in this vendored repo, so there are no barrel exports to inventory here.
+
+## `@effect/vitest` Package
+
+Package path: `packages/vitest`
+
+- `vitest` - `packages/vitest/src/index.ts` - Re-export of `vitest` APIs. Use: use standard Vitest APIs.
+- `API` - `packages/vitest/src/index.ts` - Test API type alias. Use: type custom test helpers.
+- `Vitest` - `packages/vitest/src/index.ts` - Effect-aware Vitest namespace types. Use: type Effect-based tests.
+- `addEqualityTesters` - `packages/vitest/src/index.ts` - Installs equality testers. Use: compare Effect values in assertions.
+- `effect` - `packages/vitest/src/index.ts` - Effect-aware `it` variant. Use: write scoped Effect tests.
+- `live` - `packages/vitest/src/index.ts` - Live-service test variant. Use: run tests with live services.
+- `layer` - `packages/vitest/src/index.ts` - Share a `Layer` across tests. Use: provide services to test groups.
+- `flakyTest` - `packages/vitest/src/index.ts` - Flaky-test wrapper. Use: stabilize eventually consistent checks.
+- `prop` - `packages/vitest/src/index.ts` - Property-test helper. Use: generate property-based cases.
+- `it` - `packages/vitest/src/index.ts` - Extended Vitest `it`. Use: mix regular and Effect tests.
+- `makeMethods` - `packages/vitest/src/index.ts` - Build extended test methods. Use: wrap a custom test API.
+- `describeWrapped` - `packages/vitest/src/index.ts` - `describe` helper with Effect methods. Use: define grouped Effect test suites.

--- a/skills/effect-ts/references/guide-effect.md
+++ b/skills/effect-ts/references/guide-effect.md
@@ -1,0 +1,447 @@
+# Effect Guide
+
+This guide is based on common usage patterns in the vendored repo at `./.repos/effect`.
+
+Key source areas:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/tools/`
+- `./.repos/effect/packages/platform-*`
+- `./.repos/effect/packages/opentelemetry/`
+- `./.repos/effect/packages/vitest/`
+
+## Mental Model
+
+`Effect<A, E, R>` is the default way to represent application work.
+
+It describes a computation that:
+
+- succeeds with `A`
+- fails with `E`
+- requires services `R`
+
+The repo consistently uses `Effect` as the main abstraction for:
+
+- business workflows
+- service methods
+- platform integrations
+- resource lifecycles
+- tests
+
+## Most Common Patterns In The Repo
+
+The dominant usage pattern is:
+
+1. use `Effect.gen` for workflows and orchestration
+2. use `Effect.fn` for reusable effectful functions
+3. use precise constructors such as `succeed`, `fail`, `sync`, `try`, and `tryPromise`
+4. use `map`, `flatMap`, and `tap` for local transformations
+5. access services in implementations and `provide*` only at edges
+6. use `acquireRelease` and `scoped` for owned resources
+7. use `catchTag` and `match` for typed recovery
+8. use `run*` only at runtime boundaries
+
+## Prefer `Effect.fn` For Reusable Operations
+
+For reusable effectful operations, prefer `Effect.fn`.
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Use `Effect.fn` when:
+
+- the operation is reusable
+- the operation takes parameters
+- the operation is part of business logic or a module API
+- you want consistent tracing and stack frames
+
+Do not treat `Effect.fnUntraced` as the default. If you do not want an explicit named span, use `Effect.fn` without a span name.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+
+## Use `Effect.gen` For Workflows
+
+Use `Effect.gen` for orchestration and sequential workflows, especially when there are multiple `yield*` steps.
+
+```ts
+const program = Effect.gen(function*() {
+  const config = yield* Config
+  const repo = yield* UserRepo
+  const user = yield* repo.getById("u_123")
+  return { config, user }
+})
+```
+
+Use `Effect.gen` when:
+
+- the body is a workflow
+- you are reading multiple services
+- you have branching or multiple sequential steps
+- you are implementing a layer, handler, or orchestration
+
+Repo examples:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+
+## `Effect.fn` vs `Effect.gen`
+
+Use this rule:
+
+- reusable operation: `Effect.fn`
+- inline workflow block: `Effect.gen`
+
+Good split:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+
+const program = Effect.gen(function*() {
+  const user = yield* loadUser("u_123")
+  yield* Effect.logInfo("loaded user", user)
+})
+```
+
+## `Effect.fnUntraced` Is An Escape Hatch
+
+For application and business code, `Effect.fnUntraced` is not the default.
+
+Use it only when:
+
+- the function is an internal low-level helper
+- observability is intentionally being traded away
+- there is a concrete performance or tracing reason
+
+If the only goal is to avoid an explicit named span, prefer:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Instead of:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+## Constructor Functions
+
+The repo uses constructor functions very deliberately.
+
+### `Effect.succeed`
+
+Use for pure successful values.
+
+```ts
+const ok = Effect.succeed(42)
+```
+
+### `Effect.fail`
+
+Use for expected typed failures.
+
+```ts
+const notFound = Effect.fail(UserNotFound.make({ userId: "u_123" }))
+```
+
+### `Effect.sync`
+
+Use for synchronous side effects or pure synchronous construction that should live inside `Effect`.
+
+```ts
+const buildConfig = Effect.sync(() => ({ retries: 3 }))
+```
+
+### `Effect.try`
+
+Use for synchronous code that may throw.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
+  cause: Schema.Defect
+}) {}
+
+const parseJson = (input: string) =>
+  Effect.try({
+    try: () => JSON.parse(input),
+    catch: (cause) => ParseError.make({ cause })
+  })
+```
+
+### `Effect.tryPromise`
+
+Use for Promise-returning APIs.
+
+```ts
+import { Effect, Schema } from "effect"
+
+class FetchError extends Schema.TaggedErrorClass<FetchError>()("FetchError", {
+  cause: Schema.Defect
+}) {}
+
+const fetchText = (url: string) =>
+  Effect.tryPromise({
+    try: () => fetch(url).then((response) => response.text()),
+    catch: (cause) => FetchError.make({ cause })
+  })
+```
+
+Preferred rule:
+
+- pure value: `succeed`
+- expected failure: `fail`
+- synchronous non-throwing effect: `sync`
+- synchronous throwing boundary: `try`
+- Promise boundary: `tryPromise`
+
+## Local Composition
+
+The repo uses `map`, `flatMap`, and `tap` constantly for small local transformations.
+
+### `Effect.map`
+
+Use to transform successful values.
+
+```ts
+const userName = loadUser("u_123").pipe(
+  Effect.map((user) => user.name)
+)
+```
+
+### `Effect.flatMap`
+
+Use when the next step returns another `Effect`.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.flatMap((user) => saveAudit(user.id))
+)
+```
+
+### `Effect.tap`
+
+Use for side effects that should preserve the main value.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.tap((user) => Effect.logDebug("loaded user", { userId: user.id }))
+)
+```
+
+Preferred rule:
+
+- outer workflow: `Effect.gen`
+- local transformation: `map`, `flatMap`, `tap`
+
+## Services And Provisioning
+
+Repo style is:
+
+- access services in implementation code
+- provide them at boundaries
+
+### Access services in implementations
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  const repo = yield* UserRepo
+  return yield* repo.getById(userId)
+})
+```
+
+or:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.service(UserRepo).pipe(
+    Effect.flatMap((repo) => repo.getById(userId))
+  )
+```
+
+### Provide at the edge
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Use `provideService` and `provideServiceEffect` for targeted overrides, especially in tests or framework boundaries.
+
+Do not default to exporting thin accessor functions that just fetch a service and forward to one service method. Prefer real business operations or direct service usage within the owning workflow.
+
+Repo examples:
+
+- `./.repos/effect/packages/tools/utils/src/bin.ts`
+- `./.repos/effect/packages/tools/openapi-generator/test/`
+
+## Error Handling
+
+Common repo patterns:
+
+- `catchTag` for expected tagged errors
+- `match` for totalizing an effect into a value
+- `catchCause` for full-cause infra handling
+
+### `Effect.catchTag`
+
+Use for targeted typed recovery.
+
+```ts
+const safe = loadUser("u_123").pipe(
+  Effect.catchTag("UserNotFound", () => Effect.succeed(null))
+)
+```
+
+### `Effect.match`
+
+Use when the caller wants a value either way.
+
+```ts
+const result = loadUser("u_123").pipe(
+  Effect.match({
+    onFailure: () => null,
+    onSuccess: (user) => user
+  })
+)
+```
+
+For deeper guidance, see `./references/guide-error-handling.md`.
+
+## Resource Management
+
+One of the strongest repo patterns is explicit resource ownership.
+
+### `Effect.acquireRelease`
+
+Use for resources that must be cleaned up.
+
+```ts
+const connection = Effect.acquireRelease(
+  openConnection,
+  (conn) => closeConnection(conn)
+)
+```
+
+### `Effect.scoped`
+
+Use when a workflow consumes scoped resources and should tie cleanup to scope lifetime.
+
+```ts
+const program = Effect.scoped(
+  Effect.gen(function*() {
+    const conn = yield* connection
+    return yield* conn.query("select 1")
+  })
+)
+```
+
+Repo examples:
+
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+
+## SQL And Runtime Integrations
+
+When Effect already provides a domain module for a capability, prefer that module over direct raw runtime client usage in business code.
+
+Important example:
+
+- prefer Effect SQL modules from `effect/unstable/sql/*` over embedding a native SQL driver directly in domain services
+
+Why:
+
+- transactions, spans, and typed errors stay inside the Effect model
+- layering stays cleaner
+- migrations and query conventions stay consistent
+
+For SQL-specific guidance, see `./references/guide-sql.md`.
+
+## Observability
+
+The repo uses observability around meaningful boundaries, not every tiny helper.
+
+Common patterns:
+
+- `Effect.fn` for named operations
+- `Effect.withSpan` for nested span boundaries
+- `Effect.log*` for operational events
+- `Effect.track` for metrics
+
+For detailed guidance, see `./references/guide-observability.md`.
+
+## Runtime Boundaries
+
+The repo keeps `run*` APIs at true runtime boundaries.
+
+### `Effect.runPromise`
+
+Use when leaving Effect world into Promise-based hosts.
+
+### `Effect.runFork`
+
+Use for background fibers or long-running integration hooks.
+
+### `Effect.runSync`
+
+Use sparingly, mostly in specialized internals where synchrony is guaranteed.
+
+Preferred rule:
+
+- library/business code should return `Effect`
+- entrypoints and integration boundaries should run `Effect`
+
+If you have multiple external entrypoints, prefer `ManagedRuntime`.
+
+## Commonly Used Effect APIs In This Repo
+
+These are the most practically important `Effect` functions to know first:
+
+- `Effect.fn`
+- `Effect.gen`
+- `Effect.succeed`
+- `Effect.fail`
+- `Effect.sync`
+- `Effect.try`
+- `Effect.tryPromise`
+- `Effect.map`
+- `Effect.flatMap`
+- `Effect.tap`
+- `Effect.service`
+- `Effect.provide`
+- `Effect.provideService`
+- `Effect.catchTag`
+- `Effect.match`
+- `Effect.acquireRelease`
+- `Effect.scoped`
+- `Effect.withSpan`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.runPromise`
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/utils/src/Codegen.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiPatch.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/OpenApiGenerator.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/platform-node/`
+- `./.repos/effect/packages/vitest/src/index.ts`

--- a/skills/effect-ts/references/guide-error-handling.md
+++ b/skills/effect-ts/references/guide-error-handling.md
@@ -1,0 +1,540 @@
+# Error Handling Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Mental Model
+
+Effect distinguishes three failure modes:
+
+- failure: expected, typed errors in the `E` channel of `Effect<A, E, R>`
+- defect: unexpected unchecked failures, represented as `Cause.Die`
+- interrupt: cooperative cancellation, represented as `Cause.Interrupt`
+
+This distinction is explicit in `Cause`.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Error Definition Styles
+
+Preference order:
+
+1. use schema-based errors when possible
+2. fall back to `Data.TaggedError` only when the error payload is not meaningfully serializable or schema-shaped
+
+Schema-based errors are strictly more powerful because they give you:
+
+- typed yieldable errors
+- schema-defined fields
+- encode/decode support
+- better protocol and boundary interoperability
+- stronger documentation and tooling hooks
+
+### 1. `Schema.TaggedErrorClass` for schema-backed tagged errors
+
+Use `Schema.TaggedErrorClass` by default when the error can be described with schemas.
+
+Why:
+
+- it creates a yieldable tagged error
+- fields are defined with `Schema`
+- the error shape can participate in schema-based tooling and encode/decode flows
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()(
+  "InvalidPayload",
+  {
+    field: Schema.String,
+    reason: Schema.String
+  }
+) {}
+
+const validate = Effect.fail(
+  InvalidPayload.make({
+    field: "email",
+    reason: "missing"
+  })
+)
+```
+
+Use this when:
+
+- the error is part of a protocol or transport boundary
+- the error needs a precise schema representation
+- the error should be serializable or documented structurally
+
+This is also a good default for domain errors when their payload is schema-friendly.
+
+### 2. `Schema.ErrorClass` for schema-backed errors without `_tag` routing
+
+Use `Schema.ErrorClass` when you want schema-defined error objects but do not specifically need tag-based pattern matching.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- examples across `./.repos/effect/packages/effect/src/unstable/*`
+
+Example shape from the vendored repo:
+
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+
+### 3. `Data.TaggedError` for non-serializable or lightweight domain errors
+
+Use `Data.TaggedError` when schema-based errors are not a good fit.
+
+This is mainly the fallback for:
+
+- non-serializable payloads
+- ad hoc in-memory-only errors
+- cases where schema shape would be artificial or misleading
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+
+Example:
+
+```ts
+import { Data, Effect } from "effect"
+
+class UserNotFound extends Data.TaggedError("UserNotFound")<{
+  readonly userId: string
+}> {}
+
+const loadUser = (userId: string) =>
+  Effect.fail(new UserNotFound({ userId }))
+
+const program = Effect.gen(function*() {
+  yield* loadUser("u_123")
+})
+```
+
+## When To Prefer `Data.TaggedError` vs `Schema.TaggedErrorClass`
+
+Prefer `Schema.TaggedErrorClass` when:
+
+- the error can be expressed as a schema
+- the error payload must be described by schemas
+- the error crosses process, protocol, persistence, or serialization boundaries
+- you want the error type to participate in schema tooling
+
+Prefer `Data.TaggedError` when:
+
+- the payload is not meaningfully serializable
+- the payload cannot reasonably be modeled as a schema
+- the error is intentionally local and in-memory only
+
+## Schema-Based Error Workflows
+
+### Boundary validation should fail with `SchemaError`
+
+When validating external input, Effect's schema APIs return `SchemaError` in the error channel.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownEffect`
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = Schema.decodeUnknownEffect(UserPayload)
+```
+
+This gives you:
+
+- success: validated typed data
+- failure: `Schema.SchemaError`
+
+### Normalize `SchemaError` at the boundary
+
+For application code, it is often better to convert `SchemaError` into a domain error near the boundary.
+
+Example:
+
+```ts
+import { Data, Effect, Schema } from "effect"
+
+class InvalidRequestBody extends Data.TaggedError("InvalidRequestBody")<{
+  readonly message: string
+}> {}
+
+const UserPayload = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String
+})
+
+const decodeUser = (input: unknown) =>
+  Schema.decodeUnknownEffect(UserPayload)(input).pipe(
+    Effect.catchTag("SchemaError", (error) =>
+      Effect.fail(new InvalidRequestBody({ message: error.message }))
+    )
+  )
+```
+
+Why:
+
+- transport validation stays close to the transport layer
+- the rest of the application can work with domain-specific errors
+
+### Use schema-backed errors for protocol errors
+
+The vendored repo uses schema-backed errors in places like SQL, RPC, sockets, and HTTP APIs.
+
+Strong examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/eventlog/EventLogMessage.ts`
+
+These are good reference points when the error contract matters externally.
+
+## Wrapping Foreign Or Generic Errors
+
+When an error comes from a library, runtime API, or generic `Error`, prefer wrapping it in a typed error instead of leaking the foreign error directly through your domain or protocol boundary.
+
+This is a very common pattern in the vendored repo.
+
+Good examples:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/workers/WorkerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Redis.ts`
+
+### Preferred Pattern
+
+Wrap the foreign error in a schema-backed typed error and preserve the original error in a `cause` field.
+
+Prefer using:
+
+- `Schema.Defect` when you want to preserve a generic encoded defect
+- `Schema.DefectWithStack` when the stack should be preserved in the schema contract
+
+Example:
+
+```ts
+import { Effect, Schema } from "effect"
+
+class TodoStorageError extends Schema.TaggedErrorClass<TodoStorageError>()(
+  "TodoStorageError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect
+  }
+) {}
+
+const makeStorageError = (operation: string) => (cause: unknown) =>
+  TodoStorageError.make({
+    operation,
+    cause
+  })
+
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: makeStorageError("loadTodo")
+  })
+```
+
+When stack preservation matters in the encoded schema, prefer:
+
+```ts
+class WorkerFailure extends Schema.TaggedErrorClass<WorkerFailure>()(
+  "WorkerFailure",
+  {
+    cause: Schema.DefectWithStack
+  }
+) {}
+```
+
+### Why This Is Preferred
+
+- the application still exposes a typed error contract
+- the original foreign failure is preserved for diagnostics
+- schema-aware transports can encode and decode the failure shape
+- business code does not become coupled to a raw library error type
+
+### When To Use This Pattern
+
+Use it when:
+
+- a third-party library throws or rejects with `Error`
+- a runtime API returns generic failures
+- a lower-level subsystem failure should be surfaced through a typed domain or protocol error
+- you need to preserve the underlying failure for debugging without leaking the foreign type as the public error contract
+
+### `Schema.Defect` vs `Schema.DefectWithStack`
+
+Prefer `Schema.Defect` by default.
+
+Use `Schema.DefectWithStack` when:
+
+- stack information is part of the intended encoded error contract
+- the error is primarily infrastructural or diagnostic
+- the downstream consumer benefits from the preserved stack
+
+### Avoid This Anti-Pattern
+
+Avoid exposing raw generic errors directly as the application error contract.
+
+Bad:
+
+```ts
+const loadTodo = (id: number) =>
+  Effect.try({
+    try: () => someLibraryCall(id),
+    catch: (cause) => cause as Error
+  })
+```
+
+Why this is bad:
+
+- the error channel loses a stable typed contract
+- the code depends on unsafe assertions
+- transport and schema integration become weaker
+- callers must understand foreign error shapes instead of your own typed error model
+
+## Handling Failures
+
+### Handle specific tagged errors with `Effect.catchTag`
+
+Use `catchTag` when your error type has `_tag` and you want focused recovery.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+Example:
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTag("UserNotFound", (error) =>
+    Effect.succeed({ id: error.userId, guest: true })
+  )
+)
+```
+
+### Handle several tagged errors with `Effect.catchTags`
+
+Use `catchTags` when multiple domain errors should be handled together.
+
+```ts
+const recovered = program.pipe(
+  Effect.catchTags({
+    UserNotFound: () => Effect.succeed(null),
+    InvalidPayload: (error) => Effect.succeed({ error: error.reason })
+  })
+)
+```
+
+### Handle predicate-based subsets with `Effect.catchIf`
+
+Use `catchIf` when matching on a predicate or refinement, not just `_tag`.
+
+### Turn failure into a value with `Effect.match`
+
+Use `match` when you want to fully fold the typed error channel into a success value.
+
+```ts
+const outcome = program.pipe(
+  Effect.match({
+    onFailure: (error) => ({ ok: false as const, error }),
+    onSuccess: (value) => ({ ok: true as const, value })
+  })
+)
+```
+
+## Handling Defects
+
+Defects are not normal domain failures.
+
+They come from:
+
+- `Effect.die`
+- unchecked exceptions in effectful code
+- invariants that were broken
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Preferred rule
+
+Do not model expected business failures as defects.
+
+Use defects for:
+
+- impossible states
+- programmer errors
+- unrecoverable infrastructure corruption
+
+### Inspect defects with `sandbox`, `catchCause`, or `matchCause`
+
+Use `sandbox` to expose `Cause<E>` in the error channel.
+
+```ts
+import { Cause, Effect } from "effect"
+
+const diagnosed = program.pipe(
+  Effect.sandbox,
+  Effect.catchCause((cause) => {
+    if (Cause.hasDies(cause)) {
+      return Effect.succeed("defect")
+    }
+    return Effect.failCause(cause)
+  })
+)
+```
+
+Use `matchCause` or `matchCauseEffect` when you need to distinguish:
+
+- typed failures
+- defects
+- interrupts
+
+### Boundary-only recovery for defects
+
+If you recover from defects at all, do it only at clear boundaries.
+
+Examples:
+
+- worker or RPC boundary
+- CLI top-level runner
+- HTTP server adapter
+
+Typical pattern:
+
+- log or report defect details
+- translate to a safe external error
+- avoid continuing as if it were a normal domain failure
+
+### `Effect.orDie`
+
+Use `orDie` when an error channel should be treated as unrecoverable from this point onward.
+
+That is appropriate when:
+
+- a failure has already been validated elsewhere as impossible
+- continuing with typed recovery would only obscure a broken invariant
+
+Do not use `orDie` just to silence a type you do not want to handle.
+
+## Handling Interrupts
+
+Interrupts are cancellation, not business failure.
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+### Use `Effect.interrupt` to stop work cooperatively
+
+Interrupts signal that the fiber should stop. They should not usually be translated into a domain error.
+
+### Use `Effect.onInterrupt` for cleanup
+
+If interrupted work needs special cleanup, use `onInterrupt`.
+
+```ts
+import { Console, Effect } from "effect"
+
+const program = longRunningTask.pipe(
+  Effect.onInterrupt(() => Console.log("cleaning up after interrupt"))
+)
+```
+
+### Use `Cause` inspection when interrupts must be distinguished
+
+When handling full causes, use `Cause.isInterruptReason`, `Cause.hasInterrupts`, or filtering over `cause.reasons`.
+
+This is useful for:
+
+- deciding whether to suppress logs for normal cancellation
+- keeping retries for failure but not for cancellation
+- distinguishing timeout/cancel flows from real errors
+
+### Do not treat interrupts as ordinary failures
+
+Avoid patterns that collapse all causes into a single error value too early. Interrupts often need different operational behavior.
+
+## Recommended Patterns
+
+### Pattern: domain errors inside the app, schema errors at the edge
+
+- decode external input with `Schema.decodeUnknownEffect`
+- convert `SchemaError` into a domain or transport error near the boundary
+- keep the rest of the application on domain errors
+
+### Pattern: tagged errors for recovery
+
+- define domain failures with `Data.TaggedError`
+- recover with `catchTag` or `catchTags`
+- keep `_tag` names stable and descriptive
+
+### Pattern: schema-backed errors for protocols
+
+- use `Schema.TaggedErrorClass` or `Schema.ErrorClass` when the error contract itself matters
+- follow examples in SQL, socket, RPC, and HTTP modules
+
+### Pattern: only inspect `Cause` when you really need the full failure structure
+
+Use `catchCause`, `matchCause`, or `sandbox` when you must distinguish:
+
+- expected failures
+- defects
+- interrupts
+
+Otherwise prefer the simpler typed error operators.
+
+## Anti-Patterns
+
+- using defects for expected validation or business-rule failures
+- converting every error immediately to `unknown` or `string`
+- using `orDie` to avoid proper handling of expected errors
+- treating interrupts as ordinary business failures
+- leaking `SchemaError` deep into domain code when it should be normalized at the boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Data.ts`
+- `./.repos/effect/packages/effect/src/Cause.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpClientError.ts`
+- `./.repos/effect/packages/effect/src/unstable/http/HttpServerError.ts`
+- `./.repos/effect/packages/effect/src/unstable/socket/Socket.ts`
+- `./.repos/effect/packages/effect/src/unstable/httpapi/HttpApiError.ts`

--- a/skills/effect-ts/references/guide-layers.md
+++ b/skills/effect-ts/references/guide-layers.md
@@ -1,0 +1,1018 @@
+# Layers Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## Mental Model
+
+A service is a typed dependency.
+
+A layer is a recipe for building one or more services, possibly using other services as dependencies.
+
+Effect's model is:
+
+- define service identifiers with `Context.Service` or `Context.Service(...)`
+- require services from effects with `Effect.service` or by yielding the service key directly
+- build implementations with `Layer`
+- provide layers at the program boundary or subsystem boundary
+
+`Layer<ROut, E, RIn>` means:
+
+- `ROut`: services produced by the layer
+- `E`: possible failures while constructing the layer
+- `RIn`: dependencies required to build it
+
+Repo references:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+
+## Services
+
+## What A Service Is
+
+A service is a typed key plus its implementation shape.
+
+In Effect, services are values in `Context`, not global singletons.
+
+This gives you:
+
+- explicit dependencies
+- easy substitution in tests
+- layer-based composition
+- multiple implementations for the same interface
+
+## Preferred Service Definition Style
+
+Prefer the class syntax with `Context.Service`.
+
+This matches the vendored repo's current style.
+
+There are two good definition styles:
+
+- explicit service shape in the `Context.Service<...>` generic
+- inferred service shape from the `make` argument
+
+Example:
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserRepoError>
+}>()("UserRepo") {}
+```
+
+Why this style is preferred:
+
+- the service identifier and shape live in one place
+- it works naturally with `yield* UserRepo`
+- it matches the patterns used across `.repos/effect`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+## Service Shape Inference With `make`
+
+When the implementation shape is clearer than the interface declaration, prefer using the `make` argument so the service shape is inferred from the implementation.
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserRepoError extends Schema.TaggedErrorClass<UserRepoError>()(
+  "UserRepoError",
+  {
+    message: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo>()("UserRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("UserRepo.getById")(function*(id: string) {
+      return yield* Effect.fail(
+        UserRepoError.make({ message: `User ${id} not found` })
+      )
+    })
+  })
+}) {}
+```
+
+Why this style is useful:
+
+- the implementation and inferred API stay together
+- TypeScript derives the service shape automatically
+- it avoids repeating the same method signatures twice
+
+Prefer this style when:
+
+- the implementation is small and obvious
+- the explicit service shape would only duplicate the implementation
+
+Prefer the explicit generic shape when:
+
+- you want the contract stated before the implementation
+- the API surface should be emphasized separately from the implementation
+
+## Service Example
+
+```ts
+import { Context, Effect, Schema } from "effect"
+
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
+  "UserNotFound",
+  {
+    userId: Schema.String
+  }
+) {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }, UserNotFound>
+}>()("UserRepo") {}
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+```
+
+Key points:
+
+- `UserRepo` is both the identifier and a value you can yield from `Effect.gen`
+- the implementation shape is explicit in the service definition
+- the effect that uses it stays abstract over the implementation
+
+## When To Use `Context.Reference`
+
+Use `Context.Reference` for contextual values with defaults, not for full service APIs.
+
+Good use cases:
+
+- current configuration knobs
+- current request metadata
+- feature flags or tracing flags with defaults
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+
+Use a full service instead when:
+
+- behavior matters more than data
+- you need multiple methods
+- you want a concrete test double or alternate implementation
+
+## Accessing Services
+
+Common patterns:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+})
+```
+
+or:
+
+```ts
+const program = Effect.service(UserRepo).pipe(
+  Effect.flatMap((repo) => repo.getById("u_123"))
+)
+```
+
+Best practice:
+
+- use `yield* Service` or `Effect.service(Service)` inside business logic
+- do not manually thread service implementations through function arguments when they are real application dependencies
+
+## Service Encapsulation
+
+Prefer keeping service access inside the business operation that needs it rather than exporting thin accessor wrappers for every method.
+
+Avoid this pattern:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoService
+  return yield* todos.create(title)
+})
+```
+
+Why this is usually a bad pattern:
+
+- it leaks the service dependency into a second public API layer
+- it encourages a redundant accessor function per service method
+- it spreads dependency access patterns across the codebase
+- it weakens service encapsulation instead of improving it
+
+Prefer one of these patterns instead:
+
+1. Put the real business logic in a function that uses the service internally because it adds behavior beyond simple forwarding.
+2. Expose the service itself and call its methods from the module that owns the workflow.
+3. If you need a public operation, make it a real business operation, not a trivial alias of one service method.
+
+Good:
+
+```ts
+export const completeTodo = Effect.fn("completeTodo")(function*(id: number) {
+  const todos = yield* TodoService
+  const todo = yield* todos.getById(id)
+  if (todo.completed) {
+    return todo
+  }
+  return yield* todos.setCompleted(id, true)
+})
+```
+
+This is good because:
+
+- the exported function represents a business operation
+- the service remains an internal dependency of that operation
+- the function adds behavior rather than just forwarding one method call
+
+## Layers
+
+## What A Layer Is
+
+A layer constructs services from dependencies.
+
+Use a layer when:
+
+- service construction is effectful
+- the service depends on other services
+- the service owns resources that must be acquired and released safely
+- you want composition and reuse across modules
+
+## Preferred Layer Constructors
+
+### `Layer.succeed`
+
+Use for pure, already-constructed implementations.
+
+```ts
+const UserRepoTest = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test User" })
+})
+```
+
+Use this when:
+
+- construction is pure
+- no dependencies are needed
+- no scoped resources are involved
+
+### `Layer.effect`
+
+Use when constructing a service requires effects, other services, or scoped resource acquisition.
+
+```ts
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Fetched from ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+```
+
+Use this when:
+
+- construction is effectful
+- construction depends on other services
+- construction needs `Scope` and finalization
+- you want typed construction failure
+
+This is also the correct constructor for services that own resources with acquisition and release semantics. In this repo, `Layer.effect` replaces the old `Layer.scoped` API.
+
+Typical examples:
+
+- database pools
+- sockets
+- background worker processes
+- long-lived subscriptions
+
+### `Layer.effectDiscard`
+
+Use `Layer.effectDiscard` for scoped startup effects that do not provide a service.
+
+Good use cases:
+
+- starting background fibers in a layer
+- one-time scoped initialization side effects
+- subsystem startup hooks
+
+### `Layer.effectContext`
+
+Use when one effect constructs a full `Context` containing multiple services.
+
+This is useful for subsystem builders that provide several related services together.
+
+## Layer Composition
+
+These operators do different things. Do not treat them as interchangeable.
+
+### Composition Cheat Sheet
+
+- `Layer.mergeAll(a, b, ...)`: combine outputs of multiple layers
+- `Layer.provide(target, dependencies)`: feed dependency outputs into `target` and keep only `target` outputs
+- `Layer.provideMerge(target, dependencies)`: feed dependency outputs into `target` and keep both dependency outputs and target outputs
+- `Layer.flatMap(layer, f)`: choose the next layer based on the built service value
+
+### Example Services
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class Logger extends Context.Service<Logger, {
+  readonly log: (message: string) => Effect.Effect<void>
+}>()("Logger") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const LoggerLayer = Layer.succeed(Logger)({
+  log: (message) => Effect.sync(() => console.log(message))
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+    const logger = yield* Logger
+
+    return {
+      getById: (id) =>
+        Effect.gen(function*() {
+          yield* logger.log(`loading ${id} from ${config.apiBaseUrl}`)
+          return { id, name: "Ada" }
+        })
+    }
+  })
+)
+```
+
+### `Layer.mergeAll`
+
+Use `Layer.mergeAll` to combine outputs of independent layers.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+Use this when:
+
+- the layers provide different services
+- neither needs to transform the other directly
+
+Semantics:
+
+- inputs are combined
+- outputs are combined
+- no dependency feeding happens automatically
+
+Important:
+
+- `Layer.mergeAll(ConfigLayer, UserRepoLayer)` is wrong if `UserRepoLayer` requires `Config` and `Logger`
+- `mergeAll` does not satisfy `UserRepoLayer`'s requirements
+- it only places both layers side by side in the output graph
+
+Correct pattern:
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+```
+
+### `Layer.provide`
+
+Use `Layer.provide` to satisfy a target layer's dependencies with another layer, while keeping only the target layer's outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserRepoLayerReady = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` requires `Config` and `Logger`
+- `Dependencies` provides those dependencies
+- the resulting layer provides only `UserRepo`
+- `Config` and `Logger` are used for construction but are not kept in the final output
+
+This is the operator to use when you want to hide construction dependencies behind a narrower public layer.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+### `Layer.provideMerge`
+
+Use `provideMerge` when you want to satisfy dependencies and retain both the dependency outputs and the target outputs.
+
+```ts
+const Dependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const AppLayer = Layer.provideMerge(UserRepoLayer, Dependencies)
+```
+
+Interpretation:
+
+- `UserRepoLayer` still gets `Config` and `Logger`
+- the resulting layer provides `UserRepo`, `Config`, and `Logger`
+
+This is useful for assembling larger application layers incrementally, especially when downstream code still needs access to the dependencies.
+
+Example program:
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  const logger = yield* Logger
+
+  const user = yield* repo.getById("u_123")
+  yield* logger.log(user.name)
+  return user
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Preferred rule:
+
+- use `provide` when you want to hide dependency details
+- use `provideMerge` when you want to keep dependency services available downstream
+
+### `Layer.mergeAll` vs `Layer.provide` vs `Layer.provideMerge`
+
+Think of them like this:
+
+- `mergeAll`: put layers next to each other
+- `provide`: plug one layer into another, expose only the target
+- `provideMerge`: plug one layer into another, expose both sides
+
+### Composition Style Best Practice
+
+Layers should almost always be fully composed locally before they are assembled into the final application layer.
+
+Preferred style:
+
+- define each service layer separately
+- define local subsystem dependency bundles separately
+- fully compose each subsystem locally with `Layer.provide` or `Layer.provideMerge`
+- assemble the final application layer with `Layer.mergeAll(...)`
+- apply top-level cross-cutting provisioning in a small number of explicit trailing steps
+
+Good pattern:
+
+```ts
+const UserDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer
+)
+
+const UserLayer = Layer.provide(UserRepoLayer, UserDependencies)
+
+const BillingDependencies = Layer.mergeAll(
+  ConfigLayer,
+  LoggerLayer,
+  DatabaseLayer
+)
+
+const BillingLayer = Layer.provide(BillingServiceLayer, BillingDependencies)
+
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why this style is preferred:
+
+- subsystem wiring stays local to the subsystem
+- the final application layer reads as a high-level composition map
+- cross-cutting concerns such as telemetry stay visible at the top level
+- it avoids deeply nested inline layer expressions
+
+Avoid this style when a clearer local name would help:
+
+```ts
+const AppLayer = Layer.provide(
+  Layer.mergeAll(
+    Layer.provide(UserRepoLayer, Layer.mergeAll(ConfigLayer, LoggerLayer)),
+    Layer.provide(BillingServiceLayer, Layer.mergeAll(ConfigLayer, LoggerLayer, DatabaseLayer)),
+    HttpLayer
+  ),
+  Telemetry
+).pipe(Layer.provide(NodeSdk))
+```
+
+That style is harder to read because:
+
+- subsystem composition is hidden inside the final assembly
+- shared dependencies are harder to spot
+- it is harder to refactor or reuse subsystem layers
+
+### `Layer.flatMap`
+
+Use `flatMap` when the next layer depends on the actual constructed service value, not just its type-level requirement.
+
+Example:
+
+```ts
+const UserRepoLayerFromConfig = Layer.flatMap(ConfigLayer, (config) =>
+  Layer.succeed(UserRepo)({
+    getById: (id) => Effect.succeed({ id, name: config.apiBaseUrl })
+  })
+)
+```
+
+This is more specialized than `merge` or `provide`.
+
+Prefer simpler composition first:
+
+- `merge` for combining
+- `provide` for dependency satisfaction
+- `flatMap` only when construction logic truly depends on the built value
+
+## Providing Layers To Effects
+
+## Preferred Rule
+
+Provide layers at boundaries.
+
+Usually that means:
+
+- the application entrypoint
+- a subsystem entrypoint
+- a test boundary
+
+Avoid repeatedly providing layers deep inside business logic unless you are deliberately isolating a subsystem.
+
+### Anti-Pattern: Local `Effect.provide`
+
+`Effect.provide` should be used only once at the entry of your program in normal application code.
+
+Bad pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  }).pipe(
+    Effect.provide(UserRepoLayer)
+  )
+```
+
+Why this is an anti-pattern:
+
+- it hides dependency wiring inside business logic
+- it makes implementations harder to swap in tests
+- it prevents clean top-level composition
+- it encourages many small local runtimes instead of one coherent application graph
+- it makes shared cross-cutting services harder to reason about
+
+Preferred pattern:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    return yield* repo.getById(userId)
+  })
+
+const program = loadUser("u_123").pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+Rule of thumb:
+
+- business logic should require services
+- composition should happen in layers
+- `Effect.provide` should happen at the outermost entry boundary
+
+### Multiple Entry Points
+
+If your code integrates with a framework and has multiple entry points, prefer `ManagedRuntime` instead of repeatedly calling `Effect.provide` at many call sites.
+
+Typical examples:
+
+- HTTP handlers registered separately
+- queue consumers
+- cron jobs
+- framework lifecycle hooks
+- RPC handlers or worker callbacks
+
+Preferred pattern:
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (id: string) =>
+  runtime.runPromise(loadUser(id))
+```
+
+Why:
+
+- the layer graph is still composed once
+- services remain shared according to layer semantics
+- the framework integration gets a stable runtime boundary
+- resource lifecycle is explicit through `ManagedRuntime`
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## `Effect.provide`
+
+Use `Effect.provide` to satisfy an effect's dependencies with a layer or context.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provide(UserRepoLayerReady)
+)
+```
+
+This is the main boundary provisioning operator.
+
+## `Effect.provideService`
+
+Use `provideService` for a single ad hoc implementation.
+
+```ts
+const program = loadUser("u_123").pipe(
+  Effect.provideService(UserRepo, {
+    getById: (id) => Effect.succeed({ id, name: "Inline User" })
+  })
+)
+```
+
+Good use cases:
+
+- small tests
+- one-off overrides
+- local customization
+
+Do not use this as the default replacement for real application layers.
+
+## `Effect.provideServiceEffect`
+
+Use `provideServiceEffect` when one service instance must be built effectfully without creating a reusable layer.
+
+This is useful for targeted overrides, but if the construction is reusable or part of application wiring, prefer a named `Layer.effect`.
+
+## Best Practices
+
+## 1. Keep service interfaces small and focused
+
+Prefer cohesive services over giant "everything" services.
+
+Good:
+
+- `UserRepo`
+- `Mailer`
+- `Clock`-like configuration or time abstractions
+
+Avoid:
+
+- large service shapes that mix unrelated responsibilities
+
+## 2. Prefer layers over manual wiring
+
+If construction has dependencies or effects, represent it as a layer.
+
+Avoid manually grabbing dependencies and assembling concrete objects all over the codebase.
+
+## 2.5 Prefer Effect-native integrations over raw runtime clients
+
+When Effect already provides a module for a capability, prefer the Effect-native integration over directly embedding a raw runtime client in service code.
+
+Examples:
+
+- prefer `effect/unstable/sql` modules over directly coupling business services to native SQL driver APIs
+- prefer Effect HTTP modules over direct ad hoc request clients when the project is already using Effect HTTP abstractions
+
+Why:
+
+- resource handling, tracing, and errors stay inside the Effect model
+- integrations compose better with layers and services
+- observability and transactions are easier to keep consistent
+
+## 3. Keep business logic abstract over implementations
+
+Business functions should require services, not construct them.
+
+Good:
+
+```ts
+const sendWelcomeEmail = (userId: string) =>
+  Effect.gen(function*() {
+    const repo = yield* UserRepo
+    const user = yield* repo.getById(userId)
+    return user
+  })
+```
+
+Avoid constructing `UserRepo` inside `sendWelcomeEmail`.
+
+## 4. Use `Layer.succeed` only for pure values
+
+Do not hide effectful initialization inside supposedly pure service objects.
+
+If initialization can fail, depends on effects, or needs scoped acquisition, use `Layer.effect`.
+
+## 5. Use `Layer.effect` for owned resources
+
+If the service opens something that must later close, model that lifecycle explicitly.
+
+This is one of the main reasons layers exist.
+
+## 6. Prefer top-level composition
+
+Compose major application layers once near the boundary.
+
+Good pattern:
+
+- define `ConfigLayer`
+- define `UserRepoLayer`
+- define `Dependencies = Layer.mergeAll(...)`
+- define `AppLayer` separately with `Layer.provide(...)` or `Layer.provideMerge(...)`
+- provide `AppLayer` to the top-level program
+
+## 7. Use `Layer.fresh` only when you really need a new instance
+
+Layers are shared by default.
+
+That is usually what you want.
+
+Use `Layer.fresh` only when you intentionally need to bypass sharing and rebuild the layer.
+
+## 7.5 Understand Layer Memoization
+
+Layers are memoized by reference.
+
+That means:
+
+- reusing the same layer value preserves memoization and sharing
+- creating a new layer value creates a new memoization identity
+
+Because of this, functions that return layers should be avoided unless they are absolutely necessary.
+
+Prefer plain named layer constants over layer factory functions.
+
+Only use a function returning a layer when:
+
+- the layer genuinely depends on runtime parameters
+- the caller truly needs distinct configurations or instances
+- a constant layer value cannot express the construction cleanly
+
+Even in those cases, call the function once during construction and reuse the resulting layer value.
+
+### Function Dependencies Should Stay Unprovided
+
+If a dependency of a layer is itself represented by a function that returns a layer, do not call that function locally just to satisfy the dependency.
+
+Instead, leave that dependency unprovided and let it be supplied at the edge.
+
+Bad pattern:
+
+```ts
+const UserLayer = Layer.provide(UserRepoLayer, makeDatabaseLayer(config))
+```
+
+Why this is bad:
+
+- it creates a fresh layer reference locally
+- it breaks or weakens memoization and sharing assumptions
+- it hides an important construction dependency inside subsystem wiring
+- it makes the final application graph harder to understand
+
+Preferred pattern:
+
+```ts
+const UserLayer = UserRepoLayer
+
+const DatabaseLayer = makeDatabaseLayer(config)
+
+const AppLayer = Layer.provideMerge(UserLayer, DatabaseLayer)
+```
+
+More generally:
+
+- if a layer depends on a parameterized layer factory, keep that dependency in the required environment when possible
+- construct the concrete parameterized layer once at the outer boundary
+- provide it only at the edge where the full application graph is assembled
+
+Rule:
+
+- do not call layer-producing dependency functions deep inside subsystem composition
+- keep those dependencies unprovided until the edge
+- provide the concrete layer once in the final top-level assembly
+
+Bad pattern:
+
+```ts
+const makeDatabaseLayer = () => Layer.effect(DatabaseService)(/* ... */)
+
+const AppLayer = Layer.mergeAll(
+  makeDatabaseLayer(),
+  makeDatabaseLayer()
+)
+```
+
+Why this is bad:
+
+- each call creates a distinct layer reference
+- memoization does not apply across those distinct references
+- the underlying resource or service may be constructed more than once
+- sharing assumptions become incorrect
+
+Preferred pattern:
+
+```ts
+const DatabaseLayer = makeDatabaseLayer()
+
+const AppLayer = Layer.mergeAll(
+  DatabaseLayer,
+  OtherLayer
+)
+```
+
+Rule:
+
+- avoid layer-producing functions unless they are truly necessary
+- if a function returns a layer, call it once during construction and bind the result to a named constant
+- reuse that layer value everywhere else
+
+This is especially important for:
+
+- database layers
+- HTTP client layers
+- telemetry layers
+- queues, workers, and other resource-owning services
+
+If you intentionally need a distinct instance, make that explicit with a new layer value or `Layer.fresh`, rather than accidentally creating multiple instances by repeatedly calling a layer factory.
+
+## 8. Treat `Layer.orDie` carefully
+
+`Layer.orDie` converts layer construction failures into defects.
+
+Only use it when failure is truly unrecoverable at that boundary.
+
+Do not use it to hide legitimate configuration or infrastructure failures.
+
+## 9. Use `ManagedRuntime.make` at true runtime boundaries
+
+If you need a reusable runtime built from a layer, `ManagedRuntime.make` is the edge tool for that.
+
+Good use cases:
+
+- embedding Effect into external frameworks
+- scripts or hosts that repeatedly run Effect programs
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+
+## 10. Prefer explicit test layers
+
+For tests, prefer:
+
+- `Layer.succeed` for simple fakes
+- `Layer.mock` for partial mocks when appropriate
+
+This keeps test wiring explicit and close to production composition style.
+
+## Recommended Patterns
+
+## Pattern: service definition plus live layer
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Config extends Context.Service<Config, {
+  readonly apiBaseUrl: string
+}>()("Config") {}
+
+class UserRepo extends Context.Service<UserRepo, {
+  readonly getById: (id: string) => Effect.Effect<{ id: string; name: string }>
+}>()("UserRepo") {}
+
+const ConfigLayer = Layer.succeed(Config)({
+  apiBaseUrl: "https://api.example.com"
+})
+
+const UserRepoLayer = Layer.effect(UserRepo)(
+  Effect.gen(function*() {
+    const config = yield* Config
+
+    return {
+      getById: (id) =>
+        Effect.succeed({
+          id,
+          name: `Loaded via ${config.apiBaseUrl}`
+        })
+    }
+  })
+)
+
+const Dependencies = Layer.mergeAll(ConfigLayer)
+
+const AppLayer = Layer.provide(UserRepoLayer, Dependencies)
+```
+
+## Pattern: provide at the top level
+
+```ts
+const program = Effect.gen(function*() {
+  const repo = yield* UserRepo
+  return yield* repo.getById("u_123")
+}).pipe(
+  Effect.provide(AppLayer)
+)
+```
+
+## Pattern: single-service override in tests
+
+```ts
+const TestRepo = Layer.succeed(UserRepo)({
+  getById: (id) => Effect.succeed({ id, name: "Test" })
+})
+```
+
+## Anti-Patterns
+
+- constructing live services directly inside business logic
+- using `Layer.succeed` for values that actually require effectful initialization
+- providing the same large layer repeatedly throughout the call graph
+- collapsing unrelated responsibilities into one service
+- using `Layer.orDie` to hide normal initialization failures
+- bypassing layers entirely for resource-owning services
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Context.ts`
+- `./.repos/effect/packages/effect/src/Layer.ts`
+- `./.repos/effect/packages/effect/src/ManagedRuntime.ts`
+- `./.repos/effect/packages/effect/src/Stream.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/persistence/Persistence.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcSerialization.ts`
+- `./.repos/effect/packages/effect/src/unstable/reactivity/Reactivity.ts`

--- a/skills/effect-ts/references/guide-observability.md
+++ b/skills/effect-ts/references/guide-observability.md
@@ -1,0 +1,724 @@
+# Observability Guide
+
+This guide is based on the vendored Effect source in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+## Mental Model
+
+Observable Effect code should make business operations visible by default.
+
+That means:
+
+- business logic should show up clearly in stack traces
+- important operations should produce spans
+- logs should inherit execution context
+- metrics should be attached at meaningful boundaries
+
+The most important best practice is:
+
+- prefer `Effect.fn(...)` whenever possible for business logic
+
+Why:
+
+- it adds stack frames
+- it creates spans automatically
+- it gives you better tracing and debugging for free
+- it keeps business logic observable without extra boilerplate
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+
+## Preferred Rule
+
+Use `Effect.fn` as the default constructor for business-logic functions that return `Effect`.
+
+Prefer this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+Over this:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+The second version works, but it throws away useful observability structure that `Effect.fn` gives you automatically.
+
+## Prefer `Effect.fn` Over Raw `Effect.gen`
+
+For business-logic definitions, prefer `Effect.fn` over writing raw `Effect.gen` directly, even when the operation takes no arguments.
+
+Prefer this:
+
+```ts
+const refreshCache = Effect.fn("refreshCache")(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Over this:
+
+```ts
+const refreshCache = Effect.gen(function*() {
+  yield* Effect.logInfo("refreshing cache")
+})
+```
+
+Why:
+
+- `Effect.fn` gives the operation a clear observable identity
+- stack traces are better
+- tracing is more consistent
+- the codebase gets a uniform shape for business operations
+
+Use raw `Effect.gen` when necessary, for example:
+
+- inline effect blocks inside another `Effect.fn`
+- small one-off composition at call sites
+- top-level assembly code where you are not defining a reusable business operation
+
+Rule of thumb:
+
+- reusable business operation: `Effect.fn`
+- inline composition block: `Effect.gen`
+
+## `Effect.fn` vs `Effect.fnUntraced`
+
+### `Effect.fn`
+
+Use `Effect.fn` for almost all business logic.
+
+It is the preferred default because it adds:
+
+- stack frames
+- tracing spans
+- optional post-processing of the produced effect
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const createUser = Effect.fn("createUser")(function*(name: string) {
+  return { id: "u_123", name }
+})
+```
+
+Use this for:
+
+- domain operations
+- application services
+- handlers
+- workflows
+- orchestrations
+- repository calls
+
+### `Effect.fnUntraced`
+
+Use `Effect.fnUntraced` only for edge cases.
+
+The vendored Effect repo itself uses `fnUntraced` in a number of low-level internals and integration helpers. That does not make it the default recommendation for downstream application or business code.
+
+If you do not want an explicit named span, prefer `Effect.fn` without a span name so you still keep stack traces and the normal traced-function behavior.
+
+Prefer this:
+
+```ts
+const normalizeUser = Effect.fn(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Over this:
+
+```ts
+const normalizeUser = Effect.fnUntraced(function*(input: string) {
+  return input.trim().toLowerCase()
+})
+```
+
+Typical cases:
+
+- extremely hot low-level internal helpers
+- very small internal combinators
+- tight loops where you have measured overhead and need to reduce it
+
+Preferred rule:
+
+- `Effect.fn` by default
+- `Effect.fn` without a span name when you want to avoid an explicit named span
+- `Effect.fnUntraced` only with a concrete measured reason
+
+## Business Logic Patterns
+
+### Pattern: one named `Effect.fn` per meaningful operation
+
+Good:
+
+```ts
+const parseCommand = Effect.fn("parseCommand")(function*(input: string) {
+  return input.trim()
+})
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+
+const sendWelcomeEmail = Effect.fn("sendWelcomeEmail")(function*(userId: string) {
+  const user = yield* loadUser(userId)
+  return user.email
+})
+```
+
+Why this is good:
+
+- each operation has a clear span name
+- traces reflect business concepts
+- stack traces reflect the actual workflow
+
+### Pattern: use meaningful names
+
+Span names created through `Effect.fn` should represent business operations, not generic implementation detail.
+
+Prefer:
+
+- `loadUser`
+- `chargeInvoice`
+- `syncGithubInstallation`
+
+Avoid:
+
+- `helper`
+- `run`
+- `process`
+- `step1`
+
+## Explicit Spans
+
+### `Effect.withSpan`
+
+Use `withSpan` when you need an explicit span around an effect that is not already naturally represented by a named `Effect.fn`, or when you want a nested sub-operation span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchProfile(userId).pipe(
+    Effect.withSpan("fetchProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+Use this when:
+
+- you want a nested span inside a larger operation
+- you are instrumenting an existing effect pipeline
+- you need more detailed trace structure than `Effect.fn` alone provides
+
+### `Effect.withSpanScoped`
+
+Use `withSpanScoped` when the span should remain open for the lifetime of a scope.
+
+This is less common in business logic and more common in long-lived resource or streaming workflows.
+
+### `Effect.withParentSpan`
+
+Use `withParentSpan` when integrating with an externally created span or continuing a parent span manually.
+
+This is useful in framework or interoperability boundaries.
+
+## Span Enrichment
+
+### `Effect.annotateCurrentSpan`
+
+Use `annotateCurrentSpan` to attach important structured fields to the current span.
+
+Example:
+
+```ts
+import { Effect } from "effect"
+
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+Good span annotations:
+
+- stable identifiers
+- domain-relevant keys
+- request or resource identifiers
+- small structured values
+
+Avoid:
+
+- giant payloads
+- secrets
+- noisy transient data with little diagnostic value
+
+## Logging Patterns
+
+### Use Effect logging inside effects
+
+Prefer:
+
+- `Effect.log`
+- `Effect.logInfo`
+- `Effect.logDebug`
+- `Effect.logWarning`
+- `Effect.logError`
+
+These integrate with the current Effect execution context.
+
+Example:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  yield* Effect.logDebug("loading user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### `Effect.withLogSpan`
+
+Use `withLogSpan` when you want log messages to carry a local logical span label even when you are not creating a full tracing span.
+
+Example:
+
+```ts
+const program = Effect.logInfo("starting sync").pipe(
+  Effect.withLogSpan("user-sync")
+)
+```
+
+This is useful for:
+
+- log grouping
+- quick local context
+- correlation in plain log output
+
+### Logging Best Practices
+
+- log at business boundaries, not every tiny helper
+- prefer structured values over concatenated strings
+- keep logs high-signal
+- avoid duplicate logs at every layer of the stack
+- rely on spans plus a few well-placed logs, not log spam
+
+## Metrics Patterns
+
+### Track effects at meaningful boundaries
+
+Use metric tracking on meaningful operations such as:
+
+- requests
+- jobs
+- retries
+- external calls
+- queue handlers
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `Effect.track`
+
+Example:
+
+```ts
+import { Effect, Metric } from "effect"
+
+const requests = Metric.counter("user_load_requests").pipe(
+  Metric.withConstantInput(1)
+)
+
+const loadUser = Effect.fn("loadUser")(
+  function*(userId: string) {
+    return { id: userId, name: "Ada" }
+  },
+  Effect.track(requests)
+)
+```
+
+### Prefer boundary metrics over micro-metrics
+
+Good metrics are usually attached to:
+
+- endpoint handlers
+- queue/job handlers
+- repository operations
+- external API boundaries
+
+Avoid putting a metric on every tiny internal helper.
+
+## OpenTelemetry Integration
+
+For real application observability, compose telemetry at the layer level.
+
+The vendored repo provides `@effect/opentelemetry` layers such as:
+
+- `NodeSdk.layer`
+- `Tracer.layer`
+- `Logger.layer`
+- `Metrics.layer`
+
+Repo references:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+
+Preferred composition style:
+
+```ts
+const AppLayer = Layer.mergeAll(
+  UserLayer,
+  BillingLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(Telemetry),
+  Layer.provide(NodeSdk)
+)
+```
+
+Why:
+
+- business code stays observability-agnostic
+- observability is configured once at the boundary
+- spans, logs, and metrics remain consistent across the app
+
+## OpenTelemetry JS Framework Integration
+
+The vendored repo includes a real integration layer for the OpenTelemetry JavaScript ecosystem in `@effect/opentelemetry`.
+
+This is the preferred integration path when the application needs to participate in the standard OpenTelemetry JS framework, exporters, and SDKs.
+
+Relevant modules:
+
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`
+- `./.repos/effect/packages/opentelemetry/src/Metrics.ts`
+- `./.repos/effect/packages/opentelemetry/src/Logger.ts`
+- `./.repos/effect/packages/opentelemetry/src/Resource.ts`
+- `./.repos/effect/packages/opentelemetry/src/WebSdk.ts`
+
+### Preferred Integration Model
+
+Use `@effect/opentelemetry` layers to bridge Effect observability into OpenTelemetry JS.
+
+Do not manually wire OpenTelemetry SDK objects inside business code.
+
+Prefer:
+
+- configuring tracer, metrics, logger, and resource layers once
+- composing them into the application layer graph
+- keeping business code written against Effect tracing, logging, and metrics APIs
+
+This means:
+
+- application code should keep using `Effect.fn`, `Effect.withSpan`, `Effect.log*`, and Effect metrics
+- OpenTelemetry JS should be introduced at the infrastructure layer, not inside domain operations
+
+### `NodeSdk.layer`
+
+`NodeSdk.layer(...)` is the main Node.js integration entrypoint.
+
+From the vendored source, it accepts a configuration that can include:
+
+- span processors
+- tracer config
+- metric readers
+- temporality preference
+- log record processors
+- logger provider config
+- resource information such as service name and version
+- shutdown timeout
+
+It then builds and merges:
+
+- resource layer
+- tracer layer
+- metrics layer
+- logger layer
+
+This makes it the preferred high-level integration for Node applications.
+
+### Resource Configuration
+
+OpenTelemetry JS integration should define resource metadata explicitly.
+
+From `NodeSdk.layer`, the supported resource configuration includes:
+
+- `serviceName`
+- `serviceVersion`
+- additional attributes
+
+This is important because tracer and logger setup depend on the configured resource.
+
+Best practice:
+
+- always provide a meaningful service name
+- provide service version when available
+- use resource attributes for stable deployment or environment metadata
+
+### Tracing Integration
+
+The `Tracer` module bridges Effect spans into OpenTelemetry spans.
+
+Important integration points from the vendored source:
+
+- `Tracer.layer`
+- `Tracer.layerGlobal`
+- `Tracer.layerGlobalProvider`
+- `Tracer.currentOtelSpan`
+- `Tracer.makeExternalSpan`
+
+Use these when:
+
+- you need Effect tracing to export through OpenTelemetry JS
+- you need to continue or bridge external trace context
+- you need access to the current OpenTelemetry span object
+
+Best practice:
+
+- keep creating spans with Effect APIs in application code
+- use the OpenTelemetry tracer layer to export and bridge them
+- use `makeExternalSpan` or parent-span wiring only at integration boundaries
+
+### Metrics Integration
+
+The `Metrics` module connects Effect metrics to OpenTelemetry JS metric readers.
+
+Important details from the vendored implementation:
+
+- `Metrics.layer(...)` registers a producer against one or more metric readers
+- it supports temporality preferences:
+  - `cumulative`
+  - `delta`
+- it handles shutdown through scoped layer cleanup
+
+Best practice:
+
+- choose temporality based on the backend
+- configure metric readers in the telemetry layer
+- keep application code focused on recording Effect metrics, not exporter mechanics
+
+### Logger Integration
+
+The `Logger` module connects Effect logging to OpenTelemetry JS logs.
+
+Important details from the vendored implementation:
+
+- it maps Effect log levels to OpenTelemetry severity numbers
+- it includes fiber ID, span context, log annotations, and log span timing in emitted attributes
+- `Logger.layer({ mergeWithExisting })` can merge with or replace existing application loggers
+
+Best practice:
+
+- prefer merging with existing loggers unless there is a strong reason to replace them
+- use Effect log annotations and log spans so the OpenTelemetry logger receives structured context automatically
+
+### Shutdown And Lifecycle
+
+The vendored layers use scoped acquisition and release for tracer providers, metric readers, and logger providers.
+
+This is the correct lifecycle model.
+
+Do not manually call provider shutdown methods from arbitrary business logic.
+
+Instead:
+
+- let the OpenTelemetry layers own provider lifecycle
+- compose them into the application layer graph
+- let the runtime or outer layer scope manage shutdown
+
+### External Trace Context
+
+When integrating with frameworks or inbound protocols that already carry trace context, prefer using the OpenTelemetry integration helpers rather than hand-rolling context propagation.
+
+The vendored tracer module provides:
+
+- `makeExternalSpan`
+- `currentOtelSpan`
+
+Use these only at integration boundaries such as:
+
+- HTTP adapters
+- RPC adapters
+- worker or queue adapters
+
+Keep business operations oblivious to propagation mechanics.
+
+### Recommended Pattern
+
+Preferred architecture:
+
+1. business code uses Effect observability APIs
+2. infrastructure composes `@effect/opentelemetry` layers
+3. the final app layer provides telemetry once at the top level
+
+Example shape:
+
+```ts
+const TelemetryLayer = NodeSdk.layer(() => ({
+  resource: {
+    serviceName: "todo-service",
+    serviceVersion: "1.0.0"
+  },
+  spanProcessor: mySpanProcessor,
+  metricReader: myMetricReader,
+  logRecordProcessor: myLogProcessor
+}))
+
+const AppLayer = Layer.mergeAll(
+  DomainLayer,
+  HttpLayer
+).pipe(
+  Layer.provide(TelemetryLayer)
+)
+```
+
+This keeps:
+
+- app code portable
+- OTel JS setup centralized
+- shutdown semantics correct
+- exported spans, logs, and metrics aligned
+
+### Anti-Patterns
+
+- constructing OpenTelemetry SDK clients directly inside business services
+- mixing manual exporter setup into domain code
+- bypassing Effect logging and tracing APIs in normal business operations
+- scattering provider shutdown logic across the application
+- configuring telemetry separately in many subsystems instead of one top-level layer
+
+## Anti-Patterns
+
+### Anti-Pattern: business logic built from anonymous `Effect.gen` functions everywhere
+
+Bad:
+
+```ts
+const loadUser = (userId: string) =>
+  Effect.gen(function*() {
+    return { id: userId, name: "Ada" }
+  })
+```
+
+Why this is bad:
+
+- weaker tracing structure
+- poorer stack traces
+- less consistent naming in debugging output
+
+Preferred:
+
+```ts
+const loadUser = Effect.fn("loadUser")(function*(userId: string) {
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Anti-Pattern: using `Effect.fnUntraced` by default
+
+This throws away free observability.
+
+If you just do not want an explicit span name, use `Effect.fn` without a name instead.
+
+Only use `fnUntraced` when you have a specific low-level reason.
+
+### Anti-Pattern: logging without structure or context
+
+Bad:
+
+- giant interpolated strings
+- duplicate logs at every layer
+- logs with no business identifiers
+
+Prefer:
+
+- named operations via `Effect.fn`
+- structured logs with IDs and context
+- a few high-value logs at operation boundaries
+
+### Anti-Pattern: hand-instrumenting every helper with spans
+
+Do not create explicit spans everywhere just because you can.
+
+Preferred order:
+
+1. start with `Effect.fn`
+2. add `Effect.withSpan` only where extra detail is actually useful
+3. add metrics at meaningful boundaries
+
+## Recommended Patterns
+
+### Pattern: observable business operation
+
+```ts
+import { Effect } from "effect"
+
+const fetchUser = Effect.fn("fetchUser")(function*(userId: string) {
+  yield* Effect.annotateCurrentSpan({ userId })
+  yield* Effect.logDebug("fetching user", { userId })
+  return { id: userId, name: "Ada" }
+})
+```
+
+### Pattern: orchestration with nested spans
+
+```ts
+const syncUser = Effect.fn("syncUser")(function*(userId: string) {
+  const profile = yield* fetchRemoteProfile(userId).pipe(
+    Effect.withSpan("fetchRemoteProfile")
+  )
+
+  return yield* persistProfile(profile).pipe(
+    Effect.withSpan("persistProfile")
+  )
+})
+```
+
+### Pattern: framework boundary with runtime
+
+```ts
+const runtime = ManagedRuntime.make(AppLayer)
+
+const handleRequest = (userId: string) =>
+  runtime.runPromise(fetchUser(userId))
+```
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Tracer.ts`
+- `./.repos/effect/packages/effect/src/Logger.ts`
+- `./.repos/effect/packages/effect/src/Metric.ts`
+- `./.repos/effect/packages/opentelemetry/src/NodeSdk.ts`
+- `./.repos/effect/packages/opentelemetry/src/Tracer.ts`

--- a/skills/effect-ts/references/guide-retries.md
+++ b/skills/effect-ts/references/guide-retries.md
@@ -1,0 +1,433 @@
+# Retries Guide
+
+This guide is based on retry patterns and `ExecutionPlan` usage in the vendored Effect repo.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Effect.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+Retries in Effect are not just loops.
+
+The repo uses three increasingly powerful levels:
+
+1. simple `Effect.retry` options for bounded or condition-based retries
+2. `Schedule` for timing-aware retry policies
+3. `ExecutionPlan` for fallback across different provided resources or layers
+
+Choose the smallest model that correctly expresses the retry policy.
+
+## Preferred Rule
+
+Prefer structured retry policies over ad hoc retry loops.
+
+Use:
+
+- simple `Effect.retry({ ... })` for straightforward conditions
+- `Effect.retry(schedule)` when timing matters
+- `ExecutionPlan` when retries should escalate across different layers or resources
+
+Avoid:
+
+- hand-written loops with mutable counters
+- inline `catch` plus recursive retry logic
+- resource fallback logic encoded as nested `catch` chains when `ExecutionPlan` is a better fit
+
+## `Effect.retry`
+
+`Effect.retry` is the main retry operator.
+
+The vendored tests show several important supported forms.
+
+## Retry On Success vs Failure
+
+`Effect.retry` only retries failures.
+
+If the effect succeeds, nothing is retried.
+
+This is explicitly covered in the module tests.
+
+## Simple Retry Options
+
+### `{ times: n }`
+
+Use this for the simplest bounded retry case.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+Use this when:
+
+- timing does not matter
+- you only need a fixed retry count
+
+### `{ until: predicate }`
+
+Use `until` when retries should stop once the failure value satisfies a condition.
+
+The module tests show:
+
+- pure `until`
+- effectful `until`
+- that `until` is still evaluated at least once
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ until: (error) => error._tag === "Done" })
+)
+```
+
+### `{ while: predicate }`
+
+Use `while` when retries should continue only while the failure value satisfies a condition.
+
+The tests also show pure and effectful `while` variants.
+
+Example:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ while: (error) => error._tag === "Retryable" })
+)
+```
+
+## Retry With Schedule
+
+Use a `Schedule` whenever timing matters.
+
+```ts
+const retried = effect.pipe(
+  Effect.retry(Schedule.recurs(3))
+)
+```
+
+Or with the richer object form:
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: Schedule.recurs(3),
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+This is a very important repo pattern because it lets you combine:
+
+- retry timing
+- retry limits
+- retry predicates
+
+## Current Schedule Metadata During Retries
+
+The module tests show that retry execution updates `Schedule.CurrentMetadata`.
+
+This means retry policies and retry-aware effects can inspect:
+
+- attempt number
+- elapsed time
+- previous delay timing
+- schedule output
+
+Use this when:
+
+- logging retry behavior
+- building retry-aware diagnostics
+- implementing advanced adaptive retry behavior
+
+## When To Use Simple Options Vs Schedule
+
+Prefer simple options when:
+
+- only the retry count matters
+- retry timing does not matter
+- the retry rule is just a condition on the error
+
+Prefer a schedule when:
+
+- retry timing matters
+- backoff matters
+- jitter matters
+- the policy should evolve over time
+
+## Common Retry Schedules In The Repo
+
+The vendored repo repeatedly uses these patterns:
+
+### Fixed retry count
+
+```ts
+Schedule.recurs(3)
+```
+
+### Exponential backoff
+
+```ts
+Schedule.exponential(500, 1.5)
+```
+
+### Exponential plus steady fallback spacing
+
+```ts
+Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This appears in production modules such as RPC and workflow code.
+
+### Error-sensitive delay policy
+
+```ts
+Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+The OTLP exporter uses this shape to derive delays from actual HTTP failure details such as rate limits.
+
+## Retry Only For Specific Failures
+
+The workflow `Activity` module shows an important advanced pattern:
+
+- sandbox the effect
+- retry only when the `Cause` matches a specific retryable category
+- fail or die differently once retries are exhausted
+
+Example shape from the repo:
+
+```ts
+effect.pipe(
+  Effect.sandbox,
+  Effect.retry(policy),
+  Effect.catch((cause) => {
+    if (!Cause.hasInterrupts(cause)) {
+      return Effect.failCause(cause)
+    }
+    return Effect.die("interrupted and retries exhausted")
+  })
+)
+```
+
+Use this when:
+
+- retryability depends on the full cause, not just typed failures
+- interrupt-specific retry behavior is required
+- infrastructure policy is more nuanced than a simple tagged error rule
+
+## Retry Observability
+
+Retry logic should be observable.
+
+Good patterns:
+
+- keep retries inside named `Effect.fn` operations
+- use `Schedule.CurrentMetadata` for diagnostics when needed
+- log or annotate retry attempts at meaningful boundaries
+- prefer central retry policies over duplicating timing logic everywhere
+
+Do not spread retry behavior across many small helpers where it becomes hard to see the operational policy.
+
+## `ExecutionPlan`
+
+Use `ExecutionPlan` when retries should escalate across different provided resources or layers.
+
+This is not just about retry timing. It is about retrying the same operation under different provided environments.
+
+The core use case from `ExecutionPlan.ts` is:
+
+- try one layer some number of times
+- possibly with a schedule and conditions
+- then fall back to another layer
+- then possibly fall back again
+
+### What `ExecutionPlan` Solves
+
+`ExecutionPlan` is the right tool when:
+
+- the same effect should be retried against multiple alternative providers
+- fallback should move across tiers, regions, models, or implementations
+- retry policy includes both attempt counts and provider changes
+
+Examples:
+
+- fail over between multiple language model providers
+- try one upstream cluster, then another
+- fall back from a fast but unreliable service to a slower but more reliable one
+
+## `ExecutionPlan.make`
+
+Use `ExecutionPlan.make(...)` to define ordered retry/fallback steps.
+
+Each step can include:
+
+- `provide`
+- `attempts`
+- `while`
+- `schedule`
+
+Example shape:
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: FastLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("3 seconds")
+  },
+  {
+    provide: SafeLayer,
+    attempts: 3,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+### Step Semantics
+
+For each step:
+
+- `provide` is the context or layer to use
+- `attempts` bounds how many times that step is tried
+- `while` can stop retries for that step based on the input
+- `schedule` defines the timing policy for retries within that step
+
+If `attempts` is omitted, the step attempts once unless a schedule is involved in a way that causes further retries.
+
+## `Effect.withExecutionPlan` And `Stream.withExecutionPlan`
+
+Use:
+
+- `Effect.withExecutionPlan` for effects
+- `Stream.withExecutionPlan` for streams
+
+The vendored tests focus on `Stream.withExecutionPlan` and demonstrate:
+
+- fallback from one provider to another
+- fallback after partial stream failure
+- the ability to prevent fallback on partial streams
+
+This is a strong signal that `ExecutionPlan` is particularly useful for long-running or streaming integrations where failure can happen after partial success.
+
+## `ExecutionPlan.CurrentMetadata`
+
+`ExecutionPlan` exposes metadata with:
+
+- `attempt`
+- `stepIndex`
+
+This is useful for:
+
+- diagnostics
+- logging which fallback tier is being used
+- understanding which plan step ultimately succeeded
+
+## `captureRequirements`
+
+`ExecutionPlan.captureRequirements` converts a plan with requirements into one whose requirements are satisfied from the current context.
+
+Use this when the plan should be frozen with the current environment before being applied later.
+
+## `ExecutionPlan.merge`
+
+Use `ExecutionPlan.merge(...)` when you need to concatenate multiple plans into one ordered plan.
+
+This is useful for assembling more complex fallback policies out of smaller ones.
+
+## When To Use `ExecutionPlan` Instead Of `Schedule`
+
+Use `Schedule` when:
+
+- only timing and retry conditions change
+- the same environment/provider is used for every retry
+
+Use `ExecutionPlan` when:
+
+- the provider or layer should change across retry phases
+- retries are tied to alternative resources, not just delays
+- fallback is part of dependency provisioning strategy
+
+## Recommended Patterns
+
+### Pattern: simple bounded retry
+
+```ts
+const retried = effect.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+### Pattern: retryable-error backoff
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+
+const retried = effect.pipe(
+  Effect.retry({
+    schedule: retryPolicy,
+    while: (error) => error._tag === "Retryable"
+  })
+)
+```
+
+### Pattern: fallback across providers
+
+```ts
+const Plan = ExecutionPlan.make(
+  {
+    provide: PrimaryLayer,
+    attempts: 2,
+    schedule: Schedule.spaced("1 second")
+  },
+  {
+    provide: SecondaryLayer,
+    attempts: 3,
+    schedule: Schedule.exponential(500, 1.5)
+  },
+  {
+    provide: FinalFallbackLayer
+  }
+)
+```
+
+## Anti-Patterns
+
+- hand-writing retry recursion instead of using `Effect.retry`
+- embedding sleep and counters directly in business logic
+- using `ExecutionPlan` when a simple `Schedule` is enough
+- encoding provider fallback as a maze of nested `catch` branches
+- retrying indiscriminately without checking whether the failure is actually retryable
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/test/Effect.test.ts`
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/src/ExecutionPlan.ts`
+- `./.repos/effect/packages/effect/test/ExecutionPlan.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/Activity.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`

--- a/skills/effect-ts/references/guide-schedule.md
+++ b/skills/effect-ts/references/guide-schedule.md
@@ -1,0 +1,379 @@
+# Schedule Guide
+
+This guide is based on the vendored `Schedule` module and its usage across `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+
+## Mental Model
+
+`Schedule` is the standard Effect abstraction for:
+
+- retries
+- repeats
+- polling
+- backoff
+- cadence and timing policies
+
+A schedule describes when the next step should happen and when execution should stop.
+
+The repo uses schedules heavily for:
+
+- retry policies
+- recurring work
+- time-window alignment
+- cron-based triggering
+- bounded flaky test retries
+
+## Preferred Rule
+
+When the timing behavior of an effect matters, prefer expressing it with `Schedule` rather than ad hoc loops, counters, sleeps, or manual retry recursion.
+
+Prefer:
+
+- `Effect.retry(schedule)`
+- `Effect.repeat(schedule)`
+- `Effect.schedule(schedule)`
+- `Stream.fromSchedule(schedule)`
+
+Over:
+
+- custom retry loops with mutable counters
+- `Effect.forever` plus hand-written `Effect.sleep`
+- manual backoff code scattered across business logic
+
+## Common Repo Patterns
+
+The most common patterns in the vendored repo are:
+
+1. `Schedule.recurs(n)` for bounded retries or repeats
+2. `Schedule.spaced(...)` for simple fixed spacing
+3. `Schedule.fixed(...)` or `Schedule.windowed(...)` for interval-aligned work
+4. `Schedule.exponential(...)` for backoff
+5. `Schedule.either(...)` or sequencing combinators to combine retry policies
+6. `Schedule.while(...)` to stop based on metadata or input
+7. `Schedule.addDelay(...)` for custom backoff logic
+8. `Schedule.jittered(...)` to avoid retry stampedes
+
+## Retry Vs Repeat
+
+Use schedules with the right operator:
+
+- `Effect.retry(schedule)` for failures
+- `Effect.repeat(schedule)` for successes
+- `Effect.schedule(schedule)` when you want to delay/reschedule an effect directly
+
+Good rule of thumb:
+
+- failing workflow: `retry`
+- recurring successful workflow: `repeat`
+- one effect that should run on a cadence: `schedule`
+
+## Core Constructors
+
+### `Schedule.recurs`
+
+Use `recurs(n)` for a bounded number of additional runs.
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+This is one of the most common repo retry policies.
+
+### `Schedule.forever`
+
+Use `forever` when the schedule should never terminate on its own.
+
+```ts
+const retryForever = Schedule.forever
+```
+
+This is common in infrastructure code and long-running retry loops.
+
+### `Schedule.spaced`
+
+Use `spaced(duration)` for simple constant spacing.
+
+```ts
+const pollEverySecond = Schedule.spaced("1 second")
+```
+
+This is the most straightforward schedule for polling or retry spacing.
+
+### `Schedule.fixed`
+
+Use `fixed(duration)` when work should align to fixed interval boundaries.
+
+The tests show that this differs from simple spacing when the action itself takes time.
+
+Use it when interval alignment matters more than naïve spacing.
+
+### `Schedule.windowed`
+
+Use `windowed(duration)` when you want delays to align to the nearest window boundary.
+
+This is useful for periodic flush or batching behavior.
+
+### `Schedule.duration`
+
+Use `duration(duration)` for a one-shot delay schedule.
+
+```ts
+const onceAfterOneSecond = Schedule.duration("1 second")
+```
+
+### `Schedule.cron`
+
+Use `cron(...)` for calendar-based scheduling.
+
+The module tests cover:
+
+- minute-level cron
+- second-level cron
+- calendar matching for specific weekdays and month days
+
+Use this for:
+
+- jobs that should follow wall-clock time
+- operational schedules
+- calendar-driven execution
+
+## Backoff Patterns
+
+### `Schedule.exponential`
+
+Use `exponential(base, factor)` for retry backoff.
+
+This is a dominant repo pattern.
+
+Examples from production code:
+
+- `WorkflowEngine`
+- `RpcClient`
+- persistence and eventlog modules
+
+Typical pattern:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5)
+```
+
+Use this for:
+
+- network retries
+- external system retries
+- contention or lock retries
+
+### Combine exponential with a cap or fallback spacing
+
+The repo often combines exponential backoff with a more stable spaced fallback using `Schedule.either(...)`.
+
+Example pattern from production modules:
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced(5000))
+)
+```
+
+This keeps early retries responsive without letting delays grow without bound.
+
+### `Schedule.jittered`
+
+Use `jittered(...)` to randomize timing within safe bounds.
+
+The module tests verify jittered delays remain within a bounded percentage of the original schedule.
+
+Use it when:
+
+- many workers or clients may retry at once
+- you want to avoid synchronized retry storms
+- the system would suffer from coordinated polling spikes
+
+## Combinators
+
+### `Schedule.while`
+
+Use `while(...)` to continue only while a predicate on schedule metadata holds.
+
+The repo uses this for:
+
+- stopping after a number of attempts
+- filtering retries based on the input error or cause
+- bounding retry windows by elapsed time
+
+Example pattern:
+
+```ts
+const bounded = Schedule.spaced("1 second").pipe(
+  Schedule.while(({ attempt }) => Effect.succeed(attempt <= 5))
+)
+```
+
+### `Schedule.andThenResult`
+
+Use `andThenResult(left, right)` when one schedule should run to completion and then another should take over.
+
+The module tests show this clearly.
+
+Use this when:
+
+- you want an initial aggressive policy followed by a slower steady-state policy
+- you want phase-based retry or repeat timing
+
+### `Schedule.either`
+
+Use `either` to combine two schedules so both policies influence the resulting timing.
+
+This appears frequently in repo retry policies that combine exponential growth with a stable fallback cadence.
+
+### `Schedule.addDelay`
+
+Use `addDelay` when the delay should depend on the schedule input or output.
+
+This is a strong fit for custom retry behavior based on the actual error.
+
+The OTLP exporter uses this style to honor `retry-after` behavior and otherwise fall back to a default delay.
+
+Example shape:
+
+```ts
+const policy = Schedule.forever.pipe(
+  Schedule.addDelay((error) =>
+    Effect.succeed("1 second")
+  )
+)
+```
+
+Use this when:
+
+- the delay should depend on the error
+- upstream metadata such as rate-limit headers matters
+- you need custom backoff without leaving the Schedule model
+
+## Metadata
+
+Schedules expose rich metadata including:
+
+- input
+- attempt count
+- start time
+- current time
+- elapsed time
+- elapsed since previous run
+- output
+- duration
+
+This is one of the reasons schedules are better than ad hoc retry loops.
+
+Use metadata when:
+
+- retry behavior depends on the input error
+- stop conditions depend on elapsed time
+- you want to log or collect retry state
+
+## Collection And Inspection Helpers
+
+The module tests highlight several useful helpers:
+
+- `Schedule.collectInputs(...)`
+- `Schedule.collectOutputs(...)`
+- `Schedule.collectWhile(...)`
+- `Schedule.delays(...)`
+- `Schedule.reduce(...)`
+
+Use these when:
+
+- you need to inspect or test a schedule
+- you want to accumulate state across schedule steps
+- you are building a more specialized scheduling policy
+
+These are especially useful in tests and low-level policy construction.
+
+## Typical Policies
+
+### Simple bounded retry
+
+```ts
+const retryPolicy = Schedule.recurs(3)
+```
+
+### Spaced polling
+
+```ts
+const pollPolicy = Schedule.spaced("5 seconds")
+```
+
+### Exponential retry with a stable fallback cadence
+
+```ts
+const retryPolicy = Schedule.exponential(500, 1.5).pipe(
+  Schedule.either(Schedule.spaced("5 seconds"))
+)
+```
+
+### Retry forever with custom delay logic
+
+```ts
+const retryPolicy = Schedule.forever.pipe(
+  Schedule.addDelay((error) => Effect.succeed("1 second"))
+)
+```
+
+### Cron-driven recurring job
+
+```ts
+const nightly = Schedule.cron("0 0 * * *")
+```
+
+## Testing Schedules
+
+The repo tests schedules with `TestClock` and controlled stepping.
+
+Preferred pattern:
+
+- use `TestClock`
+- advance time explicitly
+- inspect emitted delays or outputs
+
+This keeps schedule tests deterministic.
+
+The module tests also use helpers built on `Schedule.toStepWithSleep(...)` to inspect schedule behavior precisely.
+
+## Best Practices
+
+1. Prefer `Schedule` over ad hoc retry loops.
+2. Prefer `Schedule.recurs(...)` for simple bounded retries.
+3. Prefer `Schedule.exponential(...)` for backoff.
+4. Prefer `Schedule.either(...)` or sequencing combinators to compose retry phases.
+5. Prefer `Schedule.addDelay(...)` when delay depends on the actual error.
+6. Prefer `Schedule.jittered(...)` for distributed retry behavior.
+7. Prefer metadata-driven stop conditions over mutable counters.
+8. Prefer testing schedules with `TestClock`.
+
+## Anti-Patterns
+
+- hand-writing retry loops with mutable counters and sleeps
+- putting backoff logic directly in business code instead of in a schedule
+- using `Effect.forever` with embedded `sleep` as a substitute for a schedule
+- scattering retry timing logic across many call sites
+- ignoring jitter when many clients or workers retry concurrently
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/Schedule.ts`
+- `./.repos/effect/packages/effect/test/Schedule.test.ts`
+- `./.repos/effect/packages/effect/src/unstable/workflow/WorkflowEngine.ts`
+- `./.repos/effect/packages/effect/src/unstable/rpc/RpcClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/observability/OtlpExporter.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`

--- a/skills/effect-ts/references/guide-schema.md
+++ b/skills/effect-ts/references/guide-schema.md
@@ -1,0 +1,624 @@
+# Schema Guide
+
+This guide is based on the vendored Schema module and common repo usage in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/Schema.ts`
+- `./.repos/effect/packages/effect/src/SchemaTransformation.ts`
+- `./.repos/effect/packages/effect/src/SchemaGetter.ts`
+- `./.repos/effect/packages/effect/src/SchemaIssue.ts`
+- `./.repos/effect/packages/effect/src/JsonSchema.ts`
+
+Representative repo usage:
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/`
+
+## Mental Model
+
+Schema is the standard way to:
+
+- define data shapes
+- validate unknown input
+- encode typed values back to serialized form
+- transform between encoded and decoded representations
+- attach metadata and constraints
+
+The repo uses Schema pervasively for:
+
+- protocol payloads
+- configuration
+- HTTP and RPC contracts
+- database row decoding
+- error types
+- derived tooling such as JSON Schema and arbitrary generation
+
+## Preferred Rule
+
+Prefer Schema-based types whenever data crosses a boundary or should be validated, transformed, documented, or encoded.
+
+Typical boundaries:
+
+- HTTP requests and responses
+- RPC payloads
+- database rows
+- config files
+- worker messages
+- persisted data
+- domain errors
+
+## What A Schema Actually Is
+
+A schema is not just a static shape.
+
+It is a contract between:
+
+- the decoded in-memory value you want to work with
+- the encoded representation that comes from or goes to some boundary
+
+This is the most important thing many implementations get wrong.
+
+Do not think of Schema as “a typed struct definition.”
+Think of it as:
+
+- validation
+- decoding
+- encoding
+- transformation
+- metadata
+- reuse across boundaries
+
+Because of that, schemas should not be duplicated unless there is a real semantic difference.
+
+If two schemas describe the same logical model but differ only because one boundary encodes a field differently, prefer one schema with transformations instead of two parallel schemas.
+
+## Avoid Duplicating Schemas
+
+Do not create multiple parallel schemas for the same logical entity unless they truly represent different models.
+
+Bad pattern:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const TodoSql = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.BooleanFromBit
+})
+```
+
+This is usually a sign that transformations are not being used properly.
+
+If the model is still “Todo”, do not define a second schema just because one boundary stores `completed` as a bit.
+
+Prefer deriving or transforming the representation instead.
+
+Why duplication is bad:
+
+- the same model is now maintained in multiple places
+- fields drift over time
+- boundary logic gets copied instead of centralized
+- refactors become error-prone
+
+Only duplicate schemas when there is a real semantic difference, for example:
+
+- a creation payload really is a different model from a persisted entity
+- a public API contract intentionally differs from an internal domain model
+- a projection or partial view is intentionally a different type
+
+If the difference is only encoding, use a transformation.
+
+## Prefer `Class` Variants Over `Struct` Variants When Possible
+
+When a schema represents a named domain model, reusable payload, or long-lived API shape, prefer `Schema.Class`, `Schema.TaggedClass`, or `Schema.TaggedErrorClass` over a bare `Schema.Struct`.
+
+Prefer:
+
+```ts
+import { Schema } from "effect"
+
+export class User extends Schema.Class<User>("User")({
+  id: Schema.String,
+  name: Schema.String
+}) {}
+```
+
+Over:
+
+```ts
+import { Schema } from "effect"
+
+export const User = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String
+})
+```
+
+Why `Class` variants are usually better:
+
+- the schema has a stable, named identity
+- reusable models are easier to recognize in code and traces
+- constructors and validation are packaged together
+- extension patterns are clearer
+- named schemas read better in contracts and tooling output
+
+Use `Struct` when:
+
+- the shape is local and anonymous
+- it is a small inline request or response shape
+- introducing a class would add unnecessary ceremony
+- the schema is primarily a one-off composition fragment
+
+Good rule of thumb:
+
+- reusable named model: `Class`
+- reusable tagged union member: `TaggedClass`
+- reusable error payload: `TaggedErrorClass`
+- small inline object shape: `Struct`
+
+## One Logical Model, Multiple Representations
+
+The right Schema mindset is:
+
+- one logical model
+- multiple encoded forms when needed
+- transformations connecting them
+
+For example, a `Todo` may be:
+
+- a boolean in memory
+- a bit in SQL
+- a string in some external API
+
+That does not automatically mean you need three separate top-level schemas.
+
+Prefer:
+
+- one main schema for the logical model
+- transformed field schemas or transformed object schemas for boundary-specific encoding
+- derived request/result schemas when the shape is actually different
+
+## Common Schema Building Blocks
+
+Common primitives and collections used throughout the repo:
+
+- `Schema.String`
+- `Schema.Number`
+- `Schema.Boolean`
+- `Schema.BigInt`
+- `Schema.Array(...)`
+- `Schema.Record(key, value)`
+- `Schema.Tuple([...])`
+- `Schema.Struct({...})`
+- `Schema.Union([...])`
+
+Example:
+
+```ts
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+```
+
+## `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+### `Schema.Class`
+
+Use for named reusable schema-backed models.
+
+```ts
+class Product extends Schema.Class<Product>("Product")({
+  id: Schema.String,
+  price: Schema.Number
+}) {}
+```
+
+### Constructor Rule
+
+When constructing schema classes, prefer `X.make(...)` over `new X(...)`.
+
+Prefer:
+
+```ts
+const todo = Todo.make({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Over:
+
+```ts
+const todo = new Todo({
+  id: 1,
+  title: "write docs",
+  completed: false
+})
+```
+
+Why:
+
+- it is the intended schema-class construction style
+- it makes schema-backed construction explicit
+- it keeps the codebase consistent
+- it reads better across `Class`, `TaggedClass`, and `TaggedErrorClass`
+
+Use this rule consistently for:
+
+- `Schema.Class`
+- `Schema.TaggedClass`
+- `Schema.TaggedErrorClass`
+
+### `Schema.TaggedClass`
+
+Use for members of tagged unions.
+
+```ts
+class Circle extends Schema.TaggedClass<Circle>()("Circle", {
+  radius: Schema.Number
+}) {}
+
+class Rectangle extends Schema.TaggedClass<Rectangle>()("Rectangle", {
+  width: Schema.Number,
+  height: Schema.Number
+}) {}
+```
+
+### `Schema.TaggedErrorClass`
+
+Use for schema-backed typed errors.
+
+```ts
+class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  id: Schema.String
+}) {}
+```
+
+## Optional Fields
+
+Be precise about optionality.
+
+Important rule from the vendored docs:
+
+- `Schema.optional(schema)` means `T | undefined`
+- `Schema.optionalKey(schema)` means an exact optional property in a struct
+
+Prefer `optionalKey` for object fields.
+
+Prefer:
+
+```ts
+const Query = Schema.Struct({
+  search: Schema.optionalKey(Schema.String)
+})
+```
+
+Use `optional` when the value itself should be `A | undefined`, not just an omitted field.
+
+## Unions
+
+Use `Schema.Union([...])` for ordinary unions.
+
+```ts
+const Id = Schema.Union([
+  Schema.String,
+  Schema.Number
+])
+```
+
+Prefer tagged unions for domain variants.
+
+```ts
+class Created extends Schema.TaggedClass<Created>()("Created", {
+  id: Schema.String
+}) {}
+
+class Deleted extends Schema.TaggedClass<Deleted>()("Deleted", {
+  id: Schema.String
+}) {}
+
+const TodoEvent = Schema.Union([Created, Deleted])
+```
+
+Why:
+
+- decoding and branching are clearer
+- `_tag`-based matching aligns with Effect code style
+
+## Recursive Schemas
+
+Use `Schema.suspend` for recursive schemas.
+
+```ts
+type Tree = {
+  readonly name: string
+  readonly children: ReadonlyArray<Tree>
+}
+
+const Tree: Schema.Schema<Tree> = Schema.Struct({
+  name: Schema.String,
+  children: Schema.Array(Schema.suspend((): Schema.Schema<Tree> => Tree))
+})
+```
+
+Use it whenever a schema refers to itself, directly or indirectly.
+
+Without `suspend`, recursive definitions will not work correctly.
+
+## Transformations
+
+Transformations are one of the most important Schema features.
+
+Use them when decoded and encoded shapes differ.
+
+This is the main tool that avoids needless schema duplication.
+
+If your instinct is “I need another schema because this boundary encodes the same value differently”, stop and first ask whether this should be one schema with a transformation instead.
+
+### `Schema.decodeTo`
+
+Use `decodeTo` when you want one schema to decode into another schema's type.
+
+```ts
+const TrimmedString = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: (value) => value.trim(),
+    encode: (value) => value
+  })
+)
+```
+
+The vendored docs explicitly note that `decodeTo` is curried and should be used with `pipe`.
+
+### `Schema.encodeTo`
+
+Use `encodeTo` when the reverse direction reads more clearly.
+
+### `SchemaTransformation.transformOrFail`
+
+Use `transformOrFail` when the transformation itself is effectful or may fail.
+
+```ts
+import * as Effect from "effect/Effect"
+import * as SchemaTransformation from "effect/SchemaTransformation"
+
+const VerifiedString = Schema.String.pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transformOrFail({
+      decode: (value) => Effect.succeed(value.trim()),
+      encode: (value) => Effect.succeed(value)
+    })
+  )
+)
+```
+
+Use this when:
+
+- validation depends on services or effects
+- decoding can fail with structured issues
+- encoding also needs logic beyond identity
+
+## Field-Level Transformations
+
+Very often, the right answer is not a second object schema but a transformed field schema.
+
+Example shape:
+
+```ts
+const Completed = Schema.BooleanFromBit
+
+const Todo = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Completed
+})
+```
+
+In this pattern:
+
+- the logical model still has `completed: boolean`
+- the encoded SQL-facing representation can still be a bit
+- the transformation lives at the field where it belongs
+
+This is usually better than defining `Todo` and `TodoSql` as separate object schemas.
+
+## Object-Level Transformations
+
+Use object-level transformations when the whole object encoding differs, not just one field.
+
+Good use cases:
+
+- external keys differ from internal keys
+- several fields need coordinated transformation
+- the encoded shape is a structurally different representation of the same model
+
+Still prefer a single logical schema plus a transformation pipeline over maintaining multiple duplicated top-level schemas.
+
+## Rename Keys
+
+Schema supports key renaming through struct transformations.
+
+The vendored `Schema.ts` implements key renaming by mapping fields and using decode/encode transformations with renamed key maps.
+
+Use key renaming when:
+
+- external payload keys differ from internal keys
+- you want stable internal names while honoring external contract names
+
+Preferred pattern:
+
+- keep the internal decoded shape idiomatic
+- use schema-level transformation or field-mapping to adapt external keys
+
+This is another example of avoiding duplication. If the only difference is key naming, do not define a second schema just to rename fields manually later.
+
+In practice, use struct field mapping helpers and transformation composition rather than manual post-parse object rewriting.
+
+## Opaque And Branded Types
+
+Use opaque or branded schemas when a value should stay distinct from its structural base type.
+
+### `Schema.brand`
+
+Use `brand` for refined nominal distinctions.
+
+```ts
+const UserId = Schema.String.pipe(
+  Schema.brand("UserId")
+)
+```
+
+This is useful for:
+
+- IDs
+- validated domain scalars
+- preventing accidental interchange of same-shaped values
+
+### `Schema.Opaque`
+
+Use `Opaque` when you want an opaque schema-backed type with the same structure as its underlying schema.
+
+This is especially useful when the type should remain distinct at the type level without changing its runtime shape.
+
+## Picking, Omitting, Partial Shapes, And Mutability
+
+Common struct operations include:
+
+- `pick`
+- `omit`
+- `partial`
+- `mutable`
+
+Use them to derive variations instead of redefining near-identical schemas manually.
+
+Good examples:
+
+- request subset from a domain model
+- patch/update payloads
+- mutable representations for specific adapters
+
+Prefer deriving from one source schema rather than maintaining parallel copies.
+
+This is the second major tool for avoiding duplication:
+
+- use transformations when encoded and decoded representations differ
+- use derivation when one schema is a subset, superset, or variation of another
+
+## Constraints And Validation
+
+Use schema checks and filters for validation.
+
+Examples from the module docs include:
+
+- `isMinLength`
+- `isGreaterThan`
+- `isPattern`
+- `isUUID`
+
+Attach them with `.check(...)`.
+
+Use this when:
+
+- the validation is intrinsic to the schema
+- the rule belongs to the data contract
+
+For business-rule validation that depends on services or current state, prefer effectful logic outside the schema or use effectful transformations.
+
+## Decoding And Encoding
+
+Common operations:
+
+- `Schema.decodeUnknownSync`
+- `Schema.decodeUnknownEffect`
+- `Schema.decodeUnknownExit`
+- `Schema.encodeUnknownSync`
+- `Schema.encodeUnknownEffect`
+
+Preferred rule:
+
+- use `decodeUnknownEffect` and `encodeUnknownEffect` in Effect code
+- avoid throwing sync decode APIs in application flows unless you are intentionally at a sync boundary
+
+Good pattern:
+
+```ts
+const decodeUser = Schema.decodeUnknownEffect(User)
+```
+
+## Schema Metadata And Derived Tooling
+
+Schema is also used for:
+
+- annotations and documentation metadata
+- JSON Schema generation
+- arbitrary generation for tests
+- derived equivalence
+
+Useful operations from the module docs:
+
+- `.annotate(...)`
+- `Schema.toJsonSchemaDocument(...)`
+- `Schema.toArbitrary(...)`
+- `Schema.toEquivalence(...)`
+
+Use annotations when the schema participates in:
+
+- API docs
+- codegen
+- contract generation
+
+## Common Repo Patterns
+
+Patterns visible in the vendored repo:
+
+- `Schema.Class` for named reusable contract types
+- `Schema.Struct` for inline shapes and anonymous fragments
+- `Schema.Union` for alternative payloads
+- `Schema.optionalKey` for request/query/body optional fields
+- `Schema.suspend` for recursive generated schemas
+- `Schema.decodeTo` and `transformOrFail` for non-trivial decode/encode logic
+- `Schema.TaggedErrorClass` for typed error payloads
+
+## Best Practices
+
+1. Prefer `Class` variants over plain `Struct` for named reusable schemas.
+2. Prefer tagged variants for unions and errors.
+3. Prefer `optionalKey` for optional object properties.
+4. Do not duplicate schemas unless there is a real semantic difference.
+5. Prefer schema-level transformations over ad hoc post-parse object rewriting.
+6. Prefer deriving schema variants with `pick`, `omit`, `partial`, and `mutable` instead of duplicating definitions.
+7. Prefer field-level transformations when only a field encoding differs.
+8. Prefer branded or opaque types for important domain identifiers.
+9. Prefer `decodeUnknownEffect` in application code.
+10. Keep internal decoded shapes idiomatic and use schema transforms for external representation differences.
+
+## Anti-Patterns
+
+- using plain `Struct` for every reusable domain model even when `Class` would give a clearer named type
+- duplicating whole schemas when only one field encoding differs
+- creating `Foo` and `FooSql` schemas for the same logical model when a transformation would do
+- using `optional` when you actually want an optional key
+- duplicating near-identical schemas instead of deriving variants
+- rewriting keys manually after decode instead of using schema transformations
+- hand-validating external data after decode when the constraint belongs in the schema
+- exposing unvalidated external payloads deep into business logic
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/tools/ai-codegen/src/Config.ts`
+- `./.repos/effect/packages/platform-node/test/fixtures/rpc-schemas.ts`
+- `./.repos/effect/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
+- `./.repos/effect/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts`
+- `./.repos/effect/packages/effect/src/Schema.ts`

--- a/skills/effect-ts/references/guide-sql.md
+++ b/skills/effect-ts/references/guide-sql.md
@@ -1,0 +1,536 @@
+# SQL Guide
+
+This guide is based on the vendored Effect SQL modules in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`
+
+## Preferred Rule
+
+When a project uses Effect, prefer the Effect SQL modules over directly coupling business code to a native SQL driver API.
+
+Prefer:
+
+- `effect/unstable/sql/SqlClient`
+- `effect/unstable/sql/Migrator`
+- `effect/unstable/sql/SqlResolver`
+- `effect/unstable/sql/SqlSchema`
+- `effect/unstable/sql/SqlModel`
+
+Over:
+
+- embedding raw driver calls directly in business services
+- hand-rolling transactions in service methods
+- ad hoc migration scripts disconnected from the Effect runtime
+
+Why:
+
+- transactions are integrated into the Effect model
+- spans and SQL observability are built in
+- SQL errors stay typed and consistent
+- schema decoding and request resolution compose better
+- layers and services stay portable across runtimes and tests
+
+## Mental Model
+
+The Effect SQL stack is organized around:
+
+- `SqlClient` as the main database capability
+- `withTransaction` for transaction boundaries
+- `SqlResolver` for request-style batched and validated access
+- `SqlSchema` and `SqlModel` for schema-aware query/model patterns
+- `Migrator` for managed migrations
+
+The business layer should depend on Effect SQL abstractions, not on a raw driver object.
+
+## `SqlClient`
+
+`SqlClient` is the primary service for executing SQL.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Use it when:
+
+- you need to execute queries
+- you need transactions
+- you want SQL operations to participate in Effect spans and context
+
+Important capabilities from the repo:
+
+- transaction support with `withTransaction`
+- connection reservation with `reserve`
+- reactive queries
+- integration with transaction-scoped context
+
+## Typed Queries
+
+Prefer typed SQL queries instead of leaving row shapes implicit.
+
+The repo uses typed query literals like:
+
+```ts
+const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM test`
+```
+
+This is the first level of typed SQL usage and is already better than untyped row access.
+
+Use typed query literals when:
+
+- the row shape is small and obvious
+- the query is local and does not justify a reusable schema
+- you want immediate row typing without introducing extra helpers
+
+Avoid:
+
+- leaving query results untyped and then recovering shape with unsafe assertions
+- using `as` on rows after query execution
+
+## Schema Integration
+
+Prefer integrating SQL with Schema whenever the row shape matters or the query result crosses a meaningful boundary.
+
+Why:
+
+- Schema validates the shape rather than trusting the database blindly
+- row decoding stays explicit and typed
+- the same schema can often be reused for transport, domain, or contract layers
+- this avoids unsafe row assertions such as `as TodoRow`
+
+### Prefer schema-decoded results over `as`-based rows
+
+Avoid this pattern:
+
+```ts
+const row = yield* sql`SELECT id, title FROM todos WHERE id = ${id}`
+const todo = row[0] as TodoRow
+```
+
+Prefer:
+
+- a typed SQL query plus Schema decoding
+- or a SQL helper such as `SqlResolver`, `SqlSchema`, or `SqlModel` when appropriate
+
+Example boundary decode:
+
+```ts
+const TodoRow = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  completed: Schema.Boolean
+})
+
+const decodeTodoRows = Schema.decodeUnknownEffect(Schema.Array(TodoRow))
+```
+
+Then keep the query and decoding together in one SQL-aware operation.
+
+### `SqlResolver` + Schema
+
+`SqlResolver` is one of the clearest examples of SQL and Schema integration in the vendored repo.
+
+It uses:
+
+- a `Request` schema for validating resolver input
+- a `Result` schema for validating query output
+
+Example shape from the repo tests:
+
+```ts
+const resolver = SqlResolver.findById({
+  Id: Schema.Number,
+  Result: Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+  }),
+  ResultId: (row) => row.id,
+  execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
+})
+```
+
+This is a preferred pattern when:
+
+- multiple IDs are fetched together
+- request batching is useful
+- the query contract should be schema-validated
+
+### `SqlSchema` and `SqlModel`
+
+Use `SqlSchema` and `SqlModel` when you want tighter schema integration with SQL itself.
+
+They are preferred over hand-written row types when:
+
+- the row shape is central to the module
+- you want reusable schema-aware model logic
+- manual row mapping is becoming repetitive
+
+## Prefer SQL Services Over Native Driver Services
+
+Avoid this pattern:
+
+```ts
+class TodoService extends Context.Service<TodoService, { ... }>()("TodoService") {
+  static readonly layer = Layer.effect(this)(
+    Effect.acquireRelease(
+      Effect.try({ try: () => new Database("todos.sqlite") })
+    )
+  )
+}
+```
+
+Why this is usually a bad pattern in an Effect codebase:
+
+- the service is now tightly coupled to one runtime-specific database client
+- you lose the shared SQL abstraction that the Effect repo already provides
+- transaction and query conventions become ad hoc
+- it is easier to drift away from typed SQL errors, SQL tracing, and reusable query helpers
+
+Prefer a layer that provides `SqlClient`, and let domain services depend on that.
+
+## Domain Services Should Depend On `SqlClient`
+
+Good pattern:
+
+```ts
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+
+class TodoRepo extends Context.Service<TodoRepo>()("TodoRepo", {
+  make: Effect.succeed({
+    getById: Effect.fn("TodoRepo.getById")(function*(id: number) {
+      const sql = yield* SqlClient.SqlClient
+      return yield* sql`SELECT id, title, completed FROM todos WHERE id = ${id}`
+    })
+  })
+}) {}
+```
+
+Why this is better:
+
+- the domain service depends on an Effect SQL capability
+- SQL stays observable and transactional
+- the SQL client implementation can be provided separately from the business service
+
+## Transactions
+
+Use `SqlClient.withTransaction` for transaction boundaries.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+
+Prefer:
+
+```ts
+const createAndAudit = Effect.fn("TodoRepo.createAndAudit")(function*(title: string) {
+  const sql = yield* SqlClient.SqlClient
+
+  return yield* sql.withTransaction(
+    Effect.gen(function*() {
+      yield* sql`INSERT INTO todos ${sql.insert({ title, completed: false })}`
+      yield* sql`INSERT INTO audit_log ${sql.insert({ event: "todo_created" })}`
+    })
+  )
+})
+```
+
+Avoid:
+
+- manual `BEGIN` / `COMMIT` / `ROLLBACK` in application service code
+- driver-specific transaction logic spread across multiple service methods
+
+## Query Composition
+
+Prefer keeping query logic inside SQL-aware services or repositories.
+
+Good patterns:
+
+- keep queries close to the service that owns the behavior
+- use named business operations for multi-step workflows
+- use small local helpers only when they improve clarity
+
+Avoid exposing one exported accessor function per SQL service method if it only forwards to the service.
+
+Bad:
+
+```ts
+export const createTodo = Effect.fn(function*(title: string) {
+  const todos = yield* TodoRepo
+  return yield* todos.create(title)
+})
+```
+
+Prefer:
+
+- use the service method directly within the owning workflow
+- or export a real business operation that adds behavior beyond simple forwarding
+
+## SQL Resolvers
+
+Use `SqlResolver` when request-style batching or schema-validated request/response handling is useful.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+
+It is especially good for:
+
+- batched lookup patterns
+- `findById`-style resolvers
+- grouped query resolution
+- integrating SQL with request batching patterns
+
+Important repo pattern:
+
+- request schema validates inputs
+- result schema validates outputs
+- execution remains effectful and transactional
+
+This is one of the strongest typed-query patterns in the repo and should be preferred over ad hoc batched row mapping when the query fits the resolver model.
+
+## SQL Schemas And Models
+
+When schema-aware SQL helpers fit the task, prefer them over hand-mapped rows.
+
+Look at:
+
+- `SqlSchema`
+- `SqlModel`
+
+These are good fits when:
+
+- the row shape matters strongly
+- schema-based decode/encode should stay aligned with database access
+- you want to reduce ad hoc row mapping logic
+
+Avoid overusing manual `type Row = { ... }` plus custom conversion if the schema-aware modules already express the shape clearly.
+
+Preferred order for query typing:
+
+1. schema-aware SQL module such as `SqlResolver`, `SqlSchema`, or `SqlModel` when it fits
+2. typed query literals plus Schema decoding when the query is local
+3. only use manual row mapping when the first two options are clearly heavier than the problem
+
+## Migrations
+
+Use `Migrator` for migrations.
+
+Repo reference:
+
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+
+The repo shows these best practices:
+
+- maintain a dedicated migrations table
+- load migrations through a managed loader
+- run migrations through the Effect runtime
+- keep migration execution observable with logs and spans
+- use SQL client transaction and locking semantics handled by the migrator
+
+Important behavior in the vendored repo:
+
+- migrations table creation is dialect-aware
+- duplicate migration IDs are detected
+- concurrent migration runs are guarded
+- each migration is logged and wrapped in a span
+
+### Concrete Migration Loader Example
+
+The runtime-specific SQL migrator packages expose `fromRecord(...)` to define migrations from an ordered record.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+import * as Effect from "effect/Effect"
+
+const migrations = SqliteMigrator.fromRecord({
+  "1_create_todos": Effect.gen(function*() {
+    yield* sql`
+      CREATE TABLE todos (
+        id INTEGER PRIMARY KEY NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0
+      )
+    `.withoutTransform
+  }),
+  "2_add_todo_index": Effect.gen(function*() {
+    yield* sql`
+      CREATE INDEX todos_completed_idx ON todos (completed)
+    `.withoutTransform
+  })
+})
+```
+
+This matches the model used by the vendored migrator implementation:
+
+- each migration has a numeric prefix and descriptive name
+- each migration resolves to an `Effect`
+- migrations are ordered by ID
+
+### Running Migrations Directly
+
+Use the runtime-specific `run(...)` helper when you want a startup effect that runs migrations explicitly.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const runMigrations = SqliteMigrator.run({
+  loader: migrations
+})
+```
+
+This is a good fit when:
+
+- startup explicitly runs migrations before launching the main app
+- deployment tooling runs migrations as a separate command
+- you want migration results as an ordinary `Effect`
+
+The return value includes the applied migration IDs and names.
+
+### Running Migrations As A Layer
+
+Use the runtime-specific `layer(...)` helper when migrations should run as part of top-level infrastructure setup.
+
+Example shape:
+
+```ts
+import * as SqliteMigrator from "@effect/sql-sqlite-bun/SqliteMigrator"
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+```
+
+From the vendored packages, this is implemented as `Layer.effectDiscard(run(options))`.
+
+That means:
+
+- the layer performs the migration effect
+- it does not provide a new service of its own
+- it is intended to be composed into startup infrastructure
+
+### Concrete Startup Composition Example
+
+Preferred shape:
+
+```ts
+const SqlLayer = SqliteClient.layer({ filename: "todos.sqlite" })
+
+const MigrationLayer = SqliteMigrator.layer({
+  loader: migrations
+})
+
+const MigratedSqlLayer = Layer.merge(
+  SqlLayer,
+  MigrationLayer.pipe(Layer.provide(SqlLayer))
+)
+```
+
+This keeps the structure explicit:
+
+- one layer provides the SQL client
+- one layer runs migrations
+- the merged layer represents a migrated SQL environment
+
+If the same migrated SQL environment is reused in tests, create it once and reuse the layer value.
+
+### Migration Best Practices
+
+- use stable numeric migration IDs
+- keep migration files ordered and unique
+- do not hand-roll a separate migrations subsystem if `Migrator` already fits the project
+- keep migration execution at startup or a dedicated operational boundary
+- do not bury migration execution inside arbitrary service construction unless startup is explicitly the right place
+
+### Preferred Migration Boundary
+
+Good pattern:
+
+- construct the SQL layer
+- run migrations once at startup or deployment entry
+- then run the main application
+
+Concrete shapes:
+
+- separate startup effect: `SqliteMigrator.run({ loader })`
+- startup layer: `SqliteMigrator.layer({ loader })`
+- migrated environment layer: merge the SQL client layer with the migration layer provided by that client layer
+
+Avoid:
+
+- opportunistic migrations inside ordinary request handlers
+- schema creation hidden inside unrelated business service constructors
+
+## Errors
+
+Prefer SQL errors that stay inside the Effect SQL model as long as possible.
+
+Use domain-level translation only where it helps the business boundary.
+
+Good:
+
+- SQL layer or repository works with `SqlError` and schema decode failures where appropriate
+- higher-level service translates expected cases into domain errors when needed
+
+Avoid:
+
+- converting every SQL error immediately into a string
+- hiding SQL failure details too early
+
+## Observability
+
+The vendored SQL modules already integrate with spans and transaction context.
+
+This is another reason to prefer them over raw driver usage.
+
+Good pattern:
+
+- use `SqlClient` and `withTransaction`
+- keep business operations wrapped with `Effect.fn`
+- add explicit spans only where business-level detail matters beyond the built-in SQL spans
+
+## Layering Pattern
+
+Preferred layering shape:
+
+1. runtime-specific database layer provides `SqlClient`
+2. migrations run at startup boundary
+3. domain repository/service depends on `SqlClient`
+4. top-level application layer composes the database layer with the business layers
+
+This keeps:
+
+- driver choice at the edge
+- SQL capability in the middle
+- business logic above it
+
+## Anti-Patterns
+
+- embedding a native driver directly in business services when Effect SQL modules are available
+- hand-rolling transactions with raw SQL statements in service methods
+- hiding schema creation inside unrelated service constructors
+- exporting one trivial accessor function per repository/service method
+- converting SQL errors to strings too early
+- bypassing `Migrator` when the project already uses Effect SQL
+- creating ad hoc migration effects without a stable loader shape when `fromRecord(...)` already fits the project
+- scattering migration execution across multiple subsystems instead of one explicit startup boundary
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlClient.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/Migrator.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlResolver.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlSchema.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlModel.ts`
+- `./.repos/effect/packages/effect/src/unstable/sql/SqlError.ts`

--- a/skills/effect-ts/references/guide-testing.md
+++ b/skills/effect-ts/references/guide-testing.md
@@ -1,0 +1,504 @@
+# Testing Guide
+
+This guide is based on the vendored `@effect/vitest` package in `./.repos/effect`.
+
+Key source files:
+
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`
+
+## Preferred Rule
+
+When testing Effect code with Vitest, prefer `@effect/vitest` over manually calling `Effect.runPromise`, `Effect.runSync`, or ad hoc runtime setup inside ordinary Vitest tests.
+
+Layer provisioning in tests should follow these rules:
+
+1. If multiple tests should share the same layered setup, use `layer(...)`.
+2. If a nested group needs extra dependencies, use `it.layer(...)`.
+3. If tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls.
+4. Do not default to local `.pipe(Effect.provide(...))` inside test bodies.
+
+Use:
+
+- `it.effect` for Effect-based tests with test services
+- `it.live` for Effect-based tests that should use live services
+- `layer(...)` and `it.layer(...)` for shared layered test setup
+- `it.effect.prop` for Effect-based property tests
+
+Do not default to `.pipe(Effect.provide(SomeLayer))` inside test bodies when `layer(...)` or `it.layer(...)` expresses the setup more clearly.
+
+## Imports
+
+Preferred imports for Effect tests:
+
+```ts
+import { assert, describe, it, layer } from "@effect/vitest"
+import { Effect } from "effect"
+```
+
+`@effect/vitest` re-exports Vitest, so it is the normal entrypoint for test APIs in an Effect codebase.
+
+## Core Test Modes
+
+## `it.effect`
+
+Use `it.effect` for most Effect tests.
+
+It automatically:
+
+- runs the effect
+- scopes it correctly
+- provides the default test environment
+
+The default test environment includes:
+
+- `TestConsole`
+- `TestClock`
+
+This comes directly from the internal implementation.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+it.effect("loads a user", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+    assert.isTrue(true)
+  })
+)
+```
+
+Use `it.effect` when:
+
+- the test uses ordinary Effect code
+- the test benefits from `TestClock`
+- the test benefits from `TestConsole`
+- the test should run in a scoped Effect runtime
+
+## `it.live`
+
+Use `it.live` when the test should use live services instead of the default test environment.
+
+Example:
+
+```ts
+it.live("uses live services", () =>
+  Effect.gen(function*() {
+    yield* Effect.void
+  })
+)
+```
+
+Use `it.live` when:
+
+- you need the real `Clock`
+- the test should interact with live runtime services
+- you deliberately do not want the test environment overrides
+
+Rule of thumb:
+
+- default: `it.effect`
+- opt into `it.live` only when you actually need live behavior
+
+## Effect Test Structure
+
+Preferred pattern:
+
+```ts
+it.effect("does something", () =>
+  Effect.gen(function*() {
+    const value = yield* someEffect
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+Prefer `Effect.gen` inside `it.effect` and `it.live` for readability.
+
+Avoid:
+
+- `it("...", async () => ...)` for Effect programs
+- `Effect.runPromise(...)` inside plain Vitest tests
+- manual runtime setup for routine Effect tests
+
+## Assertions
+
+Use `assert` for Effect tests.
+
+The vendored repo also uses `expect` in some tests, but for skill guidance prefer `assert` in Effect-based tests because it keeps tests more uniform and explicit inside Effect programs.
+
+Examples:
+
+```ts
+assert.isTrue(value === 1)
+assert.strictEqual(a + b, b + a)
+assert.include(text, substring)
+```
+
+## Test Context
+
+`it.effect` and `it.live` test functions can receive a Vitest `TestContext`.
+
+Example:
+
+```ts
+it.effect("uses context", (ctx) =>
+  Effect.gen(function*() {
+    ctx.onTestFailed(() => {
+      // cleanup or diagnostics
+    })
+  })
+)
+```
+
+Use this when you need:
+
+- failure hooks
+- abort signals
+- ordinary Vitest test context integration
+
+## `each`, `skip`, `skipIf`, `runIf`, `only`, `fails`
+
+The Effect testers support the standard test variants:
+
+- `it.effect.each(...)`
+- `it.live.each(...)`
+- `it.effect.skip(...)`
+- `it.effect.skipIf(...)`
+- `it.effect.runIf(...)`
+- `it.effect.only(...)`
+- `it.live.fails(...)`
+
+Examples from the vendored tests show these are first-class parts of the API.
+
+Use them exactly as you would with Vitest, but return `Effect` from the test body.
+
+## Property Testing
+
+There are two different property-test entrypoints and they do not have identical behavior.
+
+## Top-level `it.prop`
+
+Use `it.prop` for non-Effect property tests.
+
+Example:
+
+```ts
+import { it } from "@effect/vitest"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a)
+```
+
+Important limitation from the internal implementation:
+
+- top-level `it.prop` does not support `Schema` arbitraries yet
+- if you pass a `Schema`, it throws
+
+So use top-level `it.prop` only with explicit `FastCheck` arbitraries.
+
+## `it.effect.prop`
+
+Use `it.effect.prop` for property tests that return `Effect`.
+
+This is the more powerful property-testing mode for Effect code.
+
+Example:
+
+```ts
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { FastCheck } from "effect/testing"
+
+const realNumber = FastCheck.float({ noNaN: true, noDefaultInfinity: true })
+
+it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(a + b, b + a)
+  })
+)
+```
+
+Unlike top-level `it.prop`, `it.effect.prop` does support `Schema` inputs by converting them with `Schema.toArbitrary`.
+
+So prefer `it.effect.prop` when:
+
+- the property test needs `Effect`
+- you want to use `Schema` values as arbitraries
+- the test needs Effect services or scope
+
+## `layer(...)`
+
+Use top-level `layer(...)` to share a `Layer` across a group of tests.
+
+Hard rule:
+
+- use `layer(...)` when tests should share one layered setup
+- do not use it when each test needs its own isolated layer instance
+
+This is one of the most important `@effect/vitest` features.
+
+Example:
+
+```ts
+import { describe, it, layer } from "@effect/vitest"
+import { Context, Effect, Layer } from "effect"
+
+class Foo extends Context.Service<Foo, string>()("Foo") {
+  static readonly layer = Layer.succeed(Foo)("foo")
+}
+
+describe("foo", () => {
+  layer(Foo.layer)((it) => {
+    it.effect("gets foo", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        return foo
+      })
+    )
+  })
+})
+```
+
+What it does internally:
+
+- builds the layer once for the test group
+- memoizes the built layer with a `MemoMap`
+- keeps the scope open for the group
+- closes the scope in `afterAll`
+
+This makes it the preferred way to share layer setup across related tests.
+
+This is also the preferred alternative to calling `Effect.provide(...)` inside each individual test body.
+
+## Anti-Pattern: Local `Effect.provide(...)` In Tests
+
+If multiple tests use the same layer, do not write tests like this:
+
+```ts
+it.effect("creates and lists todos", () =>
+  Effect.gen(function*() {
+    const service = yield* TodoService
+    yield* service.create("write tests")
+    yield* service.create("ship feature")
+  }).pipe(
+    Effect.provide(TodoService.inMemoryLayer)
+  )
+)
+```
+
+Why this is the wrong pattern:
+
+- it repeats provisioning in every test
+- it hides the layered test setup inside each test body
+- it fights the `@effect/vitest` layer helpers
+- it makes shared setup and teardown less explicit
+- it bypasses the clearer grouped-layer style that the library is designed for
+
+Prefer:
+
+```ts
+describe("TodoService", () => {
+  layer(TodoService.inMemoryLayer)((it) => {
+    it.effect("creates and lists todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        yield* service.create("write tests")
+        yield* service.create("ship feature")
+      })
+    )
+
+    it.effect("updates completion and deletes todos", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const todo = yield* service.create("close issue")
+        yield* service.setCompleted(todo.id, true)
+        yield* service.remove(todo.id)
+      })
+    )
+  })
+})
+```
+
+Rule:
+
+- if a test or group of tests depends on a layer, prefer `layer(...)`
+- if a nested group needs extra dependencies, prefer `it.layer(...)`
+- if tests need isolated layer instances per test, use multiple separate `it.layer(...)` calls
+- use local `Effect.provide(...)` in tests only for true one-off edge cases, not as the normal pattern
+
+This matches the general layer guidance: provisioning belongs at the boundary, and in `@effect/vitest` the test boundary should usually be expressed with `layer(...)` rather than ad hoc local provisioning.
+
+## `it.layer(...)`
+
+Use `it.layer(...)` inside an existing layered test group to add nested layer context.
+
+Hard rule:
+
+- use `it.layer(...)` when a specific test or nested test block should get its own isolated layered setup
+- if isolation matters, prefer multiple separate `it.layer(...)` calls over one shared `layer(...)` group
+
+Example:
+
+```ts
+layer(Foo.layer)((it) => {
+  it.layer(Bar.layer)("nested", (it) => {
+    it.effect("gets both", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        const bar = yield* Bar
+        return [foo, bar]
+      })
+    )
+  })
+})
+```
+
+Important behavior from the implementation:
+
+- nested `it.layer(...)` reuses the parent memo map
+- nested `it.layer(...)` does not accept `memoMap` or `excludeTestServices`
+- nested layering is meant to extend the current layered test environment, not redefine its runtime policy
+
+Use multiple `it.layer(...)` blocks when each test should get its own isolated layered setup instead of sharing one top-level `layer(...)` group.
+
+## `layer` Options
+
+The top-level `layer(...)` helper accepts:
+
+- `timeout`
+- `memoMap`
+- `excludeTestServices`
+
+### `excludeTestServices`
+
+By default, `layer(...)` merges your layer with the test environment (`TestClock` and `TestConsole`).
+
+Use `excludeTestServices: true` when you want your layer group to run without those test-service overrides.
+
+This is useful for tests that should keep live runtime behavior.
+
+### `memoMap`
+
+Use `memoMap` only when you have a specific reason to coordinate layer memoization manually across test setups.
+
+Most tests should let `@effect/vitest` manage it.
+
+## Scoped Resources In Tests
+
+`@effect/vitest` is designed to work correctly with scoped effects and layered resources.
+
+The vendored tests explicitly verify resource release through `afterAll`.
+
+Use this normally:
+
+- define scoped services in layers
+- use `layer(...)` to share them
+- let the helper own scope setup and teardown
+
+Avoid manually managing large scopes in test code unless the test specifically needs that control.
+
+## `flakyTest`
+
+Use `flakyTest` for tests that need bounded retrying.
+
+Repo behavior:
+
+- wraps the test in `Effect.scoped`
+- retries using a schedule
+- retries for up to a timeout window
+- converts final failure to defect with `Effect.orDie`
+
+Use this only for truly flaky integration-style conditions, not as a substitute for deterministic tests.
+
+## `makeMethods` And `describeWrapped`
+
+These exist for custom integration and wrapper scenarios.
+
+### `makeMethods`
+
+Use `makeMethods` when you need to extend or wrap a custom Vitest `it` instance while preserving Effect-aware helpers.
+
+### `describeWrapped`
+
+Use `describeWrapped` when you want a `describe` wrapper that hands you the augmented Effect-aware `it` methods directly.
+
+Most test code can just use imported `describe` and `it` from `@effect/vitest`.
+
+## Equality Testers
+
+`addEqualityTesters()` exists as part of the public API.
+
+Use it only when you have a concrete need to install equality testers for your Vitest environment.
+
+It is not needed for ordinary test structure.
+
+## Recommended Patterns
+
+### Pattern: normal Effect test
+
+```ts
+it.effect("does work", () =>
+  Effect.gen(function*() {
+    const value = yield* Effect.succeed(1)
+    assert.strictEqual(value, 1)
+  })
+)
+```
+
+### Pattern: shared layer for a test group
+
+```ts
+layer(AppLayer)("app", (it) => {
+  it.effect("uses app services", () =>
+    Effect.gen(function*() {
+      yield* Effect.void
+    })
+  )
+})
+```
+
+### Pattern: property test with Effect
+
+```ts
+it.effect.prop("law", [FastCheck.integer()], ([n]) =>
+  Effect.gen(function*() {
+    assert.strictEqual(n + 0, n)
+  })
+)
+```
+
+### Pattern: use `TestClock`
+
+```ts
+it.effect("uses TestClock", () =>
+  Effect.gen(function*() {
+    const fiber = yield* Effect.forkChild(Effect.sleep("1 second"))
+    yield* TestClock.adjust("1 second")
+    yield* Fiber.join(fiber)
+  })
+)
+```
+
+## Anti-Patterns
+
+- using plain `it(...)` with `Effect.runPromise(...)` for normal Effect tests
+- using `it.live` by default when `it.effect` is sufficient
+- manually building and tearing down large layer graphs instead of using `layer(...)`
+- using top-level `it.prop` with `Schema` inputs
+- using `flakyTest` to hide deterministic failures
+- duplicating runtime setup instead of sharing a layer
+
+## Good Repo Examples To Study
+
+- `./.repos/effect/packages/vitest/test/index.test.ts`
+- `./.repos/effect/packages/vitest/src/index.ts`
+- `./.repos/effect/packages/vitest/src/internal/internal.ts`
+- `./.repos/effect/packages/vitest/typetest/index.tst.ts`

--- a/skills/effect-ts/references/setup.md
+++ b/skills/effect-ts/references/setup.md
@@ -1,0 +1,89 @@
+# Effect Source Setup
+
+This setup task is required when `./.repos/effect` is missing from the root of the repository where this skill is used.
+
+## Prompt
+
+The local Effect source checkout was not found at `./.repos/effect`.
+
+Choose one of these setup options before continuing:
+
+1. Add `https://github.com/Effect-TS/effect-smol` as a git subtree with squashed history at `./.repos/effect`
+2. Add `https://github.com/Effect-TS/effect-smol` as a git submodule at `./.repos/effect`
+3. Use `git clone` into `./.repos/effect`, ignore it via `.gitignore`, and add a prepare script that bootstraps it when missing
+
+## Supported Options
+
+### 1. Git Subtree
+
+Use this when the repository should vendor the Effect source directly while keeping history compact.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: subtree with squashed history
+
+### 2. Git Submodule
+
+Use this when the repository should track the Effect source explicitly as a separate Git dependency.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Preferred shape: standard Git submodule
+
+### 3. Local Clone + Gitignore + Prepare Task
+
+Use this when the repository should avoid vendoring or submodule management, but still provide a reproducible local setup.
+
+- Repo path: `./.repos/effect`
+- Source: `https://github.com/Effect-TS/effect-smol`
+- Add `.repos/effect` to the repository `.gitignore`
+- Add a `prepare` task that clones the repo automatically when the directory is missing
+
+#### Concrete Shape
+
+Use this exact shape for the setup. Do not invent a different script.
+
+`package.json`:
+
+```json
+{
+  "scripts": {
+    "prepare": "./scripts/prepare-effect.sh"
+  }
+}
+```
+
+`.gitignore`:
+
+```gitignore
+.repos/effect
+```
+
+`scripts/prepare-effect.sh`:
+
+```sh
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect-smol"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"
+```
+
+#### Notes
+
+- This keeps `./.repos/effect` available for local research without forcing it into version control
+- The script is only responsible for ensuring the checkout exists; it does not update or reset an existing clone
+- If you choose this option, the setup task should add this exact script, wire it via `prepare`, and add `.repos/effect` to `.gitignore`
+
+## Guidance
+
+- Do not continue with Effect-specific work until one of the setup options is chosen.
+- Prefer the option that matches the host repository's dependency management style.


### PR DESCRIPTION
## Summary

- Vendor Effect-TS skill library as a copy-in (pinned commit b5026c68, 2026-05-15)
- Supply-chain strategy: vendored for robustness; not a submodule
- Upstream source: https://github.com/Effect-TS/skills
- All vendored files copied verbatim; our additions: PROVENANCE.md + SKILL.md source attribution comments
- License: Upstream has no explicit license statement; noted in PROVENANCE.md

## For Reviewers

- Vendored code (effect-ts/**) is a copy-in; internal style/formatting questions are not actionable (pinned upstream)
- Review focus: PROVENANCE.md and our attribution comments (SKILL.md)
- If upstream updates → fetch and merge as separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UpJDmFqvLQTiUJQ6WZHM8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Effect expert skill guide with setup, usage, and best-practice references.
  * Added extensive reference docs covering Effect features, error handling, layers, observability, retries, schedules, schemas, SQL, testing, and project setup.
  * Added provenance notes and source-attribution details for the vendored skill content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->