### PR TITLE
fix: close pr-review-respond blocking gaps (push, defer, resolve guard, waiting)

### DIFF
--- a/.agents/skills/pr-review-respond/SKILL.md
+++ b/.agents/skills/pr-review-respond/SKILL.md
@@ -28,6 +28,20 @@ CodeRabbit / Devin / 人間レビュアーが残したコメントを **盲信�
 
 ---
 
+## 実行環境前提
+
+本スキルは 3 つの実行環境で起動しうる。**待機や中断の扱いが環境ごとに違う**ため、起動時にどの環境かを意識する:
+
+| 環境 | 特徴 | 待機や行き詰まりの扱い |
+|---|---|---|
+| 対話ローカルセッション | 画面前に人間がいる | Phase E の `WAITING` verdict をそのまま人間に返してよい |
+| ヘッドレス subagent (`shipping` 等からの dispatch) | 呼び出し元 skill/agent がいる | `WAITING` verdict を呼び出し元に返す。呼び出し元が再開の責任を持つ |
+| CI / スケジュール起動 (無人実行) | `WAITING` を受け取る相手がいない | **`WAITING` で止めない**。`needs-human` ラベル付与 + 構造化コメント (`prr escalate`、後述) を必須のフォールバックとする |
+
+いずれの環境でも共通の規律は Phase E で扱う「待機委譲時の end_turn 禁止」。
+
+---
+
 ## 前提: 同梱スクリプトと権限
 
 `gh api` / `gh pr ...` を毎回 inline で叩くと、実行のたびに permission prompt が発生して煩雑になる。本スキルは GitHub API 呼び出しを `scripts/` 配下に閉じ込め、**単一エントリーポイント `prr` 経由でのみ呼び出す** 設計にしている。これにより:
@@ -44,7 +58,9 @@ scripts/
 ├── reply_thread.sh      # prr reply
 ├── resolve_thread.sh    # prr resolve
 ├── post_summary.sh      # prr summary
-└── wait_ci.sh           # prr wait-ci
+├── wait_ci.sh           # prr wait-ci
+├── defer_issue.sh       # prr defer
+└── escalate.sh          # prr escalate
 ```
 
 ### Subcommand 一覧
@@ -55,9 +71,11 @@ scripts/
 |---|---|
 | `prr fetch <PR>` | 全 review thread + PR 一般コメントを GraphQL + REST で取得し、vendor 判定 (`coderabbit` / `devin` / `human`) と `self_replied` フラグを付けた正規化 JSON を stdout に出力 |
 | `prr reply <PR> <comment-id> <body-file>` | 正しい `/repos/{O}/{R}/pulls/{PR}/comments/{id}/replies` エンドポイントで返信投稿。本文は file 経由で multi-line / 引用符事故を防ぐ |
-| `prr resolve <PR> <comment-id> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。VALID / VALID_DEFER / DUPLICATE 専用 (INVALID_PUSH では呼ばない) |
+| `prr resolve <PR> <comment-id> <classification> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。`classification` は `VALID` / `VALID_DEFER` / `DUPLICATE` のみ許可。**`INVALID_PUSH` を渡すと非ゼロ exit で拒否する** (誤 resolve ガード、後述) |
 | `prr summary <PR> <body-file>` | 集約 Review Response Summary を **新規** issue comment として投稿 (毎回新規投稿、過去サマリは履歴として残す) |
 | `prr wait-ci <PR> [interval]` | `gh pr checks --watch` をラップし全 check 完了まで block。失敗時は exit 非ゼロで呼出側に通知 (本スキルは retry しない) |
+| `prr defer <PR> <thread-url> <title> <body-file>` | `VALID_DEFER` 判定のフォロー issue を作成し、`<issue-number> <issue-url>` を stdout に出力。本文に元スレッド URL と PR URL を自動付記する |
+| `prr escalate <PR> <reason> <body-file>` | 無人実行で `WAITING` を返す相手がいない時のフォールバック。PR に `needs-human` ラベルを付け、`body-file` を構造化コメントとして投稿する |
 
 スクリプト本体は最小依存 (`gh`, `jq`, `bash`) のみ前提。Python / Node 等は使わない。
 
@@ -131,6 +149,33 @@ Refs: https://github.com/<owner>/<repo>/pull/<n>#discussion_r<id>
 
 **Devin の re-review は commit push に任せる**。`@devin` メンションでの再依頼はしない（push を検知して自動再評価するため）。
 
+### Phase C 終端 — push (省略禁止)
+
+commit を当てただけでは GitHub 上の PR は古い HEAD のままで、CI もレビュー bot もそれを見ている。**Phase D / E に進む前に必ず push する**:
+
+```bash
+git push origin <branch>
+git rev-parse HEAD   # push した SHA を記録し、以降の "Fixed in <SHA>" 返信に使う
+```
+
+- push を省略すると `prr wait-ci` が古い HEAD の CI 結果を見て「完了」と誤判定する。Devin の自動 re-review も push が trigger のため起動しない。
+- push が rejected / diverged で失敗したら、原因 (force-push 済みの remote など) を解消してから再 push する。**push が成功したことを確認した SHA でのみ** Phase D 以降に進む。
+- 複数 commit をまとめて 1 回だけ push してよい。commit ごとの push は必須ではない。
+
+### VALID_DEFER — フォロー issue 作成
+
+`VALID_DEFER` は「妥当だがスコープ外」の判定であり、返信 (Phase D) で `Tracked in #<issue>` と書く以上、その issue は **返信より前に実在していなければならない**。
+
+```bash
+# body-file には指摘の要約 (自分の言葉で) + スコープ外と判断した理由を書く
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" defer <PR> <thread-url> "<title>" <body-file>
+# stdout: "<issue-number> <issue-url>"
+```
+
+- **タイトル規約**: 指摘内容を要約した命令形 1 行 (例: `Extract retry policy into shared helper`)。skill 名等のプレフィックスは付けない。
+- **本文必須項目**: 指摘の要約、スコープ外と判断した理由 (1 文)。元スレッド URL と PR URL は `prr defer` が自動で付記する。
+- 生成された issue 番号を Phase D の返信 (`Tracked in #<issue>`) と Phase E のサマリ (`[<thread-url>] → #<issue>`) の両方に使う。
+
 ### Phase D — 返信 (reply)
 
 inline thread への返信は GitHub REST の `/replies` エンドポイントを使う必要がある (top-level review comment への返信のみ可、reply-to-reply は不可)。これも `prr` wrapper に閉じ込める。
@@ -140,7 +185,9 @@ inline thread への返信は GitHub REST の `/replies` エンドポイント�
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" reply <PR> <root-comment-id> <body-file>
 
 # CodeRabbit に「対応済み」を伝えて thread を resolve する場合 (VALID / VALID_DEFER / DUPLICATE のみ)
-bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> [body-file]
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> <classification> [body-file]
+# classification は VALID / VALID_DEFER / DUPLICATE のいずれか。
+# INVALID_PUSH を渡すとスクリプトが非ゼロ exit で拒否する (誤 resolve ガード)。
 # body-file を渡すとその内容 + 改行 + "@coderabbitai resolve" が投稿される
 ```
 
@@ -153,7 +200,7 @@ vendor 別の使い分け:
 | `VALID_DEFER` | `prr resolve` (body: 「Tracked in #`<issue>`」) | `prr reply` (Tracked in #`<issue>`) | `prr reply` (Tracked in #`<issue>`) |
 | `DUPLICATE` | `prr resolve` (body: 「Already addressed by `<other-thread-url>`」) | `prr reply` (Already addressed by ...) | 同左 |
 
-**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。
+**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。この規律は運用 (書き手の注意) だけに頼らず、`resolve_thread.sh` 自身が `classification` 引数に `INVALID_PUSH` を渡された時点で非ゼロ exit するガードとして実装されている。
 
 返信本文の最低構成 (INVALID_PUSH の例):
 
@@ -205,6 +252,27 @@ bash "${CLAUDE_SKILL_DIR}/scripts/prr" summary <PR> <body-file>
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" wait-ci <PR>   # 全 check 完了まで block、fail なら ci-self-heal に渡す
 ```
 
+### 待機委譲時の規律 (end_turn 禁止)
+
+`wait-ci` はブロッキング呼び出しだが、長時間 CI を `Monitor` 等のバックグラウンド監視に委譲したくなる場面がある。**委譲した直後に end_turn してはならない** — 誰も再開しないまま放置される実例が起きている (待機委譲後 50 分放置)。
+
+- 同一ターン内で `wait-ci` (または委譲した監視) の完了 (pass/fail) まで確認できるなら、そのまま最終報告に進む。
+- 同一ターン内で完結できない場合、最終報告の代わりに **`WAITING` verdict を明示的に返す**:
+  - 現在までの進捗 (Fixed / Pushback / Deferred / Duplicate の内訳)
+  - 何を待っているか (CI の残り check / 追加レビュー等)
+  - 再開条件 (checks 完了、新規コメント等) と再開方法 (呼び出し元がポーリングするか、`pr-monitor` 等に引き継ぐか)
+  - `WAITING` を返したターンで end_turn してよいのは、「実行環境前提」表の対話ローカル / ヘッドレス subagent のように **`WAITING` を受け取る相手が存在する場合のみ**
+- 受け取る相手がいない (CI / スケジュール起動の無人実行) 場合は `WAITING` で止めない。代わりに次を実行してから終える:
+
+```bash
+# body-file は loop-escalation:v1 形式 (issue-driven-development skill と共通の規約):
+# 自由文の状況説明 + <!-- loop-escalation:v1 --> に続く JSON
+#   {"reason": "...", "detail": "...", "attempts": <n>, "session_id": "...", "next_action_hint": "..."}
+# reason は budget-exceeded / max-turns / ci-3-fail / review-5-rounds / no-progress /
+# ambiguous-issue / repo-unresolvable / conflict / security-block / other から選ぶ
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" escalate <PR> <reason> <body-file>
+```
+
 ---
 
 ## 出力フォーマット
@@ -254,8 +322,10 @@ PR 作者本人 (= 自分) のコメントは fetcher 側ではフィルタし�
 
 - **集約サマリコメント 1 件** (`prr summary` 経由で PR の issue comment として投稿、毎回新規、過去サマリは履歴として残す)
 - **inline thread への返信文字列** (`prr reply` / `prr resolve` 経由、vendor 別フォーマット)
-- **修正コミット列** (commit message に `Refs: <thread-url>` を含む)
-- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造)
+- **修正コミット列 + push** (commit message に `Refs: <thread-url>` を含み、Phase C 終端で push 済み)
+- **フォロー issue** (`VALID_DEFER` 判定時のみ、`prr defer` 経由で作成)
+- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造、または `WAITING` verdict)
+- **`needs-human` ラベル + エスカレーションコメント** (無人実行で `WAITING` の受け手がいない場合のみ、`prr escalate` 経由)
 
 ### 出力しない成果物
 

