### PR TITLE
skill frontmatter の不変条件を機械検証 (description 1024 字制限の実障害由来)

### DIFF
--- a/.agents/skills/issue-driven-development/SKILL.md
+++ b/.agents/skills/issue-driven-development/SKILL.md
@@ -1,28 +1,20 @@
 ---
 name: issue-driven-development
 description: |
-  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
-  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
-  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
-  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
-  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
-  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
-  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
-
-  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
-  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
-  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
-  `claude-loop:N` ラベルで PR に永続化する。
-
-  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
-  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
-  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
-  いずれでも必ず起動すること。
-
-  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
-  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
-  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
-  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch → 実装 → ローカルテスト green → commit → push →
+  **PR 作成まで**ヘッドレスで完遂するワークフロー。`linear-issue-driven-development`
+  の GitHub 移植で、最大の差分は**イベント分割**: CI を watch せず PR 作成で終了し、
+  CI 修正 (`ci-self-heal`) とレビュー対応 (`pr-review-respond`) は Actions のイベント
+  トリガによる有界な反応として別途走る。acceptance criteria の無い issue は実装せず
+  `ambiguous-issue` でエスカレートする (推測で実装しない)。エスカレーションは
+  `needs-human` + 構造化コメント (loop-escalation:v1)、反復上限は `claude-loop:N`
+  ラベルで PR に永続化する。Routine / Actions (ラベルイベント) からの起動が主経路。
+  `owner/repo#123` 形式の手動再実行、「この issue やっておいて」「claude:ready の
+  issue を処理して」「issue から PR まで自走して」でも必ず起動すること。範囲外:
+  Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
+  CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
+  単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
   素の `git` / `gh` だけで動くこと。
 ---
 # issue-driven-development

--- a/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/.claude/skills/issue-driven-development/SKILL.md
+++ b/.claude/skills/issue-driven-development/SKILL.md
@@ -1,28 +1,20 @@
 ---
 name: issue-driven-development
 description: |
-  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
-  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
-  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
-  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
-  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
-  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
-  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
-
-  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
-  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
-  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
-  `claude-loop:N` ラベルで PR に永続化する。
-
-  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
-  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
-  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
-  いずれでも必ず起動すること。
-
-  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
-  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
-  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
-  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch → 実装 → ローカルテスト green → commit → push →
+  **PR 作成まで**ヘッドレスで完遂するワークフロー。`linear-issue-driven-development`
+  の GitHub 移植で、最大の差分は**イベント分割**: CI を watch せず PR 作成で終了し、
+  CI 修正 (`ci-self-heal`) とレビュー対応 (`pr-review-respond`) は Actions のイベント
+  トリガによる有界な反応として別途走る。acceptance criteria の無い issue は実装せず
+  `ambiguous-issue` でエスカレートする (推測で実装しない)。エスカレーションは
+  `needs-human` + 構造化コメント (loop-escalation:v1)、反復上限は `claude-loop:N`
+  ラベルで PR に永続化する。Routine / Actions (ラベルイベント) からの起動が主経路。
+  `owner/repo#123` 形式の手動再実行、「この issue やっておいて」「claude:ready の
+  issue を処理して」「issue から PR まで自走して」でも必ず起動すること。範囲外:
+  Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
+  CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
+  単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
   素の `git` / `gh` だけで動くこと。
 allowed-tools:
   - Read

--- a/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/skills/issue-driven-development/SKILL.md
+++ b/skills/issue-driven-development/SKILL.md
@@ -1,28 +1,20 @@
 ---
 name: issue-driven-development
 description: |
