### PR TITLE
Add to-issues skill (copy-in from mattpocock/skills)

### DIFF
--- a/.agents/skills/to-issues/LICENSE
+++ b/.agents/skills/to-issues/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/to-issues/PROVENANCE.md
+++ b/.agents/skills/to-issues/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-issues/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
 ```
 

--- a/.agents/skills/to-issues/PROVENANCE.md
+++ b/.agents/skills/to-issues/PROVENANCE.md
@@ -1,0 +1,87 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-issues`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-issues/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-issues/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-issues/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-issues/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Dependency: setup-matt-pocock-skills
+
+`SKILL.md` tells the user to run `/setup-matt-pocock-skills` when the issue tracker and
+triage label vocabulary have not been provided. That sibling skill is vendored in this
+repo (`skills/setup-matt-pocock-skills/`), so the reference resolves; it scaffolds the
+per-repo config (issue tracker, triage labels, domain docs) that this skill reads.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Break a plan…"), not the third-person form AGENTS.md prefers, and it lacks an
+  explicit "when to use" clause. This skill is `disable-model-invocation: true`
+  (slash-command only), so the description is never used for model auto-invocation and
+  the third-person / when-to-use rule's purpose (trigger matching) does not apply.
+- **`disable-model-invocation: true`** — first use of this Claude Code-specific field in
+  this catalog. It is intentional upstream design: the skill has the side effect of
+  publishing issues to the tracker, so it is invoked only by explicit user request
+  (`/to-issues`), never auto-triggered by the model. The `codexcli` mirror drops the
+  field (see above).
+
+Upstream recipe critiques (raised by automated reviewers; upstream's to fix):
+
+- **Issue template omits a verification method** — the template asks for Acceptance
+  Criteria but no verification command/test plan. This repo's
+  `skills/issue-driven-development/SKILL.md` entrance gate wants both (though it accepts
+  a verification method that is self-evident from the AC), so issues generated here may
+  need a verification method added by hand before an AFK runner picks them up.
+- **Approval step (step 4) does not show the generated issue body** — the quiz presents
+  titles, blockers, and covered stories, but not the acceptance criteria / body that
+  step 5 publishes. For side-effectful runs that create real tracker issues, review the
+  drafted bodies before publishing.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the recipe
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: to-issues
+description: >-
+  Break a plan, spec, or PRD into independently-grabbable issues on the project
+  issue tracker using tracer-bullet vertical slices.
+---
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+<vertical-slice-rules>
+
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Any prefactoring should be done first
+
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.

--- a/.claude/skills/to-issues/LICENSE
+++ b/.claude/skills/to-issues/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/to-issues/PROVENANCE.md
+++ b/.claude/skills/to-issues/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-issues/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
 ```
 

--- a/.claude/skills/to-issues/PROVENANCE.md
+++ b/.claude/skills/to-issues/PROVENANCE.md
@@ -1,0 +1,87 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-issues`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-issues/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-issues/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-issues/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-issues/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Dependency: setup-matt-pocock-skills
+
+`SKILL.md` tells the user to run `/setup-matt-pocock-skills` when the issue tracker and
+triage label vocabulary have not been provided. That sibling skill is vendored in this
+repo (`skills/setup-matt-pocock-skills/`), so the reference resolves; it scaffolds the
+per-repo config (issue tracker, triage labels, domain docs) that this skill reads.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Break a plan…"), not the third-person form AGENTS.md prefers, and it lacks an
+  explicit "when to use" clause. This skill is `disable-model-invocation: true`
+  (slash-command only), so the description is never used for model auto-invocation and
+  the third-person / when-to-use rule's purpose (trigger matching) does not apply.
+- **`disable-model-invocation: true`** — first use of this Claude Code-specific field in
+  this catalog. It is intentional upstream design: the skill has the side effect of
+  publishing issues to the tracker, so it is invoked only by explicit user request
+  (`/to-issues`), never auto-triggered by the model. The `codexcli` mirror drops the
+  field (see above).
+
+Upstream recipe critiques (raised by automated reviewers; upstream's to fix):
+
+- **Issue template omits a verification method** — the template asks for Acceptance
+  Criteria but no verification command/test plan. This repo's
+  `skills/issue-driven-development/SKILL.md` entrance gate wants both (though it accepts
+  a verification method that is self-evident from the AC), so issues generated here may
+  need a verification method added by hand before an AFK runner picks them up.
+- **Approval step (step 4) does not show the generated issue body** — the quiz presents
+  titles, blockers, and covered stories, but not the acceptance criteria / body that
+  step 5 publishes. For side-effectful runs that create real tracker issues, review the
+  drafted bodies before publishing.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the recipe
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/.claude/skills/to-issues/SKILL.md
+++ b/.claude/skills/to-issues/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: to-issues
+description: >-
+  Break a plan, spec, or PRD into independently-grabbable issues on the project
+  issue tracker using tracer-bullet vertical slices.
+disable-model-invocation: true
+---
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+<vertical-slice-rules>
+
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Any prefactoring should be done first
+
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.

--- a/skills/to-issues/LICENSE
+++ b/skills/to-issues/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/to-issues/PROVENANCE.md
+++ b/skills/to-issues/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-issues/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
 ```
 

--- a/skills/to-issues/PROVENANCE.md
+++ b/skills/to-issues/PROVENANCE.md
@@ -1,0 +1,87 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-issues`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-issues/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-issues/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-issues/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-issues/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-issues/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Dependency: setup-matt-pocock-skills
+
+`SKILL.md` tells the user to run `/setup-matt-pocock-skills` when the issue tracker and
+triage label vocabulary have not been provided. That sibling skill is vendored in this
+repo (`skills/setup-matt-pocock-skills/`), so the reference resolves; it scaffolds the
+per-repo config (issue tracker, triage labels, domain docs) that this skill reads.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Break a plan…"), not the third-person form AGENTS.md prefers, and it lacks an
+  explicit "when to use" clause. This skill is `disable-model-invocation: true`
+  (slash-command only), so the description is never used for model auto-invocation and
+  the third-person / when-to-use rule's purpose (trigger matching) does not apply.
+- **`disable-model-invocation: true`** — first use of this Claude Code-specific field in
+  this catalog. It is intentional upstream design: the skill has the side effect of
+  publishing issues to the tracker, so it is invoked only by explicit user request
+  (`/to-issues`), never auto-triggered by the model. The `codexcli` mirror drops the
+  field (see above).
+
+Upstream recipe critiques (raised by automated reviewers; upstream's to fix):
+
+- **Issue template omits a verification method** — the template asks for Acceptance
+  Criteria but no verification command/test plan. This repo's
+  `skills/issue-driven-development/SKILL.md` entrance gate wants both (though it accepts
+  a verification method that is self-evident from the AC), so issues generated here may
+  need a verification method added by hand before an AFK runner picks them up.
+- **Approval step (step 4) does not show the generated issue body** — the quiz presents
+  titles, blockers, and covered stories, but not the acceptance criteria / body that
+  step 5 publishes. For side-effectful runs that create real tracker issues, review the
+  drafted bodies before publishing.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the recipe
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices.
+disable-model-invocation: true
+---
+
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+<vertical-slice-rules>
+
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Any prefactoring should be done first
+
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.


### PR DESCRIPTION
## 概要

`to-issues` engineering skill を追加。plan / spec / PRD を tracer-bullet な vertical slice に分解し、independently-grabbable な issue として発行する skill。

オリジナル: https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md

## 変更内容

master に merge 済みの `setup-matt-pocock-skills` (#48) が確立した **byte-for-byte copy-in 規範**に合わせて収録:

- `skills/to-issues/SKILL.md` — pinned commit `272f99b` の **byte-for-byte verbatim**（`diff == 0`）。
- `skills/to-issues/LICENSE` — upstream の MIT LICENSE (Matt Pocock)。
- `skills/to-issues/PROVENANCE.md` — pin した upstream commit / retrieval date / accepted deviations / upstream recipe critiques を記録。
- `.claude/` / `.agents/` の rulesync 生成 mirror（`scripts/rulesync-sync.mjs`、hand-edit せず再生成）。

## 方針

CLAUDE.md の copy-in 例外（出典 + LICENSE を残す）に従い、`setup-matt-pocock-skills` と同一パターンで収録。この repo の copy-in は「pinned upstream に対する `diff == 0`」の supply-chain 監査性が要点のため、**upstream content はローカルでパッチせず verbatim 維持**し、自動レビュー (Devin / Codex / CodeRabbit) の指摘（description の命令形 / `disable-model-invocation` / issue template の verification method 欠落 / approval step で body 非表示）は accepted deviations / upstream recipe critiques として `PROVENANCE.md` に集約している。upstream の真のバグは `mattpocock/skills` への PR/issue が正しい直し方。

`/setup-matt-pocock-skills` 参照は sibling skill が本 repo に vendored 済みのため解決する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an issue-planning skill that converts plans/specs/PRDs into independently actionable “vertical slice” (tracer bullet) issues, including a dependency-ordered publishing flow and a template with end-to-end build details and acceptance criteria.

* **Documentation**
  * Added MIT license text for the skill materials.
  * Added provenance/audit documentation explaining vendoring, pinned upstream source verification, and mirrored skill variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->