--- a/.agents/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
+++ b/.agents/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
@@ -1,20 +1,20 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"CodeRabbit 指摘対応は主機能"}
-{"id":"t02","predicted":true,"actual":true,"reason":"レビューコメント対応の直接要請"}
-{"id":"t03","predicted":true,"actual":true,"reason":"Devin 指摘対応を明示列挙"}
-{"id":"t04","predicted":true,"actual":true,"reason":"PR 指摘を捌く = 「PR のコメント全部捌いて」に一致"}
-{"id":"t05","predicted":true,"actual":true,"reason":"人間レビュアーの新規コメント対応を明示"}
-{"id":"t06","predicted":true,"actual":true,"reason":"PR コメント対応文脈"}
-{"id":"t07","predicted":true,"actual":true,"reason":"指摘対応の口語形"}
-{"id":"t08","predicted":true,"actual":true,"reason":"resolve 運用は本スキルの手順"}
-{"id":"t09","predicted":true,"actual":true,"reason":"review feedback = レビューコメント"}
-{"id":"t10","predicted":true,"actual":true,"reason":"PR コメント片付け"}
-{"id":"t11","predicted":false,"actual":false,"reason":"PR 起票前は code-review (「既にレビュー済みの PR に後追い」の明示)"}
-{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal。push 直後トリガはスレッド対応であり CI 修理ではない"}
-{"id":"t13","predicted":false,"actual":false,"reason":"tdd の領域"}
-{"id":"t14","predicted":false,"actual":false,"reason":"design-review の領域"}
-{"id":"t15","predicted":false,"actual":false,"reason":"test-review の領域"}
-{"id":"t16","predicted":false,"actual":false,"reason":"レビュー実行は範囲外を明示"}
-{"id":"t17","predicted":false,"actual":false,"reason":"概念照会"}
-{"id":"t18","predicted":false,"actual":false,"reason":"自分発コメントの追加は対応ではない"}
-{"id":"t19","predicted":true,"actual":true,"reason":"「push した直後」「push したのでスレッド対応して」を新規に明示列挙"}
-{"id":"t20","predicted":true,"actual":true,"reason":"再 push 後のスレッド終端 = 「未解決スレッドが残る PR を離れる前に必ず一度起動」"}
+{"id":"t01","predicted":true,"actual":true,"reason":"description が明示する「コードラビット対応」の要請文言に直接一致"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「レビューコメント対応して」= description の「レビュー対応して」「コメント見て対応して」に一致"}
+{"id":"t03","predicted":true,"actual":true,"reason":"description が明示する「Devin の指摘片付けて」に直接一致"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「PR の指摘を捌く」= description の「PR のコメント全部捌いて」相当"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「人間レビュアーが新規コメントを残した時...必ず起動」に該当"}
+{"id":"t06","predicted":true,"actual":true,"reason":"PR + コメント在中の文脈は「新規コメントを残した時」の検知条件に含まれる"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「指摘」は指摘対応の口語表現、対応依頼と読める"}
+{"id":"t08","predicted":true,"actual":true,"reason":"CodeRabbit thread の resolve 運用は本スキルの Phase D/E の手順そのもの"}
+{"id":"t09","predicted":true,"actual":true,"reason":"「review feedback」= レビューコメントの言い換えで description の起動条件に該当"}
+{"id":"t10","predicted":true,"actual":true,"reason":"「PR にコメントいっぱいついてる、片付けて」は「PR のコメント全部捌いて」とほぼ同義"}
+{"id":"t11","predicted":false,"actual":false,"reason":"「PR 出す前」は code-review の領域。description は「既にレビュー済みの PR に後追いで対応する」と明示し PR 起票前を除外"}
+{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal の領域。description に CI 修理への言及は無い"}
+{"id":"t13","predicted":false,"actual":false,"reason":"テスト新規作成は tdd の領域、レビューコメント対応ではない"}
+{"id":"t14","predicted":false,"actual":false,"reason":"設計レビューは design-review の領域、PR コメント対応ではない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"テストコードレビューは test-review の領域"}
+{"id":"t16","predicted":false,"actual":false,"reason":"description が「レビュー自体を実行することはしない」と明示的に除外"}
+{"id":"t17","predicted":false,"actual":false,"reason":"PR の概念説明は対応作業ではない"}
+{"id":"t18","predicted":false,"actual":false,"reason":"自分発のコメント追加は既存指摘への対応ではない"}
+{"id":"t19","predicted":true,"actual":true,"reason":"description が明示する「既存 PR ブランチへ push した直後 (レビュー対応後の再 push を含む)」に直接一致"}
+{"id":"t20","predicted":true,"actual":true,"reason":"「push したのでスレッド対応して」+「未解決スレッドが残る PR を離れる前に必ず一度起動する」に該当"}

--- a/.agents/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/.agents/skills/pr-review-respond/scripts/defer_issue.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a follow-up issue for a VALID_DEFER review-thread classification.
+#
+# Usage:
+#   defer_issue.sh <pr-number> <thread-url> <title> <body-file>
+#
+# body-file should contain the caller's own summary of the finding plus the
+# 1-line reason it's out of scope for this PR. This script appends a fixed
+# footer linking back to the PR and the original review thread, so a
+# `Tracked in #<issue>` reply is always traceable to its source even if the
+# caller forgets to include the link.
+#
+# stdout: "<issue-number> <issue-url>"
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <pr-number> <thread-url> <title> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+thread_url="$2"
+title="$3"
+body_file="$4"
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+owner=$(gh repo view --json owner --jq '.owner.login')
+repo=$(gh repo view --json name --jq '.name')
+pr_url=$(gh pr view "$pr" --json url --jq '.url')
+
+body=$(cat "$body_file")
+full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
+
+resp=$(gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$owner/$repo/issues" \
+  -f title="$title" \
+  -f body="$full_body")
+
+jq -r '"\(.number) \(.html_url)"' <<<"$resp"

--- a/.agents/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/.agents/skills/pr-review-respond/scripts/defer_issue.sh
@@ -33,6 +33,24 @@ owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')
 pr_url=$(gh pr view "$pr" --json url --jq '.url')
 
+# Retry-safe: a prior invocation for this exact thread may have already
+# created the follow-up issue (e.g. this step succeeded but a later step in
+# the caller's flow failed and the whole defer sequence got re-run). Search
+# existing issues (any state) whose body already contains this thread_url
+# before creating a new one, so retries don't leave duplicate tracking
+# issues behind. This is best-effort: GitHub's search index can lag a few
+# seconds behind issue creation, so an immediate retry could still race it.
+search_json=$(gh search issues --repo "$owner/$repo" --match body "$thread_url" \
+  --json number,url,body --limit 10)
+existing=$(jq -r --arg url "$thread_url" \
+  '[.[] | select(.body | contains($url))][0] | if . == null then "" else "\(.number) \(.url)" end' \
+  <<<"$search_json")
+
+if [ -n "$existing" ]; then
+  echo "$existing"
+  exit 0
+fi
+
 body=$(cat "$body_file")
 full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
 

--- a/.agents/skills/pr-review-respond/scripts/escalate.sh
+++ b/.agents/skills/pr-review-respond/scripts/escalate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Unattended fallback for Phase E: label the PR `needs-human` and post a
+# structured escalation comment. Use this ONLY when there is no caller left
+# to hand a WAITING verdict to (headless CI / scheduled run). In an
+# interactive session or a subagent dispatched by another skill, return
+# WAITING instead — see skills/pr-review-respond/SKILL.md Phase E.
+#
+# Usage:
+#   escalate.sh <pr-number> <reason> <body-file>
+#
+# reason: one of budget-exceeded max-turns ci-3-fail review-5-rounds
+#         no-progress ambiguous-issue repo-unresolvable conflict
+#         security-block other
+#         (same taxonomy as skills/issue-driven-development/SKILL.md, so
+#         downstream tooling that greps for these reasons keeps working.)
+#
+# body-file: free-text situation summary, expected to end with the
+#   loop-escalation:v1 marker and JSON block:
+#     <!-- loop-escalation:v1 -->
+#     {"reason": "...", "detail": "...", "attempts": <n>, ...}
+#   This script does not construct that JSON itself — the caller fills in
+#   attempts/session_id/next_action_hint because only the caller knows them.
+
+set -euo pipefail
+
+valid_reasons="budget-exceeded max-turns ci-3-fail review-5-rounds no-progress ambiguous-issue repo-unresolvable conflict security-block other"
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <pr-number> <reason> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+reason="$2"
+body_file="$3"
+
+case " $valid_reasons " in
+  *" $reason "*)
+    ;;
+  *)
+    echo "error: unknown reason: $reason (expected one of: $valid_reasons)" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+gh pr edit "$pr" --add-label needs-human >/dev/null
+
+gh pr comment "$pr" --body-file "$body_file"

--- a/.agents/skills/pr-review-respond/scripts/escalate.sh
+++ b/.agents/skills/pr-review-respond/scripts/escalate.sh
@@ -48,6 +48,15 @@ if [ ! -f "$body_file" ]; then
   exit 2
 fi
 
-gh pr edit "$pr" --add-label needs-human >/dev/null
-
+# Post the escalation comment first. It is the only human-visible signal in
+# an unattended run, so it must not be blocked by the label step:
+# `needs-human` may not exist yet in every consumer repo, and under
+# `set -e` a failing `gh pr edit --add-label` would previously abort before
+# the comment was ever posted. Labeling is now best-effort and non-fatal —
+# if it fails (missing label, permissions, etc.) we warn to stderr but still
+# exit 0, because the comment (the actual escalation) already succeeded.
 gh pr comment "$pr" --body-file "$body_file"
+
+if ! gh pr edit "$pr" --add-label needs-human >/dev/null 2>&1; then
+  echo "warning: failed to add 'needs-human' label (it may not exist in this repo); escalation comment was posted regardless" >&2
+fi

--- a/.agents/skills/pr-review-respond/scripts/prr
+++ b/.agents/skills/pr-review-respond/scripts/prr
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Force plain output even when the calling shell/CI forces ANSI color
+# (e.g. CLICOLOR_FORCE=1). `gh ... --json` must stay parseable by `jq`;
+# color codes embedded in JSON break every downstream subcommand.
+export NO_COLOR=1
+export CLICOLOR_FORCE=0
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {

--- a/.agents/skills/pr-review-respond/scripts/prr
+++ b/.agents/skills/pr-review-respond/scripts/prr
@@ -16,6 +16,16 @@
 #   command string. With per-script invocation we'd need a separate rule per
 #   script and per install path. Routing every action through a single `prr`
 #   entry point lets a single rule (`Bash(bash *prr *)`) cover everything.
+#
+# Why the per-action scripts are dispatched via `exec bash "<script>"`
+# instead of `exec "<script>"`:
+#   Rulesync-generated mirrors (e.g. the Codex `.agents/` distribution) are
+#   committed without the executable bit, since rulesync's writer does not
+#   preserve source file permissions. Invoking the target file directly
+#   would exit 126 ("Permission denied") from that mirror even though the
+#   file itself is valid. Explicitly running it through `bash` sidesteps the
+#   executable bit entirely and works from any mirror regardless of how it
+#   was materialized.
 
 set -euo pipefail
 
@@ -49,25 +59,25 @@ shift || true
 
 case "$cmd" in
   fetch)
-    exec "$SCRIPT_DIR/fetch_threads.sh" "$@"
+    exec bash "$SCRIPT_DIR/fetch_threads.sh" "$@"
     ;;
   reply)
-    exec "$SCRIPT_DIR/reply_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/reply_thread.sh" "$@"
     ;;
   resolve)
-    exec "$SCRIPT_DIR/resolve_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/resolve_thread.sh" "$@"
     ;;
   summary)
-    exec "$SCRIPT_DIR/post_summary.sh" "$@"
+    exec bash "$SCRIPT_DIR/post_summary.sh" "$@"
     ;;
   wait-ci)