-  GitHub issue に `claude:ready` ラベルが付いた 1 件を受け取り、排他ロック → 入口ゲート
-  (acceptance criteria 検証) → branch 作成 → 実装 → ローカルテスト green → commit →
-  push → **PR 作成まで** をヘッドレスで完遂するワークフロー。Linear 版
-  (`linear-issue-driven-development`) の GitHub 移植で、最大の設計差分は **イベント分割**:
-  本スキルは CI を watch せず PR 作成で終了し、CI 修正 (`ci-self-heal`) とレビュー対応
-  (`pr-review-respond`) は GitHub Actions の イベントトリガによる有界な反応として別途
-  走る。ループはどこにも while として存在せず、イベント連鎖として現れる。
-
-  acceptance criteria の無い issue は**実装せず** `ambiguous-issue` でエスカレートする
-  (自走ループの成否は issue の入口品質で決まるため、推測で実装しない)。エスカレーション
-  は `needs-human` ラベル + 構造化コメント (loop-escalation:v1) で行い、反復上限は
-  `claude-loop:N` ラベルで PR に永続化する。
-
-  Routine / GitHub Actions (ラベルイベント) から起動される主経路、人間が
-  `/gh-issue owner/repo#123` 相当で手動再実行する時、「この issue やっておいて」
-  「claude:ready の issue を処理して」「issue から PR まで自走して」のような要請、
-  いずれでも必ず起動すること。
-
-  範囲外: Linear issue (`linear-issue-driven-development`)、ローカルの対話的な実装後の
-  出荷 (`shipping`)、CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、
-  conflict 解消単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート — 本スキルは
-  merge しない)。実行環境はクラウド (Actions runner / Anthropic sandbox) を想定し、
+  GitHub issue に `claude:ready` ラベルが付いた 1 件を、排他ロック → 入口ゲート
+  (acceptance criteria 検証) → branch → 実装 → ローカルテスト green → commit → push →
+  **PR 作成まで**ヘッドレスで完遂するワークフロー。`linear-issue-driven-development`
+  の GitHub 移植で、最大の差分は**イベント分割**: CI を watch せず PR 作成で終了し、
+  CI 修正 (`ci-self-heal`) とレビュー対応 (`pr-review-respond`) は Actions のイベント
+  トリガによる有界な反応として別途走る。acceptance criteria の無い issue は実装せず
+  `ambiguous-issue` でエスカレートする (推測で実装しない)。エスカレーションは
+  `needs-human` + 構造化コメント (loop-escalation:v1)、反復上限は `claude-loop:N`
+  ラベルで PR に永続化する。Routine / Actions (ラベルイベント) からの起動が主経路。
+  `owner/repo#123` 形式の手動再実行、「この issue やっておいて」「claude:ready の
+  issue を処理して」「issue から PR まで自走して」でも必ず起動すること。範囲外:
+  Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
+  CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
+  単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
   素の `git` / `gh` だけで動くこと。
 claudecode:
   allowed-tools:

--- a/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,0 +1,13 @@
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}

