### PR TITLE
Add setup-web.sh to install GitHub CLI and restore origin remote with tests

### DIFF
--- a/scripts/setup-web.sh
+++ b/scripts/setup-web.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare a cloud/web coding environment for this repository.
+# - Installs GitHub CLI (gh) when missing.
+# - Restores an origin remote when cloud checkout metadata leaves `git remote -v` empty.
+#
+# Usage: scripts/setup-web.sh [repo-dir]
+# Optional environment variables:
+#   SETUP_WEB_DRY_RUN=1        print install command instead of installing gh
+#   SETUP_WEB_FORCE_GH_INSTALL=1  exercise install path even when gh exists
+#   SETUP_WEB_REPOSITORY=owner/repo  preferred repo slug for origin
+#   GH_REPO=owner/repo         fallback repo slug
+#   GITHUB_REPOSITORY=owner/repo fallback repo slug used by GitHub Actions/cloud envs
+#   SETUP_WEB_REMOTE_URL=https://... or git@... explicit origin URL
+
+repo_dir=${1:-$(pwd)}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_or_print() {
+  if [[ "${SETUP_WEB_DRY_RUN:-}" == "1" ]]; then
+    printf 'dry-run: %s\n' "$*"
+  else
+    "$@"
+  fi
+}
+
+effective_euid() {
+  printf '%s\n' "${SETUP_WEB_ASSUME_EUID:-$EUID}"
+}
+
+privileged() {
+  if [[ "$(effective_euid)" == "0" ]]; then
+    run_or_print "$@"
+  elif [[ "${SETUP_WEB_DRY_RUN:-}" == "1" ]]; then
+    run_or_print sudo "$@"
+  elif have sudo; then
+    run_or_print sudo "$@"
+  else
+    log "This command needs elevated privileges but sudo is unavailable: $*"
+    return 1
+  fi
+}
+
+install_gh() {
+  if have gh && [[ "${SETUP_WEB_FORCE_GH_INSTALL:-}" != "1" ]]; then
+    log "gh is already installed: $(gh --version | head -n 1)"
+    return
+  fi
+
+  if [[ "${SETUP_WEB_FORCE_GH_INSTALL:-}" == "1" ]]; then
+    log "gh install path requested; installing GitHub CLI."
+  else
+    log "gh is not installed; installing GitHub CLI."
+  fi
+
+  if have apt-get; then
+    privileged mkdir -p -m 755 /etc/apt/keyrings
+    if [[ "${SETUP_WEB_DRY_RUN:-}" == "1" ]]; then
+      if [[ "$(effective_euid)" == "0" ]]; then
+        log "dry-run: curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null"
+        log "dry-run: chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg"
+        log "dry-run: add GitHub CLI apt source to /etc/apt/sources.list.d/github-cli.list"
+      else
+        log "dry-run: curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null"
+        log "dry-run: sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg"
+        log "dry-run: add GitHub CLI apt source to /etc/apt/sources.list.d/github-cli.list"
+      fi
+    else
+      if [[ "$(effective_euid)" == "0" ]]; then
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+        chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        printf 'deb [arch=%s signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+          "$(dpkg --print-architecture)" \
+          | tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+      else
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+        sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        printf 'deb [arch=%s signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+          "$(dpkg --print-architecture)" \
+          | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+      fi
+    fi
+    privileged apt-get update
+    privileged apt-get install -y gh
+  elif have brew; then
+    run_or_print brew install gh
+  elif have apk; then
+    privileged apk add --no-cache github-cli
+  else
+    log "No supported package manager found. Install GitHub CLI manually: https://cli.github.com/"
+    return 1
+  fi
+}
+
+repo_slug() {
+  if [[ -n "${SETUP_WEB_REPOSITORY:-}" ]]; then
+    printf '%s\n' "$SETUP_WEB_REPOSITORY"
+  elif [[ -n "${GH_REPO:-}" ]]; then
+    printf '%s\n' "$GH_REPO"
+  elif [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    printf '%s\n' "$GITHUB_REPOSITORY"
+  else
+    return 1
+  fi
+}
+
+ensure_origin_remote() {
+  if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    log "$repo_dir is not a git working tree; skipping remote setup."
+    return
+  fi
+
+  if git -C "$repo_dir" remote get-url origin >/dev/null 2>&1; then
+    log "origin remote already configured: $(git -C "$repo_dir" remote get-url origin)"
+    return
+  fi
+
+  local remote_url
+  if [[ -n "${SETUP_WEB_REMOTE_URL:-}" ]]; then
+    remote_url="$SETUP_WEB_REMOTE_URL"
+  else
+    local slug
+    slug=$(repo_slug) || {
+      log "origin remote is missing and no repository slug was provided. Set SETUP_WEB_REPOSITORY=owner/repo or SETUP_WEB_REMOTE_URL."
+      return 1
+    }
+    remote_url="https://github.com/${slug%.git}.git"
+  fi
+
+  git -C "$repo_dir" remote add origin "$remote_url"
+  log "Added origin remote: $remote_url"
+}
+
+install_gh
+ensure_origin_remote
+
+log "web setup complete."

--- a/tests/setup-web-test.sh
+++ b/tests/setup-web-test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/setup-web.sh"
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local message=$3
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$message: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+test_adds_origin_remote_from_github_repository() {
+  local tmpdir repo output remote_url
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  repo="$tmpdir/repo"
+  output="$tmpdir/setup-web-test.out"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+
+  SETUP_WEB_DRY_RUN=1 SETUP_WEB_FORCE_GH_INSTALL=1 GITHUB_REPOSITORY=kanade0404/skills "$SCRIPT" "$repo" >"$output"
+
+  remote_url=$(git -C "$repo" remote get-url origin)
+  assert_eq "https://github.com/kanade0404/skills.git" "$remote_url" "origin remote"
+
+  if ! grep -q "installing GitHub CLI" "$output"; then
+    echo "expected dry-run output to mention GitHub CLI installation" >&2
+    exit 1
+  fi
+}
+
+test_root_dry_run_does_not_require_sudo() {
+  local tmpdir repo output
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  repo="$tmpdir/repo"
+  output="$tmpdir/setup-web-test.out"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+
+  SETUP_WEB_DRY_RUN=1 SETUP_WEB_FORCE_GH_INSTALL=1 SETUP_WEB_ASSUME_EUID=0 GITHUB_REPOSITORY=kanade0404/skills "$SCRIPT" "$repo" >"$output"
+
+  if grep -q "dry-run: sudo " "$output"; then
+    echo "expected root dry-run install commands not to require sudo" >&2
+    exit 1
+  fi
+}
+
+test_adds_origin_remote_from_github_repository
+test_root_dry_run_does_not_require_sudo


### PR DESCRIPTION
### Motivation
- Provide a small helper to prepare cloud/web coding environments by ensuring the GitHub CLI is installed and an `origin` remote exists for checkouts that lose remote metadata.
- Support non-interactive environments and package managers commonly found in CI/cloud images and developer machines via `apt`, `brew`, and `apk` fallbacks.
- Allow safe testing and dry-run behavior while handling privilege elevation and explicit repository overrides.

### Description
- Add `scripts/setup-web.sh`, a POSIX-style bash script that installs `gh` (if missing or forced) and restores an `origin` remote using `SETUP_WEB_REMOTE_URL`, `SETUP_WEB_REPOSITORY`, or common env fallbacks like `GITHUB_REPOSITORY`.
- Implement dry-run mode via `SETUP_WEB_DRY_RUN`, configurable euid via `SETUP_WEB_ASSUME_EUID`, and privilege handling using `sudo` or direct execution where appropriate.
- Support Debian/Ubuntu `apt` installation (including keyring and source setup), Homebrew, and Alpine `apk`, and emit helpful messages when no supported package manager is available.
- Add executable test script `tests/setup-web-test.sh` that validates adding an `origin` remote and correct dry-run sudo behavior.

### Testing
- Ran the included test script `tests/setup-web-test.sh` which executes the script in dry-run mode against temporary git repositories and verifies the `origin` URL and dry-run output; the tests passed.
- The tests exercised `SETUP_WEB_DRY_RUN`, `SETUP_WEB_FORCE_GH_INSTALL`, and `SETUP_WEB_ASSUME_EUID` code paths and validated expected log messages and remote configuration.
- No additional automated tests were required for package-manager specific install commands when executed in dry-run mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a0e1188bc8332a9ef82b88f627047)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setup script for web/cloud coding environments that can install GitHub CLI when needed and ensure a Git remote is configured.
  * Added dry-run support so setup actions can be previewed before changes are made.
  * Added repository and remote URL options for more flexible setup in different environments.

* **Tests**
  * Added automated checks covering remote setup behavior and elevated-permission handling in dry-run mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->