-    exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    exec bash "$SCRIPT_DIR/wait_ci.sh" "$@"
     ;;
   defer)
-    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    exec bash "$SCRIPT_DIR/defer_issue.sh" "$@"
     ;;
   escalate)
-    exec "$SCRIPT_DIR/escalate.sh" "$@"
+    exec bash "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/.agents/skills/pr-review-respond/scripts/prr
+++ b/.agents/skills/pr-review-respond/scripts/prr
@@ -3,11 +3,13 @@
 # Dispatches to per-action scripts in this same directory.
 #
 # Usage:
-#   prr fetch   <pr-number>
-#   prr reply   <pr-number> <root-comment-id> <body-file>
-#   prr resolve <pr-number> <root-comment-id> [body-file]
-#   prr summary <pr-number> <body-file>
-#   prr wait-ci <pr-number> [interval-seconds]
+#   prr fetch    <pr-number>
+#   prr reply    <pr-number> <root-comment-id> <body-file>
+#   prr resolve  <pr-number> <root-comment-id> <classification> [body-file]
+#   prr summary  <pr-number> <body-file>
+#   prr wait-ci  <pr-number> [interval-seconds]
+#   prr defer    <pr-number> <thread-url> <title> <body-file>
+#   prr escalate <pr-number> <reason> <body-file>
 #
 # Why this wrapper exists:
 #   Claude Code permission rules (`allowed-tools`) match against the literal
@@ -24,11 +26,13 @@ usage() {
 prr — pr-review-respond entry point
 
 Usage:
-  prr fetch   <pr>
-  prr reply   <pr> <root-comment-id> <body-file>
-  prr resolve <pr> <root-comment-id> [body-file]
-  prr summary <pr> <body-file>
-  prr wait-ci <pr> [interval-sec]
+  prr fetch    <pr>
+  prr reply    <pr> <root-comment-id> <body-file>
+  prr resolve  <pr> <root-comment-id> <classification> [body-file]
+  prr summary  <pr> <body-file>
+  prr wait-ci  <pr> [interval-sec]
+  prr defer    <pr> <thread-url> <title> <body-file>
+  prr escalate <pr> <reason> <body-file>
 
 All subcommands shell out to <scripts-dir>/<action>_*.sh.
 EOF
@@ -52,6 +56,12 @@ case "$cmd" in
     ;;
   wait-ci)
     exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    ;;
+  defer)
+    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    ;;
+  escalate)
+    exec "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/.agents/skills/pr-review-respond/scripts/resolve_thread.sh
+++ b/.agents/skills/pr-review-respond/scripts/resolve_thread.sh
@@ -4,26 +4,45 @@
 # directive and flips the thread state.
 #
 # Usage:
-#   resolve_thread.sh <pr-number> <root-comment-id> [body-file]
+#   resolve_thread.sh <pr-number> <root-comment-id> <classification> [body-file]
+#
+# classification must be one of: VALID VALID_DEFER DUPLICATE.
+#
+# Guard: INVALID_PUSH is REJECTED (non-zero exit, no API call made). Resolving
+# an INVALID_PUSH thread would tell the reviewer "fixed" when we actually
+# pushed back — this guard makes that misuse fail loudly instead of relying
+# on the caller to remember the rule (skills/pr-review-respond/SKILL.md
+# Phase D).
 #
 # If body-file is omitted, the reply is just `@coderabbitai resolve`. When
 # given, body-file content is concatenated BEFORE the directive line, so the
 # caller can include "Fixed in <SHA>" / "Tracked in #N" etc.
-#
-# Important: this script is intended for VALID / VALID_DEFER / DUPLICATE
-# classifications only. Do NOT call it for INVALID_PUSH (we leave reviewer
-# the right to re-open).
 
 set -euo pipefail
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-  echo "usage: $0 <pr-number> <root-comment-id> [body-file]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: $0 <pr-number> <root-comment-id> <classification> [body-file]" >&2
   exit 2
 fi
 
 pr="$1"
 comment_id="$2"
-body_file="${3:-}"
+classification="$3"
+body_file="${4:-}"
+
+case "$classification" in
+  VALID|VALID_DEFER|DUPLICATE)
+    ;;
+  INVALID_PUSH)
+    echo "error: refusing to resolve thread $comment_id on PR $pr: classification is INVALID_PUSH." >&2
+    echo "       INVALID_PUSH threads must stay open (reply only, never resolve)." >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unknown classification: $classification (expected VALID|VALID_DEFER|DUPLICATE|INVALID_PUSH)" >&2
+    exit 2
+    ;;
+esac
 
 owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')

--- a/.claude/skills/pr-review-respond/SKILL.md
+++ b/.claude/skills/pr-review-respond/SKILL.md
@@ -24,6 +24,8 @@ allowed-tools:
   - Bash(git commit *)
   - Bash(git diff *)
   - Bash(git log *)
+  - Bash(git push *)
+  - Bash(git rev-parse *)
   - Bash(git status *)
   - Bash(jq *)
   - Task
@@ -37,6 +39,20 @@ CodeRabbit / Devin / 人間レビュアーが残したコメントを **盲信�
 - **verify-before-implement** — 妥当性を AI が一次判定してから手を動かす。`receiving-code-review` 系の規律を取り込む。
 - **pushback はコメントのみ** — INVALID と判定したものは根拠を書くだけで resolve しない。reviewer の最終判断余地を残す。
 - **トレーサビリティは PR 集約コメント 1 本に集約** — ローカルログは作らない。後から PR を見れば全てわかる状態にする。
+
+---
+
+## 実行環境前提
+
+本スキルは 3 つの実行環境で起動しうる。**待機や中断の扱いが環境ごとに違う**ため、起動時にどの環境かを意識する:
+
+| 環境 | 特徴 | 待機や行き詰まりの扱い |
+|---|---|---|
+| 対話ローカルセッション | 画面前に人間がいる | Phase E の `WAITING` verdict をそのまま人間に返してよい |
+| ヘッドレス subagent (`shipping` 等からの dispatch) | 呼び出し元 skill/agent がいる | `WAITING` verdict を呼び出し元に返す。呼び出し元が再開の責任を持つ |
+| CI / スケジュール起動 (無人実行) | `WAITING` を受け取る相手がいない | **`WAITING` で止めない**。`needs-human` ラベル付与 + 構造化コメント (`prr escalate`、後述) を必須のフォールバックとする |
+
+いずれの環境でも共通の規律は Phase E で扱う「待機委譲時の end_turn 禁止」。
 
 ---
 
@@ -56,7 +72,9 @@ scripts/
 ├── reply_thread.sh      # prr reply
 ├── resolve_thread.sh    # prr resolve
 ├── post_summary.sh      # prr summary
-└── wait_ci.sh           # prr wait-ci
+├── wait_ci.sh           # prr wait-ci
+├── defer_issue.sh       # prr defer
+└── escalate.sh          # prr escalate
 ```
 
 ### Subcommand 一覧
@@ -67,9 +85,11 @@ scripts/
 |---|---|
 | `prr fetch <PR>` | 全 review thread + PR 一般コメントを GraphQL + REST で取得し、vendor 判定 (`coderabbit` / `devin` / `human`) と `self_replied` フラグを付けた正規化 JSON を stdout に出力 |
 | `prr reply <PR> <comment-id> <body-file>` | 正しい `/repos/{O}/{R}/pulls/{PR}/comments/{id}/replies` エンドポイントで返信投稿。本文は file 経由で multi-line / 引用符事故を防ぐ |
-| `prr resolve <PR> <comment-id> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。VALID / VALID_DEFER / DUPLICATE 専用 (INVALID_PUSH では呼ばない) |
+| `prr resolve <PR> <comment-id> <classification> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。`classification` は `VALID` / `VALID_DEFER` / `DUPLICATE` のみ許可。**`INVALID_PUSH` を渡すと非ゼロ exit で拒否する** (誤 resolve ガード、後述) |
 | `prr summary <PR> <body-file>` | 集約 Review Response Summary を **新規** issue comment として投稿 (毎回新規投稿、過去サマリは履歴として残す) |
 | `prr wait-ci <PR> [interval]` | `gh pr checks --watch` をラップし全 check 完了まで block。失敗時は exit 非ゼロで呼出側に通知 (本スキルは retry しない) |
+| `prr defer <PR> <thread-url> <title> <body-file>` | `VALID_DEFER` 判定のフォロー issue を作成し、`<issue-number> <issue-url>` を stdout に出力。本文に元スレッド URL と PR URL を自動付記する |
+| `prr escalate <PR> <reason> <body-file>` | 無人実行で `WAITING` を返す相手がいない時のフォールバック。PR に `needs-human` ラベルを付け、`body-file` を構造化コメントとして投稿する |
 
 スクリプト本体は最小依存 (`gh`, `jq`, `bash`) のみ前提。Python / Node 等は使わない。
 
@@ -143,6 +163,33 @@ Refs: https://github.com/<owner>/<repo>/pull/<n>#discussion_r<id>
 
 **Devin の re-review は commit push に任せる**。`@devin` メンションでの再依頼はしない（push を検知して自動再評価するため）。
 
+### Phase C 終端 — push (省略禁止)
+
+commit を当てただけでは GitHub 上の PR は古い HEAD のままで、CI もレビュー bot もそれを見ている。**Phase D / E に進む前に必ず push する**:
+
+```bash
+git push origin <branch>
+git rev-parse HEAD   # push した SHA を記録し、以降の "Fixed in <SHA>" 返信に使う
+```
+
+- push を省略すると `prr wait-ci` が古い HEAD の CI 結果を見て「完了」と誤判定する。Devin の自動 re-review も push が trigger のため起動しない。
+- push が rejected / diverged で失敗したら、原因 (force-push 済みの remote など) を解消してから再 push する。**push が成功したことを確認した SHA でのみ** Phase D 以降に進む。
+- 複数 commit をまとめて 1 回だけ push してよい。commit ごとの push は必須ではない。
+
+### VALID_DEFER — フォロー issue 作成
+
+`VALID_DEFER` は「妥当だがスコープ外」の判定であり、返信 (Phase D) で `Tracked in #<issue>` と書く以上、その issue は **返信より前に実在していなければならない**。
+
+```bash
+# body-file には指摘の要約 (自分の言葉で) + スコープ外と判断した理由を書く
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" defer <PR> <thread-url> "<title>" <body-file>
+# stdout: "<issue-number> <issue-url>"
+```
+
+- **タイトル規約**: 指摘内容を要約した命令形 1 行 (例: `Extract retry policy into shared helper`)。skill 名等のプレフィックスは付けない。
+- **本文必須項目**: 指摘の要約、スコープ外と判断した理由 (1 文)。元スレッド URL と PR URL は `prr defer` が自動で付記する。
+- 生成された issue 番号を Phase D の返信 (`Tracked in #<issue>`) と Phase E のサマリ (`[<thread-url>] → #<issue>`) の両方に使う。
+
 ### Phase D — 返信 (reply)
 
 inline thread への返信は GitHub REST の `/replies` エンドポイントを使う必要がある (top-level review comment への返信のみ可、reply-to-reply は不可)。これも `prr` wrapper に閉じ込める。