--- a/tests/test_skill_frontmatter.py
+++ b/tests/test_skill_frontmatter.py
@@ -1,0 +1,98 @@
+"""skills/*/SKILL.md の frontmatter 不変条件を機械検証する (stdlib unittest).
+
+検証する不変条件:
+- frontmatter と name / description が存在する
+- name はディレクトリ名と一致する (カタログ配布の不変条件, CLAUDE.md)
+- name は小文字英数字とハイフンのみ・64 文字以内 (Anthropic 公式制約)
+- description は 1024 文字以内 (Anthropic 公式制約。超過すると Codex 等の
+  他エージェントの skill loader が読み込みに失敗する — 2026-07-06 に実発生)
+
+由来: codex exec が issue-driven-development の description 超過で
+skill load に失敗した実障害からの sensor 昇格。
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+MAX_DESCRIPTION_LENGTH = 1024
+MAX_NAME_LENGTH = 64
+NAME_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.S)
+NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.M)
+DESCRIPTION_RE = re.compile(
+    r"^description:\s*(?:(?P<style>[|>][-+]?)\s*\r?\n(?P<block>(?:[ ]+.*\r?\n?|\r?\n)*)|(?P<inline>.+))",
+    re.M,
+)
+
+
+def extract_description(frontmatter: str) -> str | None:
+    match = DESCRIPTION_RE.search(frontmatter)
+    if match is None:
+        return None
+    if match.group("block") is not None:
+        lines = []
+        for line in match.group("block").splitlines():
+            lines.append(line[2:] if line.startswith("  ") else line)
+        return "\n".join(lines).strip()
+    return match.group("inline").strip()
+
+
+def skill_files() -> list[Path]:
+    return sorted(SKILLS_DIR.glob("*/SKILL.md"))
+
+
+class TestSkillFrontmatter(unittest.TestCase):
+    def test_catalog_is_not_empty(self) -> None:
+        self.assertGreater(len(skill_files()), 0)
+
+    def test_frontmatter_invariants(self) -> None:
+        for path in skill_files():
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            with self.subTest(skill=rel):
+                text = path.read_text(encoding="utf-8")
+                fm_match = FRONTMATTER_RE.match(text)
+                self.assertIsNotNone(fm_match, f"{rel}: frontmatter がない")
+                frontmatter = fm_match.group(1)
+
+                name_match = NAME_RE.search(frontmatter)
+                self.assertIsNotNone(name_match, f"{rel}: name がない")
+                name = name_match.group(1)
+
+                self.assertEqual(
+                    name,
+                    path.parent.name,
+                    f"{rel}: name '{name}' がディレクトリ名と一致しない (配布の不変条件)",
+                )
+                self.assertLessEqual(
+                    len(name), MAX_NAME_LENGTH, f"{rel}: name が {MAX_NAME_LENGTH} 文字超"
+                )
+                self.assertRegex(
+                    name,
+                    NAME_PATTERN,
+                    f"{rel}: name は小文字英数字とハイフンのみ",
+                )
+
+                description = extract_description(frontmatter)
+                self.assertIsNotNone(description, f"{rel}: description がない")
+                assert description is not None
+                self.assertGreater(len(description), 0, f"{rel}: description が空")
+                self.assertLessEqual(
+                    len(description),
+                    MAX_DESCRIPTION_LENGTH,
+                    (
+                        f"{rel}: description が {len(description)} 文字で上限"
+                        f" {MAX_DESCRIPTION_LENGTH} を超過 (他エージェントの skill loader"
+                        " が読み込みに失敗する)"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **実障害由来**: codex exec が `.agents/skills/issue-driven-development/SKILL.md` の読み込みに失敗 (`invalid description: exceeds maximum length of 1024 characters`)。description が 1093 字で Anthropic 公式制約 (≤1024) を超過していた。Claude Code は寛容に読むため顕在化せず、**他エンジンとの相互運用で初めて露見**
- issue-driven-development の description を 1024 字以内に圧縮 (トリガ語彙・negative space は維持、trigger 結果 JSONL を再測定して同梱)
- **sensor 昇格**: `tests/test_skill_frontmatter.py` — 全 skill の frontmatter 不変条件を機械検証
  - description ≤1024 字 (今回の障害クラス)
  - name = ディレクトリ名 (CLAUDE.md の配布不変条件を初めて機械化)
  - name の文字種・長さ (公式制約)
- rulesync mirror 再生成済み (drift check 通過)

## 検証
- unittest: 全 skill を subTest で検証し OK (現カタログで違反は修正した 1 件のみだったことを事前計測済み)
- score_triggers.py: 新結果 JSONL は 13/13 一致
- `node scripts/rulesync-sync.mjs --check`: ✓ / ruff: clean

## Test plan
- [x] ローカル unittest / scorer / drift check
- [ ] CI (trigger-evals は PR #50 merge 後は unittest ステップでこのテストも毎回実行される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcnmrjKiVvAYmDbCcixzX3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the issue-driven development skill guidance for clearer, shorter workflow instructions and handling of edge cases.
  * Clarified when automation stops and when follow-up actions are handled separately.

* **Tests**
  * Added automated checks to verify skill metadata consistency across all skill files.
  * Added evaluation data covering expected and out-of-scope trigger scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->