### PR TITLE
skills: add to-prd (copy-in from mattpocock/skills)

### DIFF
--- a/.agents/skills/to-prd/LICENSE
+++ b/.agents/skills/to-prd/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/to-prd/PROVENANCE.md
+++ b/.agents/skills/to-prd/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-prd/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
 ```
 

--- a/.agents/skills/to-prd/PROVENANCE.md
+++ b/.agents/skills/to-prd/PROVENANCE.md
@@ -1,0 +1,83 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-prd`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-prd/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-prd/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-prd/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-prd/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Caveat: sibling-skill dependencies
+
+`SKILL.md` references `/setup-matt-pocock-skills`, which scaffolds the per-repo config
+(issue tracker, triage label vocabulary, domain doc layout) that this skill reads. That
+skill is vendored alongside it at `skills/setup-matt-pocock-skills/`, so the dependency
+resolves within this repo. `SKILL.md` also assumes the surrounding Matt Pocock
+engineering suite (domain glossary / `CONTEXT.md`, ADRs); vendor the sibling skills the
+same way if you intend to use the rest of the suite.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Turn the current conversation…"), not the third-person form AGENTS.md prefers. This
+  skill is `disable-model-invocation: true` (slash-command only), so the description is
+  never used for model auto-invocation and the third-person rule's purpose (trigger
+  matching) does not apply.
+
+Upstream behaviour critiques (raised by automated reviewers; upstream's to fix):
+
+- `SKILL.md` step 2 — "Check with the user that these seams match their expectations"
+  reads as a clarification step, which reviewers flag against the frontmatter's "no
+  interview" line. Upstream's intent is narrower: don't re-run a full requirements
+  interview (synthesize from existing context) while still confirming the test seams
+  once. Kept verbatim.
+- `SKILL.md` step 3 — applies the literal `ready-for-agent` triage label. That is
+  upstream's canonical default; repos with a different AFK-ready label remap it via
+  `setup-matt-pocock-skills`' `triage-labels.md` rather than by editing this skill.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/.agents/skills/to-prd/SKILL.md
+++ b/.agents/skills/to-prd/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: to-prd
+description: >-
+  Turn the current conversation into a PRD and publish it to the project issue
+  tracker — no interview, just synthesis of what you've already discussed.
+---
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better - the ideal number is one.
+
+Check with the user that these seams match their expectations.
+
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>

--- a/.claude/skills/to-prd/LICENSE
+++ b/.claude/skills/to-prd/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/to-prd/PROVENANCE.md
+++ b/.claude/skills/to-prd/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-prd/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
 ```
 

--- a/.claude/skills/to-prd/PROVENANCE.md
+++ b/.claude/skills/to-prd/PROVENANCE.md
@@ -1,0 +1,83 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-prd`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-prd/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-prd/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-prd/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-prd/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Caveat: sibling-skill dependencies
+
+`SKILL.md` references `/setup-matt-pocock-skills`, which scaffolds the per-repo config
+(issue tracker, triage label vocabulary, domain doc layout) that this skill reads. That
+skill is vendored alongside it at `skills/setup-matt-pocock-skills/`, so the dependency
+resolves within this repo. `SKILL.md` also assumes the surrounding Matt Pocock
+engineering suite (domain glossary / `CONTEXT.md`, ADRs); vendor the sibling skills the
+same way if you intend to use the rest of the suite.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Turn the current conversation…"), not the third-person form AGENTS.md prefers. This
+  skill is `disable-model-invocation: true` (slash-command only), so the description is
+  never used for model auto-invocation and the third-person rule's purpose (trigger
+  matching) does not apply.
+
+Upstream behaviour critiques (raised by automated reviewers; upstream's to fix):
+
+- `SKILL.md` step 2 — "Check with the user that these seams match their expectations"
+  reads as a clarification step, which reviewers flag against the frontmatter's "no
+  interview" line. Upstream's intent is narrower: don't re-run a full requirements
+  interview (synthesize from existing context) while still confirming the test seams
+  once. Kept verbatim.
+- `SKILL.md` step 3 — applies the literal `ready-for-agent` triage label. That is
+  upstream's canonical default; repos with a different AFK-ready label remap it via
+  `setup-matt-pocock-skills`' `triage-labels.md` rather than by editing this skill.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/.claude/skills/to-prd/SKILL.md
+++ b/.claude/skills/to-prd/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: to-prd
+description: >-
+  Turn the current conversation into a PRD and publish it to the project issue
+  tracker — no interview, just synthesis of what you've already discussed.
+disable-model-invocation: true
+---
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better - the ideal number is one.
+
+Check with the user that these seams match their expectations.
+
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>

--- a/skills/to-prd/LICENSE
+++ b/skills/to-prd/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/to-prd/PROVENANCE.md
+++ b/skills/to-prd/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 untouched. To audit, diff the file under `skills/to-prd/` against the pinned
 upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
 ```
 

--- a/skills/to-prd/PROVENANCE.md
+++ b/skills/to-prd/PROVENANCE.md
@@ -1,0 +1,83 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` ("サードパーティ skill は vendor しない。
+copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す"). It was copied — not
+fetched at runtime via `npx skill` / `gh skill` — deliberately, to avoid executing
+upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/mattpocock/skills
+- **Upstream path**: `skills/engineering/to-prd`
+- **Author**: Matt Pocock
+- **License**: MIT (see [LICENSE](./LICENSE))
+- **Commit pinned**: `272f99b22574f50e4266791c86b9302682970e23` (`main`)
+- **Retrieved**: 2026-07-05
+
+In the **source-of-truth** directory `skills/to-prd/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else is
+untouched. To audit, diff the file under `skills/to-prd/` against the pinned
+upstream URL:
+
+```
+https://raw.githubusercontent.com/mattpocock/skills/272f99b22574f50e4266791c86b9302682970e23/skills/engineering/to-prd/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/to-prd/` only. This repo also commits
+**rulesync-generated** mirrors under `.claude/skills/` and `.agents/skills/` (see
+`scripts/rulesync-sync.mjs`; regenerate, don't hand-edit). Those are derived artifacts
+and rulesync transforms frontmatter per target — notably the `codexcli` target
+(`.agents/`) drops fields Codex CLI doesn't support, so
+`.agents/skills/to-prd/SKILL.md` omits `disable-model-invocation: true` while the
+source and the `.claude/` (Claude Code) mirror keep it. Verify the mirrors with
+`node scripts/rulesync-sync.mjs --check`, not by diffing against upstream.
+
+## Caveat: sibling-skill dependencies
+
+`SKILL.md` references `/setup-matt-pocock-skills`, which scaffolds the per-repo config
+(issue tracker, triage label vocabulary, domain doc layout) that this skill reads. That
+skill is vendored alongside it at `skills/setup-matt-pocock-skills/`, so the dependency
+resolves within this repo. `SKILL.md` also assumes the surrounding Matt Pocock
+engineering suite (domain glossary / `CONTEXT.md`, ADRs); vendor the sibling skills the
+same way if you intend to use the rest of the suite.
+
+## Accepted deviations from local conventions, and known upstream critiques
+
+This is a **byte-for-byte vendored copy**, so upstream content is kept verbatim even
+where it diverges from this repo's local conventions or where automated reviewers flag
+it. Editing the vendored file would break the `diff == 0`-against-pinned-upstream
+guarantee that is the whole point of the copy-in (supply-chain auditability). The items
+below are therefore **intentionally not patched here**; where they are genuine upstream
+bugs, the right fix is a PR/issue against `mattpocock/skills`, not a local fork.
+
+Deviations from *this repo's* conventions (accepted for fidelity):
+
+- **Description voice** — `SKILL.md`'s frontmatter description is imperative
+  ("Turn the current conversation…"), not the third-person form AGENTS.md prefers. This
+  skill is `disable-model-invocation: true` (slash-command only), so the description is
+  never used for model auto-invocation and the third-person rule's purpose (trigger
+  matching) does not apply.
+
+Upstream behaviour critiques (raised by automated reviewers; upstream's to fix):
+
+- `SKILL.md` step 2 — "Check with the user that these seams match their expectations"
+  reads as a clarification step, which reviewers flag against the frontmatter's "no
+  interview" line. Upstream's intent is narrower: don't re-run a full requirements
+  interview (synthesize from existing context) while still confirming the test seams
+  once. Kept verbatim.
+- `SKILL.md` step 3 — applies the literal `ready-for-agent` triage label. That is
+  upstream's canonical default; repos with a different AFK-ready label remap it via
+  `setup-matt-pocock-skills`' `triage-labels.md` rather than by editing this skill.
+
+## Updating
+
+Re-run the copy against a newer upstream commit, update the pinned commit / retrieval
+date above, and re-verify the byte-for-byte claim. If upstream fixes any of the
+critiques above, bumping the pinned commit pulls the fix in automatically.

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: to-prd
+description: Turn the current conversation into a PRD and publish it to the project issue tracker — no interview, just synthesis of what you've already discussed.
+disable-model-invocation: true
+---
+
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better - the ideal number is one.
+
+Check with the user that these seams match their expectations.
+
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>


### PR DESCRIPTION
## 概要

会話コンテキストを PRD に合成し、プロジェクトの issue tracker に publish する `to-prd` skill を追加します。ユーザへのインタビューは行わず、既知の内容だけを合成するのが特徴です。

オリジナル: https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md（`main` @ `272f99b` を pin）

## 変更内容

- `skills/to-prd/SKILL.md` — upstream `272f99b` の byte-for-byte コピー
- `skills/to-prd/PROVENANCE.md` — 出典・pin した upstream commit・license・許容した規約逸脱を明記（`skills/setup-matt-pocock-skills/`（#48）と同形式）
- `skills/to-prd/LICENSE` — upstream の MIT LICENSE（Copyright (c) 2026 Matt Pocock）
- 生成ミラー `.claude/skills/to-prd/`・`.agents/skills/to-prd/` — `scripts/rulesync-sync.mjs` で生成（drift check pass）

## 方針との整合

- **copy-in 例外**: CLAUDE.md / README の「サードパーティ skill は原則 vendor しない。copy-in 例外は skill ディレクトリ内に出典 + LICENSE を残す」に従い、`PROVENANCE.md` と `LICENSE` を skill ディレクトリ内に同梱。`diff == 0`(against pinned upstream) の監査性を保つため vendored 本文はローカル改変しない。
- **配布の不変条件**: ディレクトリ名 `to-prd` = frontmatter `name: to-prd` を満たす。
- **依存の解決**: `to-prd` が参照する `/setup-matt-pocock-skills` は、master に既に vendored 済みの sibling skill（#48）で解決される。

## レビュー対応メモ

vendored 本文への改変提案（description を三人称化 / seam のユーザ確認ステップ削除 / `ready-for-agent` ラベルの可変化）は、byte-for-byte copy-in の監査性を壊すため**本文は変更せず**、いずれも upstream 由来の意図として `PROVENANCE.md` に記録しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GBbMkRa6H83Gm9Z8jWuVx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “to-prd” skill that converts existing conversation context into a PRD and publishes it for follow-up via the issue tracker.
  * Includes a structured workflow (repo exploration, identifying/testing seam candidates, confirming with the user, then generating a standardized PRD using the embedded template and applying the ready-for-agent handoff label).

* **Documentation**
  * Added MIT license text for the skill.
  * Added provenance documentation describing the vendored source, audit steps, and verification guidance for mirrors across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->