@@ -152,7 +199,9 @@ inline thread への返信は GitHub REST の `/replies` エンドポイント�
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" reply <PR> <root-comment-id> <body-file>
 
 # CodeRabbit に「対応済み」を伝えて thread を resolve する場合 (VALID / VALID_DEFER / DUPLICATE のみ)
-bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> [body-file]
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> <classification> [body-file]
+# classification は VALID / VALID_DEFER / DUPLICATE のいずれか。
+# INVALID_PUSH を渡すとスクリプトが非ゼロ exit で拒否する (誤 resolve ガード)。
 # body-file を渡すとその内容 + 改行 + "@coderabbitai resolve" が投稿される
 ```
 
@@ -165,7 +214,7 @@ vendor 別の使い分け:
 | `VALID_DEFER` | `prr resolve` (body: 「Tracked in #`<issue>`」) | `prr reply` (Tracked in #`<issue>`) | `prr reply` (Tracked in #`<issue>`) |
 | `DUPLICATE` | `prr resolve` (body: 「Already addressed by `<other-thread-url>`」) | `prr reply` (Already addressed by ...) | 同左 |
 
-**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。
+**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。この規律は運用 (書き手の注意) だけに頼らず、`resolve_thread.sh` 自身が `classification` 引数に `INVALID_PUSH` を渡された時点で非ゼロ exit するガードとして実装されている。
 
 返信本文の最低構成 (INVALID_PUSH の例):
 
@@ -217,6 +266,27 @@ bash "${CLAUDE_SKILL_DIR}/scripts/prr" summary <PR> <body-file>
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" wait-ci <PR>   # 全 check 完了まで block、fail なら ci-self-heal に渡す
 ```
 
+### 待機委譲時の規律 (end_turn 禁止)
+
+`wait-ci` はブロッキング呼び出しだが、長時間 CI を `Monitor` 等のバックグラウンド監視に委譲したくなる場面がある。**委譲した直後に end_turn してはならない** — 誰も再開しないまま放置される実例が起きている (待機委譲後 50 分放置)。
+
+- 同一ターン内で `wait-ci` (または委譲した監視) の完了 (pass/fail) まで確認できるなら、そのまま最終報告に進む。
+- 同一ターン内で完結できない場合、最終報告の代わりに **`WAITING` verdict を明示的に返す**:
+  - 現在までの進捗 (Fixed / Pushback / Deferred / Duplicate の内訳)
+  - 何を待っているか (CI の残り check / 追加レビュー等)
+  - 再開条件 (checks 完了、新規コメント等) と再開方法 (呼び出し元がポーリングするか、`pr-monitor` 等に引き継ぐか)
+  - `WAITING` を返したターンで end_turn してよいのは、「実行環境前提」表の対話ローカル / ヘッドレス subagent のように **`WAITING` を受け取る相手が存在する場合のみ**
+- 受け取る相手がいない (CI / スケジュール起動の無人実行) 場合は `WAITING` で止めない。代わりに次を実行してから終える:
+
+```bash
+# body-file は loop-escalation:v1 形式 (issue-driven-development skill と共通の規約):
+# 自由文の状況説明 + <!-- loop-escalation:v1 --> に続く JSON
+#   {"reason": "...", "detail": "...", "attempts": <n>, "session_id": "...", "next_action_hint": "..."}
+# reason は budget-exceeded / max-turns / ci-3-fail / review-5-rounds / no-progress /
+# ambiguous-issue / repo-unresolvable / conflict / security-block / other から選ぶ
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" escalate <PR> <reason> <body-file>
+```
+
 ---
 
 ## 出力フォーマット
@@ -266,8 +336,10 @@ PR 作者本人 (= 自分) のコメントは fetcher 側ではフィルタし�
 
 - **集約サマリコメント 1 件** (`prr summary` 経由で PR の issue comment として投稿、毎回新規、過去サマリは履歴として残す)
 - **inline thread への返信文字列** (`prr reply` / `prr resolve` 経由、vendor 別フォーマット)
-- **修正コミット列** (commit message に `Refs: <thread-url>` を含む)
-- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造)
+- **修正コミット列 + push** (commit message に `Refs: <thread-url>` を含み、Phase C 終端で push 済み)
+- **フォロー issue** (`VALID_DEFER` 判定時のみ、`prr defer` 経由で作成)
+- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造、または `WAITING` verdict)
+- **`needs-human` ラベル + エスカレーションコメント** (無人実行で `WAITING` の受け手がいない場合のみ、`prr escalate` 経由)
 
 ### 出力しない成果物
 

--- a/.claude/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
+++ b/.claude/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
@@ -1,20 +1,20 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"CodeRabbit 指摘対応は主機能"}
-{"id":"t02","predicted":true,"actual":true,"reason":"レビューコメント対応の直接要請"}
-{"id":"t03","predicted":true,"actual":true,"reason":"Devin 指摘対応を明示列挙"}
-{"id":"t04","predicted":true,"actual":true,"reason":"PR 指摘を捌く = 「PR のコメント全部捌いて」に一致"}
-{"id":"t05","predicted":true,"actual":true,"reason":"人間レビュアーの新規コメント対応を明示"}
-{"id":"t06","predicted":true,"actual":true,"reason":"PR コメント対応文脈"}
-{"id":"t07","predicted":true,"actual":true,"reason":"指摘対応の口語形"}
-{"id":"t08","predicted":true,"actual":true,"reason":"resolve 運用は本スキルの手順"}
-{"id":"t09","predicted":true,"actual":true,"reason":"review feedback = レビューコメント"}
-{"id":"t10","predicted":true,"actual":true,"reason":"PR コメント片付け"}
-{"id":"t11","predicted":false,"actual":false,"reason":"PR 起票前は code-review (「既にレビュー済みの PR に後追い」の明示)"}
-{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal。push 直後トリガはスレッド対応であり CI 修理ではない"}
-{"id":"t13","predicted":false,"actual":false,"reason":"tdd の領域"}
-{"id":"t14","predicted":false,"actual":false,"reason":"design-review の領域"}
-{"id":"t15","predicted":false,"actual":false,"reason":"test-review の領域"}
-{"id":"t16","predicted":false,"actual":false,"reason":"レビュー実行は範囲外を明示"}
-{"id":"t17","predicted":false,"actual":false,"reason":"概念照会"}
-{"id":"t18","predicted":false,"actual":false,"reason":"自分発コメントの追加は対応ではない"}
-{"id":"t19","predicted":true,"actual":true,"reason":"「push した直後」「push したのでスレッド対応して」を新規に明示列挙"}
-{"id":"t20","predicted":true,"actual":true,"reason":"再 push 後のスレッド終端 = 「未解決スレッドが残る PR を離れる前に必ず一度起動」"}
+{"id":"t01","predicted":true,"actual":true,"reason":"description が明示する「コードラビット対応」の要請文言に直接一致"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「レビューコメント対応して」= description の「レビュー対応して」「コメント見て対応して」に一致"}
+{"id":"t03","predicted":true,"actual":true,"reason":"description が明示する「Devin の指摘片付けて」に直接一致"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「PR の指摘を捌く」= description の「PR のコメント全部捌いて」相当"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「人間レビュアーが新規コメントを残した時...必ず起動」に該当"}
+{"id":"t06","predicted":true,"actual":true,"reason":"PR + コメント在中の文脈は「新規コメントを残した時」の検知条件に含まれる"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「指摘」は指摘対応の口語表現、対応依頼と読める"}
+{"id":"t08","predicted":true,"actual":true,"reason":"CodeRabbit thread の resolve 運用は本スキルの Phase D/E の手順そのもの"}
+{"id":"t09","predicted":true,"actual":true,"reason":"「review feedback」= レビューコメントの言い換えで description の起動条件に該当"}
+{"id":"t10","predicted":true,"actual":true,"reason":"「PR にコメントいっぱいついてる、片付けて」は「PR のコメント全部捌いて」とほぼ同義"}
+{"id":"t11","predicted":false,"actual":false,"reason":"「PR 出す前」は code-review の領域。description は「既にレビュー済みの PR に後追いで対応する」と明示し PR 起票前を除外"}
+{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal の領域。description に CI 修理への言及は無い"}
+{"id":"t13","predicted":false,"actual":false,"reason":"テスト新規作成は tdd の領域、レビューコメント対応ではない"}
+{"id":"t14","predicted":false,"actual":false,"reason":"設計レビューは design-review の領域、PR コメント対応ではない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"テストコードレビューは test-review の領域"}
+{"id":"t16","predicted":false,"actual":false,"reason":"description が「レビュー自体を実行することはしない」と明示的に除外"}
+{"id":"t17","predicted":false,"actual":false,"reason":"PR の概念説明は対応作業ではない"}
+{"id":"t18","predicted":false,"actual":false,"reason":"自分発のコメント追加は既存指摘への対応ではない"}
+{"id":"t19","predicted":true,"actual":true,"reason":"description が明示する「既存 PR ブランチへ push した直後 (レビュー対応後の再 push を含む)」に直接一致"}
+{"id":"t20","predicted":true,"actual":true,"reason":"「push したのでスレッド対応して」+「未解決スレッドが残る PR を離れる前に必ず一度起動する」に該当"}

--- a/.claude/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/.claude/skills/pr-review-respond/scripts/defer_issue.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a follow-up issue for a VALID_DEFER review-thread classification.
+#
+# Usage:
+#   defer_issue.sh <pr-number> <thread-url> <title> <body-file>
+#
+# body-file should contain the caller's own summary of the finding plus the
+# 1-line reason it's out of scope for this PR. This script appends a fixed
+# footer linking back to the PR and the original review thread, so a
+# `Tracked in #<issue>` reply is always traceable to its source even if the
+# caller forgets to include the link.
+#
+# stdout: "<issue-number> <issue-url>"
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <pr-number> <thread-url> <title> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+thread_url="$2"
+title="$3"
+body_file="$4"
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+owner=$(gh repo view --json owner --jq '.owner.login')
+repo=$(gh repo view --json name --jq '.name')
+pr_url=$(gh pr view "$pr" --json url --jq '.url')
+
+body=$(cat "$body_file")
+full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
+
+resp=$(gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$owner/$repo/issues" \
+  -f title="$title" \
+  -f body="$full_body")
+
+jq -r '"\(.number) \(.html_url)"' <<<"$resp"

--- a/.claude/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/.claude/skills/pr-review-respond/scripts/defer_issue.sh
@@ -33,6 +33,24 @@ owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')
 pr_url=$(gh pr view "$pr" --json url --jq '.url')
 
+# Retry-safe: a prior invocation for this exact thread may have already
+# created the follow-up issue (e.g. this step succeeded but a later step in
+# the caller's flow failed and the whole defer sequence got re-run). Search
+# existing issues (any state) whose body already contains this thread_url
+# before creating a new one, so retries don't leave duplicate tracking
+# issues behind. This is best-effort: GitHub's search index can lag a few
+# seconds behind issue creation, so an immediate retry could still race it.
+search_json=$(gh search issues --repo "$owner/$repo" --match body "$thread_url" \
+  --json number,url,body --limit 10)
+existing=$(jq -r --arg url "$thread_url" \
+  '[.[] | select(.body | contains($url))][0] | if . == null then "" else "\(.number) \(.url)" end' \
+  <<<"$search_json")
+
+if [ -n "$existing" ]; then
+  echo "$existing"
+  exit 0
+fi
+
 body=$(cat "$body_file")
 full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
 

--- a/.claude/skills/pr-review-respond/scripts/escalate.sh
+++ b/.claude/skills/pr-review-respond/scripts/escalate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Unattended fallback for Phase E: label the PR `needs-human` and post a
+# structured escalation comment. Use this ONLY when there is no caller left
+# to hand a WAITING verdict to (headless CI / scheduled run). In an
+# interactive session or a subagent dispatched by another skill, return
+# WAITING instead — see skills/pr-review-respond/SKILL.md Phase E.
+#
+# Usage:
+#   escalate.sh <pr-number> <reason> <body-file>
+#
+# reason: one of budget-exceeded max-turns ci-3-fail review-5-rounds
+#         no-progress ambiguous-issue repo-unresolvable conflict
+#         security-block other
+#         (same taxonomy as skills/issue-driven-development/SKILL.md, so
+#         downstream tooling that greps for these reasons keeps working.)
+#
+# body-file: free-text situation summary, expected to end with the
+#   loop-escalation:v1 marker and JSON block:
+#     <!-- loop-escalation:v1 -->
+#     {"reason": "...", "detail": "...", "attempts": <n>, ...}
+#   This script does not construct that JSON itself — the caller fills in
+#   attempts/session_id/next_action_hint because only the caller knows them.
+
+set -euo pipefail
+
+valid_reasons="budget-exceeded max-turns ci-3-fail review-5-rounds no-progress ambiguous-issue repo-unresolvable conflict security-block other"
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <pr-number> <reason> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+reason="$2"
+body_file="$3"
+
+case " $valid_reasons " in
+  *" $reason "*)
+    ;;
+  *)
+    echo "error: unknown reason: $reason (expected one of: $valid_reasons)" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+gh pr edit "$pr" --add-label needs-human >/dev/null
+
+gh pr comment "$pr" --body-file "$body_file"

--- a/.claude/skills/pr-review-respond/scripts/escalate.sh
+++ b/.claude/skills/pr-review-respond/scripts/escalate.sh
@@ -48,6 +48,15 @@ if [ ! -f "$body_file" ]; then
   exit 2
 fi
 
-gh pr edit "$pr" --add-label needs-human >/dev/null
-
+# Post the escalation comment first. It is the only human-visible signal in
+# an unattended run, so it must not be blocked by the label step:
+# `needs-human` may not exist yet in every consumer repo, and under
+# `set -e` a failing `gh pr edit --add-label` would previously abort before
+# the comment was ever posted. Labeling is now best-effort and non-fatal —
+# if it fails (missing label, permissions, etc.) we warn to stderr but still
+# exit 0, because the comment (the actual escalation) already succeeded.
 gh pr comment "$pr" --body-file "$body_file"
+
+if ! gh pr edit "$pr" --add-label needs-human >/dev/null 2>&1; then
+  echo "warning: failed to add 'needs-human' label (it may not exist in this repo); escalation comment was posted regardless" >&2
+fi

--- a/.claude/skills/pr-review-respond/scripts/prr
+++ b/.claude/skills/pr-review-respond/scripts/prr
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Force plain output even when the calling shell/CI forces ANSI color
+# (e.g. CLICOLOR_FORCE=1). `gh ... --json` must stay parseable by `jq`;
+# color codes embedded in JSON break every downstream subcommand.
+export NO_COLOR=1
+export CLICOLOR_FORCE=0
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {

--- a/.claude/skills/pr-review-respond/scripts/prr
+++ b/.claude/skills/pr-review-respond/scripts/prr
@@ -16,6 +16,16 @@
 #   command string. With per-script invocation we'd need a separate rule per
 #   script and per install path. Routing every action through a single `prr`
 #   entry point lets a single rule (`Bash(bash *prr *)`) cover everything.
+#
+# Why the per-action scripts are dispatched via `exec bash "<script>"`
+# instead of `exec "<script>"`:
+#   Rulesync-generated mirrors (e.g. the Codex `.agents/` distribution) are
+#   committed without the executable bit, since rulesync's writer does not
+#   preserve source file permissions. Invoking the target file directly
+#   would exit 126 ("Permission denied") from that mirror even though the
+#   file itself is valid. Explicitly running it through `bash` sidesteps the
+#   executable bit entirely and works from any mirror regardless of how it
+#   was materialized.
 
 set -euo pipefail
 
@@ -49,25 +59,25 @@ shift || true
 
 case "$cmd" in
   fetch)
-    exec "$SCRIPT_DIR/fetch_threads.sh" "$@"
+    exec bash "$SCRIPT_DIR/fetch_threads.sh" "$@"
     ;;
   reply)
-    exec "$SCRIPT_DIR/reply_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/reply_thread.sh" "$@"
     ;;
   resolve)
-    exec "$SCRIPT_DIR/resolve_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/resolve_thread.sh" "$@"
     ;;
   summary)
-    exec "$SCRIPT_DIR/post_summary.sh" "$@"
+    exec bash "$SCRIPT_DIR/post_summary.sh" "$@"
     ;;
   wait-ci)
-    exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    exec bash "$SCRIPT_DIR/wait_ci.sh" "$@"
     ;;
   defer)
-    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    exec bash "$SCRIPT_DIR/defer_issue.sh" "$@"
     ;;
   escalate)
-    exec "$SCRIPT_DIR/escalate.sh" "$@"
+    exec bash "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/.claude/skills/pr-review-respond/scripts/prr
+++ b/.claude/skills/pr-review-respond/scripts/prr
@@ -3,11 +3,13 @@
 # Dispatches to per-action scripts in this same directory.
 #
 # Usage:
-#   prr fetch   <pr-number>
-#   prr reply   <pr-number> <root-comment-id> <body-file>
-#   prr resolve <pr-number> <root-comment-id> [body-file]
-#   prr summary <pr-number> <body-file>
-#   prr wait-ci <pr-number> [interval-seconds]
+#   prr fetch    <pr-number>
+#   prr reply    <pr-number> <root-comment-id> <body-file>
+#   prr resolve  <pr-number> <root-comment-id> <classification> [body-file]
+#   prr summary  <pr-number> <body-file>
+#   prr wait-ci  <pr-number> [interval-seconds]
+#   prr defer    <pr-number> <thread-url> <title> <body-file>
+#   prr escalate <pr-number> <reason> <body-file>
 #
 # Why this wrapper exists:
 #   Claude Code permission rules (`allowed-tools`) match against the literal
@@ -24,11 +26,13 @@ usage() {
 prr — pr-review-respond entry point
 
 Usage:
-  prr fetch   <pr>
-  prr reply   <pr> <root-comment-id> <body-file>
-  prr resolve <pr> <root-comment-id> [body-file]
-  prr summary <pr> <body-file>
-  prr wait-ci <pr> [interval-sec]
+  prr fetch    <pr>
+  prr reply    <pr> <root-comment-id> <body-file>
+  prr resolve  <pr> <root-comment-id> <classification> [body-file]
+  prr summary  <pr> <body-file>
+  prr wait-ci  <pr> [interval-sec]
+  prr defer    <pr> <thread-url> <title> <body-file>
+  prr escalate <pr> <reason> <body-file>
 
 All subcommands shell out to <scripts-dir>/<action>_*.sh.
 EOF
@@ -52,6 +56,12 @@ case "$cmd" in
     ;;
   wait-ci)
     exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    ;;
+  defer)
+    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    ;;
+  escalate)
+    exec "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/.claude/skills/pr-review-respond/scripts/resolve_thread.sh
+++ b/.claude/skills/pr-review-respond/scripts/resolve_thread.sh
@@ -4,26 +4,45 @@
 # directive and flips the thread state.
 #
 # Usage:
-#   resolve_thread.sh <pr-number> <root-comment-id> [body-file]
+#   resolve_thread.sh <pr-number> <root-comment-id> <classification> [body-file]
+#
+# classification must be one of: VALID VALID_DEFER DUPLICATE.
+#
+# Guard: INVALID_PUSH is REJECTED (non-zero exit, no API call made). Resolving
+# an INVALID_PUSH thread would tell the reviewer "fixed" when we actually
+# pushed back — this guard makes that misuse fail loudly instead of relying
+# on the caller to remember the rule (skills/pr-review-respond/SKILL.md
+# Phase D).
 #
 # If body-file is omitted, the reply is just `@coderabbitai resolve`. When
 # given, body-file content is concatenated BEFORE the directive line, so the
 # caller can include "Fixed in <SHA>" / "Tracked in #N" etc.
-#
-# Important: this script is intended for VALID / VALID_DEFER / DUPLICATE
-# classifications only. Do NOT call it for INVALID_PUSH (we leave reviewer
-# the right to re-open).
 
 set -euo pipefail
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-  echo "usage: $0 <pr-number> <root-comment-id> [body-file]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: $0 <pr-number> <root-comment-id> <classification> [body-file]" >&2
   exit 2
 fi
 
 pr="$1"
 comment_id="$2"
-body_file="${3:-}"
+classification="$3"
+body_file="${4:-}"
+
+case "$classification" in
+  VALID|VALID_DEFER|DUPLICATE)
+    ;;
+  INVALID_PUSH)
+    echo "error: refusing to resolve thread $comment_id on PR $pr: classification is INVALID_PUSH." >&2
+    echo "       INVALID_PUSH threads must stay open (reply only, never resolve)." >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unknown classification: $classification (expected VALID|VALID_DEFER|DUPLICATE|INVALID_PUSH)" >&2
+    exit 2
+    ;;
+esac
 
 owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')

--- a/skills/pr-review-respond/SKILL.md
+++ b/skills/pr-review-respond/SKILL.md
@@ -11,6 +11,8 @@ claudecode:
     - Bash(git commit *)
     - Bash(git diff *)
     - Bash(git log *)
+    - Bash(git push *)
+    - Bash(git rev-parse *)
     - Bash(git status *)
     - Bash(jq *)
     - Task
@@ -25,6 +27,20 @@ CodeRabbit / Devin / 人間レビュアーが残したコメントを **盲信�
 - **verify-before-implement** — 妥当性を AI が一次判定してから手を動かす。`receiving-code-review` 系の規律を取り込む。
 - **pushback はコメントのみ** — INVALID と判定したものは根拠を書くだけで resolve しない。reviewer の最終判断余地を残す。
 - **トレーサビリティは PR 集約コメント 1 本に集約** — ローカルログは作らない。後から PR を見れば全てわかる状態にする。
+
+---
+
+## 実行環境前提
+
+本スキルは 3 つの実行環境で起動しうる。**待機や中断の扱いが環境ごとに違う**ため、起動時にどの環境かを意識する:
+
+| 環境 | 特徴 | 待機や行き詰まりの扱い |
+|---|---|---|
+| 対話ローカルセッション | 画面前に人間がいる | Phase E の `WAITING` verdict をそのまま人間に返してよい |
+| ヘッドレス subagent (`shipping` 等からの dispatch) | 呼び出し元 skill/agent がいる | `WAITING` verdict を呼び出し元に返す。呼び出し元が再開の責任を持つ |
+| CI / スケジュール起動 (無人実行) | `WAITING` を受け取る相手がいない | **`WAITING` で止めない**。`needs-human` ラベル付与 + 構造化コメント (`prr escalate`、後述) を必須のフォールバックとする |
+
+いずれの環境でも共通の規律は Phase E で扱う「待機委譲時の end_turn 禁止」。
 
 ---
 
@@ -44,7 +60,9 @@ scripts/
 ├── reply_thread.sh      # prr reply
 ├── resolve_thread.sh    # prr resolve
 ├── post_summary.sh      # prr summary
-└── wait_ci.sh           # prr wait-ci
+├── wait_ci.sh           # prr wait-ci
+├── defer_issue.sh       # prr defer
+└── escalate.sh          # prr escalate
 ```
 
 ### Subcommand 一覧
@@ -55,9 +73,11 @@ scripts/
 |---|---|
 | `prr fetch <PR>` | 全 review thread + PR 一般コメントを GraphQL + REST で取得し、vendor 判定 (`coderabbit` / `devin` / `human`) と `self_replied` フラグを付けた正規化 JSON を stdout に出力 |
 | `prr reply <PR> <comment-id> <body-file>` | 正しい `/repos/{O}/{R}/pulls/{PR}/comments/{id}/replies` エンドポイントで返信投稿。本文は file 経由で multi-line / 引用符事故を防ぐ |
-| `prr resolve <PR> <comment-id> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。VALID / VALID_DEFER / DUPLICATE 専用 (INVALID_PUSH では呼ばない) |
+| `prr resolve <PR> <comment-id> <classification> [body-file]` | `body + @coderabbitai resolve` を投稿し thread を resolve。`classification` は `VALID` / `VALID_DEFER` / `DUPLICATE` のみ許可。**`INVALID_PUSH` を渡すと非ゼロ exit で拒否する** (誤 resolve ガード、後述) |
 | `prr summary <PR> <body-file>` | 集約 Review Response Summary を **新規** issue comment として投稿 (毎回新規投稿、過去サマリは履歴として残す) |
 | `prr wait-ci <PR> [interval]` | `gh pr checks --watch` をラップし全 check 完了まで block。失敗時は exit 非ゼロで呼出側に通知 (本スキルは retry しない) |
+| `prr defer <PR> <thread-url> <title> <body-file>` | `VALID_DEFER` 判定のフォロー issue を作成し、`<issue-number> <issue-url>` を stdout に出力。本文に元スレッド URL と PR URL を自動付記する |
+| `prr escalate <PR> <reason> <body-file>` | 無人実行で `WAITING` を返す相手がいない時のフォールバック。PR に `needs-human` ラベルを付け、`body-file` を構造化コメントとして投稿する |
 
 スクリプト本体は最小依存 (`gh`, `jq`, `bash`) のみ前提。Python / Node 等は使わない。
 
@@ -131,6 +151,33 @@ Refs: https://github.com/<owner>/<repo>/pull/<n>#discussion_r<id>
 
 **Devin の re-review は commit push に任せる**。`@devin` メンションでの再依頼はしない（push を検知して自動再評価するため）。
 
+### Phase C 終端 — push (省略禁止)
+
+commit を当てただけでは GitHub 上の PR は古い HEAD のままで、CI もレビュー bot もそれを見ている。**Phase D / E に進む前に必ず push する**:
+
+```bash
+git push origin <branch>
+git rev-parse HEAD   # push した SHA を記録し、以降の "Fixed in <SHA>" 返信に使う
+```
+
+- push を省略すると `prr wait-ci` が古い HEAD の CI 結果を見て「完了」と誤判定する。Devin の自動 re-review も push が trigger のため起動しない。
+- push が rejected / diverged で失敗したら、原因 (force-push 済みの remote など) を解消してから再 push する。**push が成功したことを確認した SHA でのみ** Phase D 以降に進む。
+- 複数 commit をまとめて 1 回だけ push してよい。commit ごとの push は必須ではない。
+
+### VALID_DEFER — フォロー issue 作成
+
+`VALID_DEFER` は「妥当だがスコープ外」の判定であり、返信 (Phase D) で `Tracked in #<issue>` と書く以上、その issue は **返信より前に実在していなければならない**。
+
+```bash
+# body-file には指摘の要約 (自分の言葉で) + スコープ外と判断した理由を書く
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" defer <PR> <thread-url> "<title>" <body-file>
+# stdout: "<issue-number> <issue-url>"
+```
+
+- **タイトル規約**: 指摘内容を要約した命令形 1 行 (例: `Extract retry policy into shared helper`)。skill 名等のプレフィックスは付けない。
+- **本文必須項目**: 指摘の要約、スコープ外と判断した理由 (1 文)。元スレッド URL と PR URL は `prr defer` が自動で付記する。
+- 生成された issue 番号を Phase D の返信 (`Tracked in #<issue>`) と Phase E のサマリ (`[<thread-url>] → #<issue>`) の両方に使う。
+
 ### Phase D — 返信 (reply)
 
 inline thread への返信は GitHub REST の `/replies` エンドポイントを使う必要がある (top-level review comment への返信のみ可、reply-to-reply は不可)。これも `prr` wrapper に閉じ込める。
@@ -140,7 +187,9 @@ inline thread への返信は GitHub REST の `/replies` エンドポイント�
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" reply <PR> <root-comment-id> <body-file>
 
 # CodeRabbit に「対応済み」を伝えて thread を resolve する場合 (VALID / VALID_DEFER / DUPLICATE のみ)
-bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> [body-file]
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" resolve <PR> <root-comment-id> <classification> [body-file]
+# classification は VALID / VALID_DEFER / DUPLICATE のいずれか。
+# INVALID_PUSH を渡すとスクリプトが非ゼロ exit で拒否する (誤 resolve ガード)。
 # body-file を渡すとその内容 + 改行 + "@coderabbitai resolve" が投稿される
 ```
 
@@ -153,7 +202,7 @@ vendor 別の使い分け:
 | `VALID_DEFER` | `prr resolve` (body: 「Tracked in #`<issue>`」) | `prr reply` (Tracked in #`<issue>`) | `prr reply` (Tracked in #`<issue>`) |
 | `DUPLICATE` | `prr resolve` (body: 「Already addressed by `<other-thread-url>`」) | `prr reply` (Already addressed by ...) | 同左 |
 
-**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。
+**重要**: `INVALID_PUSH` は **どのレビュアーに対しても resolve コマンドを発行しない** (`prr reply` のみ使用)。reviewer 側に「無視された」と取られる余地を消すため。この規律は運用 (書き手の注意) だけに頼らず、`resolve_thread.sh` 自身が `classification` 引数に `INVALID_PUSH` を渡された時点で非ゼロ exit するガードとして実装されている。
 
 返信本文の最低構成 (INVALID_PUSH の例):
 
@@ -205,6 +254,27 @@ bash "${CLAUDE_SKILL_DIR}/scripts/prr" summary <PR> <body-file>
 bash "${CLAUDE_SKILL_DIR}/scripts/prr" wait-ci <PR>   # 全 check 完了まで block、fail なら ci-self-heal に渡す
 ```
 
+### 待機委譲時の規律 (end_turn 禁止)
+
+`wait-ci` はブロッキング呼び出しだが、長時間 CI を `Monitor` 等のバックグラウンド監視に委譲したくなる場面がある。**委譲した直後に end_turn してはならない** — 誰も再開しないまま放置される実例が起きている (待機委譲後 50 分放置)。
+
+- 同一ターン内で `wait-ci` (または委譲した監視) の完了 (pass/fail) まで確認できるなら、そのまま最終報告に進む。
+- 同一ターン内で完結できない場合、最終報告の代わりに **`WAITING` verdict を明示的に返す**:
+  - 現在までの進捗 (Fixed / Pushback / Deferred / Duplicate の内訳)
+  - 何を待っているか (CI の残り check / 追加レビュー等)
+  - 再開条件 (checks 完了、新規コメント等) と再開方法 (呼び出し元がポーリングするか、`pr-monitor` 等に引き継ぐか)
+  - `WAITING` を返したターンで end_turn してよいのは、「実行環境前提」表の対話ローカル / ヘッドレス subagent のように **`WAITING` を受け取る相手が存在する場合のみ**
+- 受け取る相手がいない (CI / スケジュール起動の無人実行) 場合は `WAITING` で止めない。代わりに次を実行してから終える:
+
+```bash
+# body-file は loop-escalation:v1 形式 (issue-driven-development skill と共通の規約):
+# 自由文の状況説明 + <!-- loop-escalation:v1 --> に続く JSON
+#   {"reason": "...", "detail": "...", "attempts": <n>, "session_id": "...", "next_action_hint": "..."}
+# reason は budget-exceeded / max-turns / ci-3-fail / review-5-rounds / no-progress /
+# ambiguous-issue / repo-unresolvable / conflict / security-block / other から選ぶ
+bash "${CLAUDE_SKILL_DIR}/scripts/prr" escalate <PR> <reason> <body-file>
+```
+
 ---
 
 ## 出力フォーマット
@@ -254,8 +324,10 @@ PR 作者本人 (= 自分) のコメントは fetcher 側ではフィルタし�
 
 - **集約サマリコメント 1 件** (`prr summary` 経由で PR の issue comment として投稿、毎回新規、過去サマリは履歴として残す)
 - **inline thread への返信文字列** (`prr reply` / `prr resolve` 経由、vendor 別フォーマット)
-- **修正コミット列** (commit message に `Refs: <thread-url>` を含む)
-- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造)
+- **修正コミット列 + push** (commit message に `Refs: <thread-url>` を含み、Phase C 終端で push 済み)
+- **フォロー issue** (`VALID_DEFER` 判定時のみ、`prr defer` 経由で作成)
+- **ユーザ向け最終報告** (Stats / Commits / Pushback / CI / Summary URL の固定構造、または `WAITING` verdict)
+- **`needs-human` ラベル + エスカレーションコメント** (無人実行で `WAITING` の受け手がいない場合のみ、`prr escalate` 経由)
 
 ### 出力しない成果物
 

--- a/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
+++ b/skills/pr-review-respond/evals/pr-review-respond-trigger-results-2026-07-06.jsonl
@@ -1,20 +1,20 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"CodeRabbit 指摘対応は主機能"}
-{"id":"t02","predicted":true,"actual":true,"reason":"レビューコメント対応の直接要請"}
-{"id":"t03","predicted":true,"actual":true,"reason":"Devin 指摘対応を明示列挙"}
-{"id":"t04","predicted":true,"actual":true,"reason":"PR 指摘を捌く = 「PR のコメント全部捌いて」に一致"}
-{"id":"t05","predicted":true,"actual":true,"reason":"人間レビュアーの新規コメント対応を明示"}
-{"id":"t06","predicted":true,"actual":true,"reason":"PR コメント対応文脈"}
-{"id":"t07","predicted":true,"actual":true,"reason":"指摘対応の口語形"}
-{"id":"t08","predicted":true,"actual":true,"reason":"resolve 運用は本スキルの手順"}
-{"id":"t09","predicted":true,"actual":true,"reason":"review feedback = レビューコメント"}
-{"id":"t10","predicted":true,"actual":true,"reason":"PR コメント片付け"}
-{"id":"t11","predicted":false,"actual":false,"reason":"PR 起票前は code-review (「既にレビュー済みの PR に後追い」の明示)"}
-{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal。push 直後トリガはスレッド対応であり CI 修理ではない"}
-{"id":"t13","predicted":false,"actual":false,"reason":"tdd の領域"}
-{"id":"t14","predicted":false,"actual":false,"reason":"design-review の領域"}
-{"id":"t15","predicted":false,"actual":false,"reason":"test-review の領域"}
-{"id":"t16","predicted":false,"actual":false,"reason":"レビュー実行は範囲外を明示"}
-{"id":"t17","predicted":false,"actual":false,"reason":"概念照会"}
-{"id":"t18","predicted":false,"actual":false,"reason":"自分発コメントの追加は対応ではない"}
-{"id":"t19","predicted":true,"actual":true,"reason":"「push した直後」「push したのでスレッド対応して」を新規に明示列挙"}
-{"id":"t20","predicted":true,"actual":true,"reason":"再 push 後のスレッド終端 = 「未解決スレッドが残る PR を離れる前に必ず一度起動」"}
+{"id":"t01","predicted":true,"actual":true,"reason":"description が明示する「コードラビット対応」の要請文言に直接一致"}
+{"id":"t02","predicted":true,"actual":true,"reason":"「レビューコメント対応して」= description の「レビュー対応して」「コメント見て対応して」に一致"}
+{"id":"t03","predicted":true,"actual":true,"reason":"description が明示する「Devin の指摘片付けて」に直接一致"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「PR の指摘を捌く」= description の「PR のコメント全部捌いて」相当"}
+{"id":"t05","predicted":true,"actual":true,"reason":"「人間レビュアーが新規コメントを残した時...必ず起動」に該当"}
+{"id":"t06","predicted":true,"actual":true,"reason":"PR + コメント在中の文脈は「新規コメントを残した時」の検知条件に含まれる"}
+{"id":"t07","predicted":true,"actual":true,"reason":"「指摘」は指摘対応の口語表現、対応依頼と読める"}
+{"id":"t08","predicted":true,"actual":true,"reason":"CodeRabbit thread の resolve 運用は本スキルの Phase D/E の手順そのもの"}
+{"id":"t09","predicted":true,"actual":true,"reason":"「review feedback」= レビューコメントの言い換えで description の起動条件に該当"}
+{"id":"t10","predicted":true,"actual":true,"reason":"「PR にコメントいっぱいついてる、片付けて」は「PR のコメント全部捌いて」とほぼ同義"}
+{"id":"t11","predicted":false,"actual":false,"reason":"「PR 出す前」は code-review の領域。description は「既にレビュー済みの PR に後追いで対応する」と明示し PR 起票前を除外"}
+{"id":"t12","predicted":false,"actual":false,"reason":"CI 修復は ci-self-heal の領域。description に CI 修理への言及は無い"}
+{"id":"t13","predicted":false,"actual":false,"reason":"テスト新規作成は tdd の領域、レビューコメント対応ではない"}
+{"id":"t14","predicted":false,"actual":false,"reason":"設計レビューは design-review の領域、PR コメント対応ではない"}
+{"id":"t15","predicted":false,"actual":false,"reason":"テストコードレビューは test-review の領域"}
+{"id":"t16","predicted":false,"actual":false,"reason":"description が「レビュー自体を実行することはしない」と明示的に除外"}
+{"id":"t17","predicted":false,"actual":false,"reason":"PR の概念説明は対応作業ではない"}
+{"id":"t18","predicted":false,"actual":false,"reason":"自分発のコメント追加は既存指摘への対応ではない"}
+{"id":"t19","predicted":true,"actual":true,"reason":"description が明示する「既存 PR ブランチへ push した直後 (レビュー対応後の再 push を含む)」に直接一致"}
+{"id":"t20","predicted":true,"actual":true,"reason":"「push したのでスレッド対応して」+「未解決スレッドが残る PR を離れる前に必ず一度起動する」に該当"}

--- a/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/skills/pr-review-respond/scripts/defer_issue.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a follow-up issue for a VALID_DEFER review-thread classification.
+#
+# Usage:
+#   defer_issue.sh <pr-number> <thread-url> <title> <body-file>
+#
+# body-file should contain the caller's own summary of the finding plus the
+# 1-line reason it's out of scope for this PR. This script appends a fixed
+# footer linking back to the PR and the original review thread, so a
+# `Tracked in #<issue>` reply is always traceable to its source even if the
+# caller forgets to include the link.
+#
+# stdout: "<issue-number> <issue-url>"
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <pr-number> <thread-url> <title> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+thread_url="$2"
+title="$3"
+body_file="$4"
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+owner=$(gh repo view --json owner --jq '.owner.login')
+repo=$(gh repo view --json name --jq '.name')
+pr_url=$(gh pr view "$pr" --json url --jq '.url')
+
+body=$(cat "$body_file")
+full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
+
+resp=$(gh api -X POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$owner/$repo/issues" \
+  -f title="$title" \
+  -f body="$full_body")
+
+jq -r '"\(.number) \(.html_url)"' <<<"$resp"

--- a/skills/pr-review-respond/scripts/defer_issue.sh
+++ b/skills/pr-review-respond/scripts/defer_issue.sh
@@ -33,6 +33,24 @@ owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')
 pr_url=$(gh pr view "$pr" --json url --jq '.url')
 
+# Retry-safe: a prior invocation for this exact thread may have already
+# created the follow-up issue (e.g. this step succeeded but a later step in
+# the caller's flow failed and the whole defer sequence got re-run). Search
+# existing issues (any state) whose body already contains this thread_url
+# before creating a new one, so retries don't leave duplicate tracking
+# issues behind. This is best-effort: GitHub's search index can lag a few
+# seconds behind issue creation, so an immediate retry could still race it.
+search_json=$(gh search issues --repo "$owner/$repo" --match body "$thread_url" \
+  --json number,url,body --limit 10)
+existing=$(jq -r --arg url "$thread_url" \
+  '[.[] | select(.body | contains($url))][0] | if . == null then "" else "\(.number) \(.url)" end' \
+  <<<"$search_json")
+
+if [ -n "$existing" ]; then
+  echo "$existing"
+  exit 0
+fi
+
 body=$(cat "$body_file")
 full_body=$(printf '%s\n\nDeferred from PR %s review thread: %s\n' "$body" "$pr_url" "$thread_url")
 

--- a/skills/pr-review-respond/scripts/escalate.sh
+++ b/skills/pr-review-respond/scripts/escalate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Unattended fallback for Phase E: label the PR `needs-human` and post a
+# structured escalation comment. Use this ONLY when there is no caller left
+# to hand a WAITING verdict to (headless CI / scheduled run). In an
+# interactive session or a subagent dispatched by another skill, return
+# WAITING instead — see skills/pr-review-respond/SKILL.md Phase E.
+#
+# Usage:
+#   escalate.sh <pr-number> <reason> <body-file>
+#
+# reason: one of budget-exceeded max-turns ci-3-fail review-5-rounds
+#         no-progress ambiguous-issue repo-unresolvable conflict
+#         security-block other
+#         (same taxonomy as skills/issue-driven-development/SKILL.md, so
+#         downstream tooling that greps for these reasons keeps working.)
+#
+# body-file: free-text situation summary, expected to end with the
+#   loop-escalation:v1 marker and JSON block:
+#     <!-- loop-escalation:v1 -->
+#     {"reason": "...", "detail": "...", "attempts": <n>, ...}
+#   This script does not construct that JSON itself — the caller fills in
+#   attempts/session_id/next_action_hint because only the caller knows them.
+
+set -euo pipefail
+
+valid_reasons="budget-exceeded max-turns ci-3-fail review-5-rounds no-progress ambiguous-issue repo-unresolvable conflict security-block other"
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <pr-number> <reason> <body-file>" >&2
+  exit 2
+fi
+
+pr="$1"
+reason="$2"
+body_file="$3"
+
+case " $valid_reasons " in
+  *" $reason "*)
+    ;;
+  *)
+    echo "error: unknown reason: $reason (expected one of: $valid_reasons)" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$body_file" ]; then
+  echo "error: body file not found: $body_file" >&2
+  exit 2
+fi
+
+gh pr edit "$pr" --add-label needs-human >/dev/null
+
+gh pr comment "$pr" --body-file "$body_file"

--- a/skills/pr-review-respond/scripts/escalate.sh
+++ b/skills/pr-review-respond/scripts/escalate.sh
@@ -48,6 +48,15 @@ if [ ! -f "$body_file" ]; then
   exit 2
 fi
 
-gh pr edit "$pr" --add-label needs-human >/dev/null
-
+# Post the escalation comment first. It is the only human-visible signal in
+# an unattended run, so it must not be blocked by the label step:
+# `needs-human` may not exist yet in every consumer repo, and under
+# `set -e` a failing `gh pr edit --add-label` would previously abort before
+# the comment was ever posted. Labeling is now best-effort and non-fatal —
+# if it fails (missing label, permissions, etc.) we warn to stderr but still
+# exit 0, because the comment (the actual escalation) already succeeded.
 gh pr comment "$pr" --body-file "$body_file"
+
+if ! gh pr edit "$pr" --add-label needs-human >/dev/null 2>&1; then
+  echo "warning: failed to add 'needs-human' label (it may not exist in this repo); escalation comment was posted regardless" >&2
+fi

--- a/skills/pr-review-respond/scripts/prr
+++ b/skills/pr-review-respond/scripts/prr
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Force plain output even when the calling shell/CI forces ANSI color
+# (e.g. CLICOLOR_FORCE=1). `gh ... --json` must stay parseable by `jq`;
+# color codes embedded in JSON break every downstream subcommand.
+export NO_COLOR=1
+export CLICOLOR_FORCE=0
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {

--- a/skills/pr-review-respond/scripts/prr
+++ b/skills/pr-review-respond/scripts/prr
@@ -16,6 +16,16 @@
 #   command string. With per-script invocation we'd need a separate rule per
 #   script and per install path. Routing every action through a single `prr`
 #   entry point lets a single rule (`Bash(bash *prr *)`) cover everything.
+#
+# Why the per-action scripts are dispatched via `exec bash "<script>"`
+# instead of `exec "<script>"`:
+#   Rulesync-generated mirrors (e.g. the Codex `.agents/` distribution) are
+#   committed without the executable bit, since rulesync's writer does not
+#   preserve source file permissions. Invoking the target file directly
+#   would exit 126 ("Permission denied") from that mirror even though the
+#   file itself is valid. Explicitly running it through `bash` sidesteps the
+#   executable bit entirely and works from any mirror regardless of how it
+#   was materialized.
 
 set -euo pipefail
 
@@ -49,25 +59,25 @@ shift || true
 
 case "$cmd" in
   fetch)
-    exec "$SCRIPT_DIR/fetch_threads.sh" "$@"
+    exec bash "$SCRIPT_DIR/fetch_threads.sh" "$@"
     ;;
   reply)
-    exec "$SCRIPT_DIR/reply_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/reply_thread.sh" "$@"
     ;;
   resolve)
-    exec "$SCRIPT_DIR/resolve_thread.sh" "$@"
+    exec bash "$SCRIPT_DIR/resolve_thread.sh" "$@"
     ;;
   summary)
-    exec "$SCRIPT_DIR/post_summary.sh" "$@"
+    exec bash "$SCRIPT_DIR/post_summary.sh" "$@"
     ;;
   wait-ci)
-    exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    exec bash "$SCRIPT_DIR/wait_ci.sh" "$@"
     ;;
   defer)
-    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    exec bash "$SCRIPT_DIR/defer_issue.sh" "$@"
     ;;
   escalate)
-    exec "$SCRIPT_DIR/escalate.sh" "$@"
+    exec bash "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/skills/pr-review-respond/scripts/prr
+++ b/skills/pr-review-respond/scripts/prr
@@ -3,11 +3,13 @@
 # Dispatches to per-action scripts in this same directory.
 #
 # Usage:
-#   prr fetch   <pr-number>
-#   prr reply   <pr-number> <root-comment-id> <body-file>
-#   prr resolve <pr-number> <root-comment-id> [body-file]
-#   prr summary <pr-number> <body-file>
-#   prr wait-ci <pr-number> [interval-seconds]
+#   prr fetch    <pr-number>
+#   prr reply    <pr-number> <root-comment-id> <body-file>
+#   prr resolve  <pr-number> <root-comment-id> <classification> [body-file]
+#   prr summary  <pr-number> <body-file>
+#   prr wait-ci  <pr-number> [interval-seconds]
+#   prr defer    <pr-number> <thread-url> <title> <body-file>
+#   prr escalate <pr-number> <reason> <body-file>
 #
 # Why this wrapper exists:
 #   Claude Code permission rules (`allowed-tools`) match against the literal
@@ -24,11 +26,13 @@ usage() {
 prr — pr-review-respond entry point
 
 Usage:
-  prr fetch   <pr>
-  prr reply   <pr> <root-comment-id> <body-file>
-  prr resolve <pr> <root-comment-id> [body-file]
-  prr summary <pr> <body-file>
-  prr wait-ci <pr> [interval-sec]
+  prr fetch    <pr>
+  prr reply    <pr> <root-comment-id> <body-file>
+  prr resolve  <pr> <root-comment-id> <classification> [body-file]
+  prr summary  <pr> <body-file>
+  prr wait-ci  <pr> [interval-sec]
+  prr defer    <pr> <thread-url> <title> <body-file>
+  prr escalate <pr> <reason> <body-file>
 
 All subcommands shell out to <scripts-dir>/<action>_*.sh.
 EOF
@@ -52,6 +56,12 @@ case "$cmd" in
     ;;
   wait-ci)
     exec "$SCRIPT_DIR/wait_ci.sh" "$@"
+    ;;
+  defer)
+    exec "$SCRIPT_DIR/defer_issue.sh" "$@"
+    ;;
+  escalate)
+    exec "$SCRIPT_DIR/escalate.sh" "$@"
     ;;
   help|--help|-h)
     usage

--- a/skills/pr-review-respond/scripts/resolve_thread.sh
+++ b/skills/pr-review-respond/scripts/resolve_thread.sh
@@ -4,26 +4,45 @@
 # directive and flips the thread state.
 #
 # Usage:
-#   resolve_thread.sh <pr-number> <root-comment-id> [body-file]
+#   resolve_thread.sh <pr-number> <root-comment-id> <classification> [body-file]
+#
+# classification must be one of: VALID VALID_DEFER DUPLICATE.
+#
+# Guard: INVALID_PUSH is REJECTED (non-zero exit, no API call made). Resolving
+# an INVALID_PUSH thread would tell the reviewer "fixed" when we actually
+# pushed back — this guard makes that misuse fail loudly instead of relying
+# on the caller to remember the rule (skills/pr-review-respond/SKILL.md
+# Phase D).
 #
 # If body-file is omitted, the reply is just `@coderabbitai resolve`. When
 # given, body-file content is concatenated BEFORE the directive line, so the
 # caller can include "Fixed in <SHA>" / "Tracked in #N" etc.
-#
-# Important: this script is intended for VALID / VALID_DEFER / DUPLICATE
-# classifications only. Do NOT call it for INVALID_PUSH (we leave reviewer
-# the right to re-open).
 
 set -euo pipefail
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-  echo "usage: $0 <pr-number> <root-comment-id> [body-file]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: $0 <pr-number> <root-comment-id> <classification> [body-file]" >&2
   exit 2
 fi
 
 pr="$1"
 comment_id="$2"
-body_file="${3:-}"
+classification="$3"
+body_file="${4:-}"
+
+case "$classification" in
+  VALID|VALID_DEFER|DUPLICATE)
+    ;;
+  INVALID_PUSH)
+    echo "error: refusing to resolve thread $comment_id on PR $pr: classification is INVALID_PUSH." >&2
+    echo "       INVALID_PUSH threads must stay open (reply only, never resolve)." >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unknown classification: $classification (expected VALID|VALID_DEFER|DUPLICATE|INVALID_PUSH)" >&2
+    exit 2
+    ;;
+esac
 
 owner=$(gh repo view --json owner --jq '.owner.login')
 repo=$(gh repo view --json name --jq '.name')


### PR DESCRIPTION
## Summary

評価 workflow の実測で `pr-review-respond` skill に 5 件の blocking 欠陥が見つかった。すべて body / script レベルで修正した。

1. **push 欠落**: Phase C で修正 commit を当てた後の `git push` が allowed-tools にも本文手順にも無く、CI が古い HEAD に対して完了しうる
   → Phase C 終端に push ステップ (`git push` → `git rev-parse HEAD`) を明記。`allowed-tools` に `Bash(git push *)` / `Bash(git rev-parse *)` を追加
2. **VALID_DEFER に issue 作成手段が無い**
   → 新規サブコマンド `prr defer` (`scripts/defer_issue.sh`, `gh issue create` 相当を wrap) を追加し、返信 (`Tracked in #<issue>`) より前に issue を作る手順を明記
3. **`scripts/prr resolve` に INVALID_PUSH 誤 resolve 防止ガードが無い**
   → `resolve_thread.sh` に `classification` 引数を追加し、`INVALID_PUSH` を渡すと API 呼び出し前に非ゼロ exit で拒否
4. **待機委譲後の end_turn で誰も再開しない構造バグ** (実例: 50 分放置)
   → Phase E に「待機委譲時の end_turn 禁止」を追記。同一ターンで完結できなければ `WAITING` verdict を返す規律とし、受け手のいない無人実行では新規サブコマンド `prr escalate` (`needs-human` ラベル + `loop-escalation:v1` 構造化コメント) を使う
5. **実行環境前提が未記載**
   → 冒頭に「実行環境前提」節を追加 (対話ローカル / ヘッドレス subagent / CI・無人実行の 3 分岐)

## Changes

- `skills/pr-review-respond/SKILL.md`: 実行環境前提節、Phase C 終端 push 手順、VALID_DEFER issue 化手順、resolve ガードの言及、Phase E の待機規律を追加。allowed-tools に `git push` / `git rev-parse` を追加。500 行制限内 (349 行)
- `skills/pr-review-respond/scripts/prr`: `defer` / `escalate` サブコマンドをディスパッチに追加
- `skills/pr-review-respond/scripts/resolve_thread.sh`: `classification` 引数必須化 + `INVALID_PUSH` 拒否ガード
- `skills/pr-review-respond/scripts/defer_issue.sh` (新規): `VALID_DEFER` 用フォロー issue 作成
- `skills/pr-review-respond/scripts/escalate.sh` (新規): 無人実行フォールバック (`needs-human` ラベル + 構造化コメント)
- `.claude/skills/pr-review-respond/**`, `.agents/skills/pr-review-respond/**`: `node scripts/rulesync-sync.mjs` で再生成した rulesync mirror (`--check` pass 確認済み)

## Test plan

- [x] `bash -n` で全 script の構文チェック (`prr`, `resolve_thread.sh`, `defer_issue.sh`, `escalate.sh`)
- [x] `resolve_thread.sh` に `INVALID_PUSH` / 不正な classification を渡すと非ゼロ exit で API 呼び出し前に拒否することを確認
- [x] `escalate.sh` に不正な reason を渡すと非ゼロ exit で拒否することを確認
- [x] `node scripts/rulesync-sync.mjs` → `--check` が pass することを確認 (mirror 同期済み)
- [ ] 実 PR での end-to-end 動作確認 (issue 作成 / push / escalate) は本 PR のスコープ外 (ネットワーク環境が無い開発サンドボックスのため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2CFHmQZWEq7ib6T85hpuR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `defer` to create (or reuse) follow-up issues for deferred review threads, including a printed issue number/URL.
  * Added `escalate` fallback for unattended runs to add `needs-human` and post a structured escalation comment.
  * Expanded `resolve` to require a classification (`VALID`, `VALID_DEFER`, `DUPLICATE`).
* **Bug Fixes**
  * `resolve` now fails (non-zero exit) when given an invalid-push classification, preventing incorrect thread resolution.
* **Documentation**
  * Updated skill spec and command usage/contract details, including clarified waiting/turn-handling rules and updated `wait-ci` interval wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->