### PR TITLE
Fix pr-conflict-resolver blocking defects with deterministic scripts

### DIFF
--- a/.agents/skills/pr-conflict-resolver/SKILL.md
+++ b/.agents/skills/pr-conflict-resolver/SKILL.md
@@ -3,24 +3,64 @@ name: pr-conflict-resolver
 description: |
   GitHub PR で発生した merge conflict を自動修正するための手順とベストプラクティス。
   PR コメントで `@claude` 経由で呼ばれた conflict 解決タスクや、ローカルでの rebase / merge
-  conflict を解決するときに必ず参照する。チェックアウト → merge / rebase → conflict 解決 →
-  lock ファイル再生成 → テスト → push までの一連の安全な流れを定義する。
+  conflict を解決するときに必ず参照する。チェックアウト → merge → conflict 解決 →
+  lock ファイル再生成 → 検証 → commit で merge を確定 → push までの一連の安全な流れを、
+  同梱スクリプト (`scripts/*.sh`) の決定的な実行として定義する。
 ---
 # PR conflict resolver
 
 PR のターゲットブランチ (base) と head ブランチの間で発生した merge conflict を、機能を欠落させず
-安全に解決するための手順。Claude Code Action から呼び出される前提で、すべて非対話で完結すること。
+安全に解決するための手順。
+
+## 実行環境前提
+
+本スキルは **対話ローカル実行 / ヘッドレス実行 (Claude Code Action 等) の両方**で使う。
+呼び出し元が人間かどうかに関わらず、以降の手順は同一とする:
+
+- 判断が必要な分岐 (ソース conflict の統合方針、撤退判断) で**人間に質問して止まる設計にしない**。
+  ヘッドレスでは応答が来ないため、質問した時点でセッションが unattended のまま放置される。
+- 継続不能なときは 4 章「エスカレーション」の **`needs-human` ラベル + 構造化コメント**で停止する。
+  これは対話環境でも同じ挙動にする (人間に質問するのではなく、判断材料を残して停止し、人間の
+  タイミングでコメントを読んでもらう)。
+- 決定的な多段操作 (PR 情報抽出・merge 実行・lockfile 再生成・検証・push 前確定) は
+  すべて `scripts/*.sh` に閉じ込めてある。**フラグを追加したり、同等のコマンドを手で
+  組み立てて代替したりしない** — 実行者ごとの手順のブレをなくすための決定的スクリプトなので、
+  そのまま実行する。
+
+## 同梱スクリプトと権限
+
+```text
+scripts/
+├── pr-context.sh       # 0. PR 情報の取得
+├── resolve-merge.sh    # 2. base の merge 実行 + conflict 検出
+├── regen-lockfiles.sh  # 3. lockfile の再生成
+├── verify.sh           # 4. 検証チェーン
+└── finalize.sh         # 5. commit で merge 確定 → push 前チェック → push
+```
+
+| script | 役割 | exit code |
+|---|---|---|
+| `pr-context.sh <PR番号>` | `gh pr view --json` で `PR_NUMBER`/`PR_HEAD`/`PR_BASE`/`PR_TITLE`/`PR_URL`/`PR_HEAD_SHA` を `eval` 可能な `NAME=value` 形式で stdout に出力 | 0=成功、127=`gh`/`jq` 不在、1=PR 取得失敗、2=usage |
+| `resolve-merge.sh <base-branch>` | `origin/<base>` を `--no-ff --no-edit` で merge。stdout は conflict ファイル一覧のみ (git 自身の進捗メッセージは stderr に retarget 済み) | 0=conflict なし (merge 完了済み)、10=conflict あり (stdout に一覧)、その他=想定外の merge 失敗 |
+| `regen-lockfiles.sh <path...>` | 渡された各パスの basename でエコシステムを判定し `case` 文で再生成 (`package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` / `bun.lock(b)` / `Cargo.lock` / `poetry.lock` / `uv.lock` / `go.sum` / `Gemfile.lock`)。未知の lockfile は再生成せずエラー | 0=全件成功、1=1件以上失敗、2=usage |
+| `verify.sh` | repo 検出 (`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml`/`Makefile`) に応じて tsc/lint/test 等を実行。**`\|\| true` は使わない** — 各チェックの exit code をそのまま保持する | 0=全チェック PASS (未検出時も PASS 扱い)、1=1件以上 FAIL |
+| `finalize.sh <push-branch> <resolved-file...>` | conflict marker の残存チェック → `git add` → `git commit` で merge を確定 → push 前チェックリスト → `git push` | 0=push 完了、1=チェックリスト不通過または push 失敗、2=usage |
+
+`scripts/*.sh` は `bash "${CLAUDE_SKILL_DIR}/scripts/<name>.sh" <args>` で呼び出す。
+最小依存 (`bash`, `git`, `gh`, `jq`) のみを前提とし、Python/Node 等の追加ランタイムは使わない。
 
 ## 0. 前提情報の確認
 
-呼び出し元のコメントから以下を取得する:
+呼び出し元のコメントに PR 番号があればそれを使う。明示的な解決方針の指示 (例:「lock ファイルは
+theirs を採用」) があれば以降の手順より優先する。
 
-- **PR 番号** (`#N`)
-- **head ブランチ** (作業対象)
-- **base ブランチ** (merge 元)
-- 解決方針の明示的な指示があれば優先する (例: 「lock ファイルは theirs を採用」)
+`scripts/pr-context.sh <PR番号> を正確に実行。フラグ追加禁止。`
 
-不明な場合は `gh pr view <N> --json number,headRefName,baseRefName,title` で取得する。
+```bash
+eval "$(bash "${CLAUDE_SKILL_DIR}/scripts/pr-context.sh" <PR番号>)"
+```
+
+以降 `$PR_NUMBER` / `$PR_HEAD` / `$PR_BASE` / `$PR_TITLE` / `$PR_URL` / `$PR_HEAD_SHA` を使う。
 
 ## 1. ブランチをチェックアウト
 
@@ -31,47 +71,48 @@ git pull --ff-only origin "$PR_HEAD"
 ```
 
 `--ff-only` は他者の push を上書きしないための安全策。fast-forward できないときは
-push が走った可能性があるので一度 `git status` で状態を確認し、想定外であれば停止する。
+push が走った可能性があるので `git status` で状態を確認し、想定外であれば
+4 章の手順でエスカレーションする (無理に `--force` で追従しない)。
 
-## 2. base を merge
+## 2. base を merge して conflict を検出
 
-rebase ではなく **merge** を既定とする。理由:
+rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
+壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
+希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
 
-- PR の commit 履歴と署名 (Co-Authored-By 等) を壊さない
-- PR がレビュー中の場合、force-push は差分を見失わせるため避ける
-
-```bash
-merge_status=0
-git merge --no-ff --no-edit "origin/$PR_BASE" || merge_status=$?
-if [ "$merge_status" -ne 0 ]; then
-  if git diff --name-only --diff-filter=U | grep -q .; then
-    echo "merge conflict を検知。解決ステップへ進行。"
-  else
-    echo "merge が conflict 以外の理由で失敗。処理を中断。" >&2
-    exit "$merge_status"
-  fi
-fi
-```
-
-`|| true` で全エラーを握り潰すと、認証エラーや壊れた ref 等の異常時にも誤って
-解決処理へ進んでしまう。上記のように **conflict (未マージファイルあり) のときだけ継続**し、
-それ以外の非ゼロ終了は中断する。特別な指示で rebase を希望される場合のみ
-`git rebase origin/$PR_BASE` を選択する。
-
-## 3. conflict 箇所の特定
+`scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git diff --name-only --diff-filter=U
+bash "${CLAUDE_SKILL_DIR}/scripts/resolve-merge.sh" "$PR_BASE"
 ```
 
-ファイル種別別に処理戦略を切り替える:
+exit code で分岐する:
+
+- **0** — conflict なし。merge commit は作成済み。3〜4 章を飛ばして 5 章 (`finalize.sh`) へ進む。
+- **10** — conflict あり。stdout に conflict ファイル一覧 (1 行 1 ファイル) が出力される。
+  3 章に進んで各ファイルを解決する。
+- **それ以外** — 認証エラーや壊れた ref 等、merge conflict 以外の理由での失敗。
+  **conflict 解決フローに進まない**。4 章の手順でエスカレーションする。
+
+## 3. conflict 箇所を種別ごとに解決する
+
+`resolve-merge.sh` が出力した一覧をファイル種別で振り分ける:
 
 | ファイル種別 | 戦略 |
 |------------|------|
-| ソースコード | 後述「ソース conflict 解決ガイドライン」に従い手で解決 |
-| lock ファイル (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | conflict マーカーごと削除し、対応するパッケージマネージャで再生成 |
+| ソースコード | 下記「ソース conflict 解決ガイドライン」に従い Edit ツールで手で解決 |
+| lock ファイル (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock(b)`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | `scripts/regen-lockfiles.sh` に渡して再生成する (手で marker を編集しない) |
 | 生成物 (`dist/`, `build/`, `*.min.js`, snapshot) | `.gitignore` 漏れがないか確認した上で、可能ならビルドし直して上書き |
-| バイナリ | `git checkout --theirs` または `--ours` で base を採用するのが基本。理由をコメントで残す |
+| バイナリ | `git checkout --theirs <path>` または `--ours <path>` で base/head どちらかを採用。採用理由を最終コメントに残す |
+
+lock ファイルは `scripts/regen-lockfiles.sh を正確に実行。フラグ追加禁止。`
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile のパス...>
+```
+
+未知の lockfile 名 (`case` の `*)` 分岐) は再生成コマンドを推測せず失敗する。その場合は
+手動解決に切り替えるか、4 章の手順でエスカレーションする。
 
 ### ソース conflict 解決ガイドライン
 
@@ -79,66 +120,52 @@ git diff --name-only --diff-filter=U
 2. **関数/ブロック単位で統合**: 片側削除を安易に選ばない。同じ箇所への重複編集は **両方の機能を残す**
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
-5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で確認
+5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
+   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
-4 章「無理しない撤退判断」に従って PR にコメントしてエスカレーションする。
-
-### lock ファイルの再生成
-
-各エコシステムごとに対応コマンドが異なる:
-
-```bash
-# package-lock.json
-rm -f package-lock.json && npm install --package-lock-only --ignore-scripts
-
-# pnpm
-rm -f pnpm-lock.yaml && pnpm install --lockfile-only --ignore-scripts
-
-# yarn (berry / classic で挙動が違うので存在するコマンドを使う)
-rm -f yarn.lock && yarn install --mode update-lockfile 2>/dev/null || yarn install --ignore-scripts
-
-# bun
-rm -f bun.lock bun.lockb && bun install --frozen-lockfile=false --ignore-scripts
-
-# Cargo
-cargo update --workspace --offline 2>/dev/null || cargo generate-lockfile
-
-# uv
-uv lock
-
-# poetry
-poetry lock --no-update
-
-# go
-go mod tidy
-```
-
-`--ignore-scripts` を付けるのは untrusted な postinstall を防ぐため。
-リポジトリ固有の `package.json` scripts に必要な処理があれば、CI 上で別途実行されるのでここでは省略してよい。
+4 章「エスカレーション」に従って停止する。ユーザに質問して応答を待つ設計にはしない。
 
 ## 4. 検証
 
-push 前に最低限以下を実行し、conflict 解決の副作用がないことを確認する。
+`scripts/verify.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-# 静的検証 (リポジトリにある場合のみ)
-[ -f package.json ] && npx --no-install tsc --noEmit 2>/dev/null || true
-[ -f package.json ] && npm run lint --if-present
-[ -f package.json ] && npm test --if-present -- --run 2>/dev/null || npm test --if-present
-[ -f Makefile ] && grep -qE '^test:' Makefile && make test
+bash "${CLAUDE_SKILL_DIR}/scripts/verify.sh"
 ```
 
-タイムアウトが発生したり、テスト基盤の起動に外部依存がある場合は **無理に通そうとせず**、
-PR コメントでその旨を報告して push に進む。CI 側で再走するため二重に時間を使わない。
+exit 0 (`RESULT: PASS`) でなければ **conflict 解決の副作用がある**とみなし、5 章に進まない。
+出力の各行 (`<name>: PASS|FAIL`) は完了コメントにそのまま転記する — 実行していないチェックを
+PASS と書かない。タイムアウトや外部依存で特定チェックが実行不能な場合は `verify.sh` の出力
+どおりに (`FAIL` として) 報告し、CI 側の再走に委ねる旨を追記する。**`\|\| true` 等で失敗を
+握り潰して push に進まない。**
 
-## 5. push と報告
+## 5. commit で merge を確定し push する
+
+`scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git push origin "$PR_HEAD"
+bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
 ```
 
-force-push (`--force-with-lease` も含む) は merge コミットを使う限り不要。
+このスクリプトが強制する順序 (手動での代替手順を組み立てない):
+
+1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
+3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
+   `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
+   検知できない)
+4. `git add -- <ファイル一覧>` (`git add -A` は使わない — 無関係な変更を巻き込まないため)
+5. `git commit --no-edit` で merge commit を確定
+6. push 前チェックリスト (working tree clean / `MERGE_HEAD` 消滅 / unmerged パスなし /
+   想定ブランチに HEAD がある)
+7. `git push origin "$PR_HEAD"` (force push は使わない — merge commit である限り不要)
+
+exit 0 で完了。exit 1 の場合、**merge commit は既にローカルに作成されている**ことがあるため
+(2〜3 のチェック不通過ならまだ未作成、6 のチェック不通過なら作成済みでの停止)、
+stderr のメッセージを読んでから対応する。盲目的にスクリプトを再実行しない。
+
 push 後、PR に以下フォーマットで結果コメントを残す:
 
 ```markdown
@@ -147,40 +174,54 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 - 解決方針: <merge / rebase>
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
-  - `package-lock.json` — 再生成
-- 検証結果:
-  - tsc: ✅
-  - lint: ⏭ (CI に委譲)
-  - test: ⚠ <一部 skip した場合の理由>
+  - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)
+- 検証結果 (`verify.sh` の出力をそのまま転記):
+  - tsc: PASS
+  - lint: PASS
+  - test: FAIL <理由>
 - 残課題: <あれば箇条書き / なければ「なし」>
 
 push: `<commit-sha>`
 ```
 
-## 無理しない撤退判断
+## エスカレーション (無理しない撤退)
 
-次の条件のいずれかに該当するときは **conflict を解決せず**、PR に方針をコメントして撤退する:
+次のいずれかに該当するときは **その場で解決を試み続けず**、`needs-human` ラベル + 構造化
+コメントで停止する:
 
 1. 機能仕様レベルで相反する変更 (双方の機能を両立させると要件矛盾になる)
 2. 同一テストケースに対する期待値が両側で食い違う
-3. 巨大な自動生成物 (e.g. protobuf, GraphQL schema, OpenAPI) の手解決が現実的でない
+3. 巨大な自動生成物 (protobuf, GraphQL schema, OpenAPI 等) の手解決が現実的でない
 4. `secrets` / 認証情報 / migration 順序など、誤った解決が破壊的になるもの
-5. 5 回以上修正を試みても CI / 型チェックが通らない
+5. `regen-lockfiles.sh` が未知の lockfile でエラー終了し、手動解決も安全に行えない
+6. `verify.sh` が 5 回以上修正を試みても `RESULT: PASS` にならない
+7. `resolve-merge.sh` が exit 10 (conflict) 以外の非ゼロで失敗した (2 章)
 
-撤退コメントには以下を含める:
+手順:
 
-- conflict が起きているファイルと衝突箇所の概要
-- 両側の変更の意図 (commit log を参照した推定で可)
-- 推奨される解決方針 (どちらを採用すべきか、または人手で merge すべき理由)
-- 自動解決を断念した理由
+1. `gh label create needs-human --color FBCA04 2>/dev/null || true` (既存なら no-op 扱い)
+2. `gh pr edit "$PR_NUMBER" --add-label needs-human`
+3. コメント本文を一時ファイル (例: `/tmp/escalation-comment.md`) に Write ツールで書き出し、
+   `gh pr comment "$PR_NUMBER" --body-file <path>` で投稿する。本文の形式:
 
-## チェックリスト (push 前)
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか。conflict が起きているファイルと衝突箇所の概要、
+両側の変更意図の推定、推奨される解決方針を含める>
 
-- [ ] `git diff --name-only --diff-filter=U` が空である (= 全 conflict 解決済み)
-- [ ] `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で残マーカーなし
-- [ ] lock ファイルは整合性が取れている
-- [ ] 型 / lint / 単体テストが通る (もしくは通らない理由を報告予定)
-- [ ] commit メッセージは `.gitmessage` の絵文字プレフィックス規約に従っている
-  - merge commit の場合は既定メッセージで可
-  - 追加修正の commit は `:recycle: Resolve conflicts with <base>` などを使う
-- [ ] secrets / 認証情報を含むファイルを誤って追加していない
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "conflict", "detail": "<1-2 文>", "attempts": <試行回数>, "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+ユーザに質問して応答を待つ設計にはしない — コメント投稿とラベル付与をもって処理を終了する。
+`needs-human` 対応後の再開は人間または別トリガに委ねる。
+
+## ガードレール
+
+- **destructive git 禁止**: `push --force*` / `reset --hard` を使わない。merge commit は
+  常に追加コミットとして扱う
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類が conflict
+  していたら 3 の条件でエスカレーションする
+- **`.github/workflows/` の conflict は自動解決しない**: エスカレーションする (security-block 相当)
+- **PR を merge しない**: merge は常に人間ゲート

--- a/.agents/skills/pr-conflict-resolver/SKILL.md
+++ b/.agents/skills/pr-conflict-resolver/SKILL.md
@@ -77,8 +77,12 @@ push が走った可能性があるので `git status` で状態を確認し、�
 ## 2. base を merge して conflict を検出
 
 rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
-壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
-希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
+壊さず、レビュー中の force-push による差分見失いも避けられるため。**rebase への切り替えは
+サポートしない** — 同梱スクリプトは merge 専用に決定的な処理を組んでおり
+(`finalize.sh` は `MERGE_HEAD` の存在と非 force push を前提とする)、rebase は履歴を
+書き換えて force push が必要になる (「destructive git 禁止」のガードレールと矛盾する)
+うえ `finalize.sh` では完了処理できない。rebase を明示的に希望された場合は 4 章の手順で
+エスカレーションする。
 
 `scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
@@ -121,7 +125,7 @@ bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile 
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
 5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
-   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `grep -rnE '^<<<<<<< |^=======$|^>>>>>>> ' .` で確認する (`finalize.sh` も同じチェックを
    `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
@@ -145,13 +149,28 @@ PASS と書かない。タイムアウトや外部依存で特定チェックが
 
 `scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
-```
+呼び出し方は 2 章の `resolve-merge.sh` の exit code で変わる:
+
+- **conflict あり (exit 10) で 3 章を経由した場合** — 解決した全ファイルを渡す:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
+  ```
+
+- **conflict なし (exit 0) で 3〜4 章を飛ばした場合** — `resolve-merge.sh` の
+  `git merge` が merge commit を作成済み (`MERGE_HEAD` は既に消えている) なので、
+  ファイル一覧を渡さず push 前チェックリストだけを実行させる:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD"
+  ```
 
 このスクリプトが強制する順序 (手動での代替手順を組み立てない):
 
-1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+1. `MERGE_HEAD` の有無で分岐する。存在すれば 2〜5 (conflict 解決パス)、なければ
+   ファイル一覧が空であることだけ確認して 6 のチェックリストに直行する
+   (`MERGE_HEAD` なしでファイル一覧が渡されていたらエラーで停止する — exit code の
+   取り違えを検知するため)
 2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
 3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
    `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
@@ -171,7 +190,7 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 ```markdown
 ### conflict 解決完了
 
-- 解決方針: <merge / rebase>
+- 解決方針: merge
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
   - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)

--- a/.agents/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# finalize.sh - stage resolved conflict files, complete the in-progress
+# merge commit, run a pre-push safety checklist, and push.
+#
+# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+#
+# This is the step the previous prose-only workflow was missing entirely:
+# without `git add` + `git commit`, a resolved merge stays half-finished
+# (MERGE_HEAD still set, paths still "unmerged" in the index) and a
+# subsequent `git push` either fails outright or - worse - pushes a branch
+# that silently dropped the merge. This script refuses to push unless the
+# merge is actually complete.
+#
+# Exit codes:
+#   0 - merge committed, checklist passed, pushed
+#   1 - refused to proceed (see stderr for which checklist item failed) or
+#       `git push` itself failed
+#   2 - usage error
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+  exit 2
+fi
+
+branch="$1"
+shift
+resolved_files=("$@")
+
+git_dir=$(git rev-parse --git-dir)
+
+# 0. There must actually be a merge in progress. Committing here otherwise
+#    would create an unrelated, confusing commit instead of finalizing one.
+if [ ! -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
+  exit 1
+fi
+
+# 1. Every currently-unmerged path must be covered by the caller's file list.
+#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+#    regardless of its content, so after staging this check would always
+#    come back empty and prove nothing about whether resolution happened.
+unmerged=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$unmerged" ]; then
+  missing=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    found=0
+    for rf in "${resolved_files[@]}"; do
+      [ "$rf" = "$path" ] && found=1 && break
+    done
+    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+  done <<<"$unmerged"
+  if [ -n "$missing" ]; then
+    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+    printf '  %s\n' "$missing" >&2
+    exit 1
+  fi
+fi
+
+# 2. Refuse to stage any resolved file that still contains literal conflict
+#    markers. This is the check that actually catches "claimed resolved but
+#    wasn't" - staging alone would happily clear the unmerged flag on a file
+#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+#    slips through unnoticed.
+marker_hit=0
+for f in "${resolved_files[@]}"; do
+  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
+    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+    marker_hit=1
+  fi
+done
+if [ "$marker_hit" -ne 0 ]; then
+  echo "refusing to stage files with unresolved conflict markers" >&2
+  exit 1
+fi
+
+# 3. Stage exactly the files the caller says it resolved. Deliberately not
+#    `git add -A`, which could sweep in unrelated stray changes.
+git add -- "${resolved_files[@]}"
+
+# 4. Sanity check: staging should have cleared every unmerged path. If not,
+#    something outside this script's model changed the index concurrently.
+remaining=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$remaining" ]; then
+  echo "error: unmerged paths remain after staging (unexpected):" >&2
+  printf '  %s\n' "$remaining" >&2
+  exit 1
+fi
+
+# 5. Complete the merge commit (uses the pre-populated merge message).
+git commit --no-edit
+
+# 6. Pre-push checklist. Every item must hold before this script pushes
+#    anything. Content-level marker scanning already happened in step 2,
+#    pre-commit; this is git-state verification only.
+checklist_failed=0
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: [checklist] working tree not clean after merge commit" >&2
+  git status --porcelain >&2
+  checklist_failed=1
+fi
+
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: [checklist] MERGE_HEAD still present after commit; merge did not complete" >&2
+  checklist_failed=1
+fi
+
+if git diff --name-only --diff-filter=U | grep -q .; then
+  echo "error: [checklist] unmerged paths still present" >&2
+  checklist_failed=1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "$branch" ]; then
+  echo "error: [checklist] expected HEAD on '$branch', but it is on '$current_branch'" >&2
+  checklist_failed=1
+fi
+
+if [ "$checklist_failed" -ne 0 ]; then
+  echo "error: pre-push checklist failed; refusing to push (merge commit was already created locally - fix the issue above and push manually once verified, do not re-run this script blindly)" >&2
+  exit 1
+fi
+
+# 7. Push. No --force / --force-with-lease: a merge commit never needs
+#    history rewriting.
+git push origin "$branch"

--- a/.agents/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -2,7 +2,7 @@
 # finalize.sh - stage resolved conflict files, complete the in-progress
 # merge commit, run a pre-push safety checklist, and push.
 #
-# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+# Usage: finalize.sh <push-branch> [<resolved-file> ...]
 #
 # This is the step the previous prose-only workflow was missing entirely:
 # without `git add` + `git commit`, a resolved merge stays half-finished
@@ -11,15 +11,24 @@
 # that silently dropped the merge. This script refuses to push unless the
 # merge is actually complete.
 #
+# Two entry states, both ending at the same pre-push checklist + push:
+#   - Conflicted merge (MERGE_HEAD present): caller passes every resolved
+#     file; this script verifies coverage + no leftover markers, stages,
+#     and commits.
+#   - Already-clean merge (MERGE_HEAD absent, e.g. resolve-merge.sh exited 0
+#     with no conflicts and its own `git merge` already created the commit):
+#     caller passes zero resolved files; this script skips straight to the
+#     checklist instead of erroring out on "no merge in progress".
+#
 # Exit codes:
-#   0 - merge committed, checklist passed, pushed
+#   0 - merge committed (or already committed), checklist passed, pushed
 #   1 - refused to proceed (see stderr for which checklist item failed) or
 #       `git push` itself failed
 #   2 - usage error
 set -euo pipefail
 
-if [ "$#" -lt 2 ]; then
-  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <push-branch> [<resolved-file> ...]" >&2
   exit 2
 fi
 
@@ -29,67 +38,79 @@ resolved_files=("$@")
 
 git_dir=$(git rev-parse --git-dir)
 
-# 0. There must actually be a merge in progress. Committing here otherwise
-#    would create an unrelated, confusing commit instead of finalizing one.
-if [ ! -f "$git_dir/MERGE_HEAD" ]; then
-  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
-  exit 1
-fi
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  # 1. Every currently-unmerged path must be covered by the caller's file list.
+  #    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+  #    regardless of its content, so after staging this check would always
+  #    come back empty and prove nothing about whether resolution happened.
+  unmerged=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$unmerged" ]; then
+    missing=""
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      found=0
+      for rf in "${resolved_files[@]}"; do
+        [ "$rf" = "$path" ] && found=1 && break
+      done
+      [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+    done <<<"$unmerged"
+    if [ -n "$missing" ]; then
+      echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+      printf '  %s\n' "$missing" >&2
+      exit 1
+    fi
+  fi
 
-# 1. Every currently-unmerged path must be covered by the caller's file list.
-#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
-#    regardless of its content, so after staging this check would always
-#    come back empty and prove nothing about whether resolution happened.
-unmerged=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$unmerged" ]; then
-  missing=""
-  while IFS= read -r path; do
-    [ -z "$path" ] && continue
-    found=0
-    for rf in "${resolved_files[@]}"; do
-      [ "$rf" = "$path" ] && found=1 && break
-    done
-    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
-  done <<<"$unmerged"
-  if [ -n "$missing" ]; then
-    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
-    printf '  %s\n' "$missing" >&2
+  # 2. Refuse to stage any resolved file that still contains literal conflict
+  #    markers. This is the check that actually catches "claimed resolved but
+  #    wasn't" - staging alone would happily clear the unmerged flag on a file
+  #    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+  #    slips through unnoticed. Git's real markers are always `<<<<<<< <ref>`,
+  #    a bare `=======`, and `>>>>>>> <ref>` - anchoring on the trailing space
+  #    (outer markers) / end-of-line (middle separator) avoids false-positives
+  #    on unrelated content that merely starts with 7+ of these characters
+  #    (e.g. a longer Markdown Setext heading underline).
+  marker_hit=0
+  for f in "${resolved_files[@]}"; do
+    if [ -f "$f" ] && grep -ncE '^<<<<<<< |^=======$|^>>>>>>> ' -- "$f" >/dev/null 2>&1; then
+      echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+      marker_hit=1
+    fi
+  done
+  if [ "$marker_hit" -ne 0 ]; then
+    echo "refusing to stage files with unresolved conflict markers" >&2
     exit 1
   fi
-fi
 
-# 2. Refuse to stage any resolved file that still contains literal conflict
-#    markers. This is the check that actually catches "claimed resolved but
-#    wasn't" - staging alone would happily clear the unmerged flag on a file
-#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
-#    slips through unnoticed.
-marker_hit=0
-for f in "${resolved_files[@]}"; do
-  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
-    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
-    marker_hit=1
+  # 3. Stage exactly the files the caller says it resolved. Deliberately not
+  #    `git add -A`, which could sweep in unrelated stray changes.
+  git add -- "${resolved_files[@]}"
+
+  # 4. Sanity check: staging should have cleared every unmerged path. If not,
+  #    something outside this script's model changed the index concurrently.
+  remaining=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$remaining" ]; then
+    echo "error: unmerged paths remain after staging (unexpected):" >&2
+    printf '  %s\n' "$remaining" >&2
+    exit 1
   fi
-done
-if [ "$marker_hit" -ne 0 ]; then
-  echo "refusing to stage files with unresolved conflict markers" >&2
-  exit 1
+
+  # 5. Complete the merge commit (uses the pre-populated merge message).
+  git commit --no-edit
+else
+  # 1'. MERGE_HEAD absent: either resolve-merge.sh already completed a
+  # conflict-free merge (its own `git merge` auto-commits and clears
+  # MERGE_HEAD), or this call is confused about which exit code it followed.
+  # resolve-merge.sh only ever produces a resolved-file list on exit 10
+  # (conflicts); on exit 0 there is nothing to resolve, so a non-empty list
+  # here means the caller thinks there was a conflict when there wasn't.
+  if [ "${#resolved_files[@]}" -gt 0 ]; then
+    echo "error: no merge in progress (MERGE_HEAD not found), but resolved file(s) were passed: ${resolved_files[*]}" >&2
+    echo "       resolve-merge.sh only produces a file list on exit 10 (conflicts); on exit 0 there is nothing to resolve" >&2
+    exit 1
+  fi
+  echo "no merge in progress (MERGE_HEAD not found); treating this as an already-committed, conflict-free merge and proceeding to the pre-push checklist" >&2
 fi
-
-# 3. Stage exactly the files the caller says it resolved. Deliberately not
-#    `git add -A`, which could sweep in unrelated stray changes.
-git add -- "${resolved_files[@]}"
-
-# 4. Sanity check: staging should have cleared every unmerged path. If not,
-#    something outside this script's model changed the index concurrently.
-remaining=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$remaining" ]; then
-  echo "error: unmerged paths remain after staging (unexpected):" >&2
-  printf '  %s\n' "$remaining" >&2
-  exit 1
-fi
-
-# 5. Complete the merge commit (uses the pre-populated merge message).
-git commit --no-edit
 
 # 6. Pre-push checklist. Every item must hold before this script pushes
 #    anything. Content-level marker scanning already happened in step 2,

--- a/.agents/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# pr-context.sh - resolve a PR number into eval-able shell variable
+# assignments (head/base branch, title, url, head SHA).
+#
+# Usage: pr-context.sh <pr-number>
+# Requires: gh (authenticated), jq
+#
+# Output (stdout): one `NAME=value` assignment per line, each value shell-
+# quoted with bash's `printf %q` so the whole output is safe to consume with
+# `eval "$(bash pr-context.sh <n>)"` even if a title/branch contains spaces
+# or quotes.
+#
+# Exported names:
+#   PR_NUMBER   - the PR number, as returned by gh (validated integer)
+#   PR_HEAD     - head branch name (what to check out / push back to)
+#   PR_BASE     - base branch name (what to merge in)
+#   PR_TITLE    - PR title (for status comments)
+#   PR_URL      - PR URL (for status comments)
+#   PR_HEAD_SHA - head branch's commit SHA at fetch time (drift/race check:
+#                 compare against HEAD after checkout before pushing)
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+pr="$1"
+
+if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+  echo "error: PR number must be a positive integer, got: '$pr'" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found on PATH" >&2
+  exit 127
+fi
+
+if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+  exit 1
+fi
+
+pr_number=$(jq -r '.number' <<<"$json")
+pr_head=$(jq -r '.headRefName' <<<"$json")
+pr_base=$(jq -r '.baseRefName' <<<"$json")
+pr_title=$(jq -r '.title' <<<"$json")
+pr_url=$(jq -r '.url' <<<"$json")
+pr_head_sha=$(jq -r '.headRefOid' <<<"$json")
+
+if [ -z "$pr_head" ] || [ "$pr_head" = "null" ] || [ -z "$pr_base" ] || [ "$pr_base" = "null" ]; then
+  echo "error: gh returned an incomplete PR record for #$pr (headRefName/baseRefName missing)" >&2
+  exit 1
+fi
+
+printf 'PR_NUMBER=%q\n' "$pr_number"
+printf 'PR_HEAD=%q\n' "$pr_head"
+printf 'PR_BASE=%q\n' "$pr_base"
+printf 'PR_TITLE=%q\n' "$pr_title"
+printf 'PR_URL=%q\n' "$pr_url"
+printf 'PR_HEAD_SHA=%q\n' "$pr_head_sha"

--- a/.agents/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -20,6 +20,24 @@
 #                 compare against HEAD after checkout before pushing)
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `gh pr view` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <pr-number>" >&2
   exit 2
@@ -42,8 +60,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 127
 fi
 
-if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
-  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+# Deliberately NOT `2>&1`: merging stderr into the captured JSON means any
+# warning gh writes to stderr (deprecation notice, etc.) corrupts the value
+# `jq` parses below, even when the PR lookup itself succeeded. Let stderr
+# surface on its own; only stdout is captured as the JSON payload.
+if ! json=$(run_with_timeout 30 gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, no access, or timed out)" >&2
   exit 1
 fi
 

--- a/.agents/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# regen-lockfiles.sh - regenerate conflicted dependency lockfiles instead of
+# hand-editing conflict markers inside generated content.
+#
+# Usage: regen-lockfiles.sh <lockfile-path> [<lockfile-path> ...]
+#
+# Each path's basename selects the ecosystem-specific regeneration command
+# (the `case` below). An unrecognized lockfile name fails loudly rather than
+# being silently skipped, so the caller never pushes a file that still has
+# `<<<<<<<` markers in it.
+#
+# --ignore-scripts (npm/pnpm/yarn/bun) is deliberate: it stops untrusted
+# postinstall hooks from executing during unattended conflict resolution.
+# Repository-specific postinstall steps still run in CI afterward.
+set -uo pipefail
+# NOTE: no `-e` at the top level on purpose. With N conflicted lockfiles we
+# want to attempt every one and report which failed, not abort after the
+# first failure and leave the rest un-attempted. Exit status is computed
+# explicitly from the per-file results below.
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <lockfile-path> [<lockfile-path> ...]" >&2
+  exit 2
+fi
+
+status=0
+
+for path in "$@"; do
+  if [ ! -e "$path" ]; then
+    echo "error: '$path' does not exist (conflict marker removal or a prior step may have deleted it)" >&2
+    status=1
+    continue
+  fi
+
+  base=$(basename -- "$path")
+  dir=$(dirname -- "$path")
+
+  echo "== regenerating $path ==" >&2
+
+  (
+    set -e
+    cd "$dir"
+    case "$base" in
+      package-lock.json)
+        rm -f package-lock.json
+        npm install --package-lock-only --ignore-scripts
+        ;;
+      pnpm-lock.yaml)
+        rm -f pnpm-lock.yaml
+        pnpm install --lockfile-only --ignore-scripts
+        ;;
+      yarn.lock)
+        rm -f yarn.lock
+        yarn install --mode update-lockfile --ignore-scripts 2>/dev/null \
+          || yarn install --ignore-scripts
+        ;;
+      bun.lock | bun.lockb)
+        rm -f bun.lock bun.lockb
+        bun install --frozen-lockfile=false --ignore-scripts
+        ;;
+      Cargo.lock)
+        cargo update --workspace --offline 2>/dev/null \
+          || cargo generate-lockfile
+        ;;
+      poetry.lock)
+        poetry lock --no-update
+        ;;
+      uv.lock)
+        uv lock
+        ;;
+      go.sum)
+        go mod tidy
+        ;;
+      Gemfile.lock)
+        bundle lock --update
+        ;;
+      *)
+        echo "error: unsupported lockfile '$base' - resolve manually, do not guess a regen command" >&2
+        exit 1
+        ;;
+    esac
+  )
+  file_status=$?
+
+  if [ "$file_status" -ne 0 ]; then
+    echo "error: regeneration failed for '$path' (exit $file_status)" >&2
+    status=1
+  fi
+done
+
+exit "$status"

--- a/.agents/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -63,15 +63,30 @@ for path in "$@"; do
           || cargo generate-lockfile
         ;;
       poetry.lock)
+        # poetry/uv/go/bundle all parse the existing lockfile before
+        # resolving, so a conflict-marker-tainted file aborts even
+        # `--no-update` mode. Remove it first, matching the fallback the
+        # npm/pnpm/yarn/bun/Cargo.lock branches above already use.
+        rm -f poetry.lock
         poetry lock --no-update
         ;;
       uv.lock)
+        rm -f uv.lock
         uv lock
         ;;
       go.sum)
+        rm -f go.sum
         go mod tidy
+        # `go mod tidy` can also rewrite go.mod (missing/unused
+        # requirements). go.mod isn't part of the caller's resolved-file
+        # list (only go.sum was conflicted), so stage it here - otherwise
+        # finalize.sh's pre-push "working tree clean" checklist fails after
+        # the merge commit has already been created, since go.mod would be
+        # left modified but uncommitted.
+        git add -- go.mod
         ;;
       Gemfile.lock)
+        rm -f Gemfile.lock
         bundle lock --update
         ;;
       *)

--- a/.agents/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -21,6 +21,24 @@
 #        report the actual error.
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `git fetch` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <base-branch>" >&2
   exit 2
@@ -28,8 +46,8 @@ fi
 
 base="$1"
 
-if ! git fetch origin "$base"; then
-  echo "error: 'git fetch origin $base' failed" >&2
+if ! run_with_timeout 30 git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed (or timed out)" >&2
   exit 1
 fi
 

--- a/.agents/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# resolve-merge.sh - merge a base branch into the currently checked-out
+# branch and report conflicts via a distinct exit code, instead of a prose
+# "if conflict, continue" convention that's easy to get wrong.
+#
+# Usage: resolve-merge.sh <base-branch>
+#
+# Precondition: the PR head branch is already checked out and up to date
+# (see pr-context.sh for PR_HEAD/PR_BASE, then `git checkout "$PR_HEAD"`
+# separately). This script does not check out anything itself.
+#
+# Exit codes:
+#   0  - merge completed with NO conflicts. A merge commit already exists;
+#        skip straight to finalize.sh (there is nothing to `git add`).
+#   10 - merge produced conflicts. Conflicted file paths are printed to
+#        stdout, one per line. Resolve each one (regen-lockfiles.sh for
+#        lockfiles, manual edit for source), THEN call finalize.sh.
+#   *  - any other exit code is an unexpected merge failure (auth error,
+#        unknown ref, corrupt repo, uncommitted local changes blocking the
+#        merge, ...). Do NOT treat this as "conflicts to resolve" - stop and
+#        report the actual error.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <base-branch>" >&2
+  exit 2
+fi
+
+base="$1"
+
+if ! git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed" >&2
+  exit 1
+fi
+
+merge_status=0
+# `git merge` writes its own progress ("Auto-merging ...", "CONFLICT ...")
+# to stdout, which would otherwise corrupt this script's stdout contract
+# (conflicted-file-list only). Redirect it to stderr instead.
+git merge --no-ff --no-edit "origin/$base" >&2 || merge_status=$?
+
+if [ "$merge_status" -eq 0 ]; then
+  echo "merge completed with no conflicts" >&2
+  exit 0
+fi
+
+conflicts=$(git diff --name-only --diff-filter=U || true)
+
+if [ -z "$conflicts" ]; then
+  echo "error: git merge failed (exit $merge_status) for a reason other than conflicts; not proceeding to conflict resolution" >&2
+  exit "$merge_status"
+fi
+
+printf '%s\n' "$conflicts"
+exit 10

--- a/.agents/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/verify.sh
@@ -44,11 +44,20 @@ if [ -f package.json ]; then
   if [ -f tsconfig.json ]; then
     run_check tsc npx --no-install tsc --noEmit
   fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
-    run_check lint npm run lint --if-present
-  fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
-    run_check test npm test --if-present
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+      run_check lint npm run lint --if-present
+    fi
+    if jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+      # CI=true is the de-facto standard signal (jest, vitest, mocha, ava,
+      # ...) for "don't enter watch mode". A bare `npm test` invoking a
+      # watch-by-default runner would otherwise hang here indefinitely
+      # (never emit PASS/FAIL, never reach the trailing RESULT line) in an
+      # unattended run.
+      run_check test env CI=true npm test --if-present
+    fi
+  else
+    echo "warning: jq not found; cannot detect package.json scripts.lint/scripts.test - lint/test checks skipped without running them" >&2
   fi
 fi
 

--- a/.agents/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/.agents/skills/pr-conflict-resolver/scripts/verify.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# verify.sh - run the applicable verification chain (typecheck / lint / test)
+# for whatever stacks are detected in the current working tree, and report a
+# structured, truthful pass/fail summary.
+#
+# Usage: verify.sh
+#
+# THIS SCRIPT NEVER SWALLOWS A CHECK'S EXIT CODE. The previous prose workflow
+# piped `tsc --noEmit` through `|| true`, so a broken build could still be
+# reported as a passing "tsc: ✅" in the PR comment. Every check below keeps
+# its real exit status; a single failing check makes the whole script exit 1.
+#
+# Output (stdout): one line per check that ran, `<name>: PASS|FAIL`, followed
+# by a trailing `RESULT: PASS|FAIL` line. Use this output verbatim as the
+# source of truth for any completion comment - never assert a check passed
+# without pointing at its line here.
+#
+# Exit codes:
+#   0 - every detected check passed (including "no tooling detected")
+#   1 - at least one detected check failed
+set -uo pipefail
+# NOTE: no `-e` on purpose. The point of this script is to run every
+# applicable check and report all of their outcomes, not stop at the first
+# failure. The overall exit status is computed explicitly at the end.
+
+overall=0
+ran_any=0
+
+run_check() {
+  local name="$1"
+  shift
+  echo "-- running: $name --" >&2
+  if "$@"; then
+    echo "$name: PASS"
+  else
+    echo "$name: FAIL"
+    overall=1
+  fi
+  ran_any=1
+}
+
+# --- Node / TypeScript ---
+if [ -f package.json ]; then
+  if [ -f tsconfig.json ]; then
+    run_check tsc npx --no-install tsc --noEmit
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+    run_check lint npm run lint --if-present
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+    run_check test npm test --if-present
+  fi
+fi
+
+# --- Python ---
+if [ -f pyproject.toml ]; then
+  if command -v ruff >/dev/null 2>&1; then
+    run_check ruff ruff check .
+  fi
+  if command -v pytest >/dev/null 2>&1; then
+    run_check pytest pytest
+  fi
+fi
+
+# --- Go ---
+if [ -f go.mod ]; then
+  run_check go-build go build ./...
+  run_check go-test go test ./...
+fi
+
+# --- Rust ---
+if [ -f Cargo.toml ]; then
+  run_check cargo-check cargo check --workspace
+  run_check cargo-test cargo test --workspace
+fi
+
+# --- Make-based projects (only if no more specific check already covered it) ---
+if [ -f Makefile ] && grep -qE '^test:' Makefile; then
+  run_check make-test make test
+fi
+
+if [ "$ran_any" -eq 0 ]; then
+  echo "no known verification tooling detected (package.json/pyproject.toml/go.mod/Cargo.toml/Makefile); nothing to run" >&2
+fi
+
+if [ "$overall" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+
+exit "$overall"

--- a/.claude/skills/pr-conflict-resolver/SKILL.md
+++ b/.claude/skills/pr-conflict-resolver/SKILL.md
@@ -84,8 +84,12 @@ push が走った可能性があるので `git status` で状態を確認し、�
 ## 2. base を merge して conflict を検出
 
 rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
-壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
-希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
+壊さず、レビュー中の force-push による差分見失いも避けられるため。**rebase への切り替えは
+サポートしない** — 同梱スクリプトは merge 専用に決定的な処理を組んでおり
+(`finalize.sh` は `MERGE_HEAD` の存在と非 force push を前提とする)、rebase は履歴を
+書き換えて force push が必要になる (「destructive git 禁止」のガードレールと矛盾する)
+うえ `finalize.sh` では完了処理できない。rebase を明示的に希望された場合は 4 章の手順で
+エスカレーションする。
 
 `scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
@@ -128,7 +132,7 @@ bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile 
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
 5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
-   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `grep -rnE '^<<<<<<< |^=======$|^>>>>>>> ' .` で確認する (`finalize.sh` も同じチェックを
    `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
@@ -152,13 +156,28 @@ PASS と書かない。タイムアウトや外部依存で特定チェックが
 
 `scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
-```
+呼び出し方は 2 章の `resolve-merge.sh` の exit code で変わる:
+
+- **conflict あり (exit 10) で 3 章を経由した場合** — 解決した全ファイルを渡す:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
+  ```
+
+- **conflict なし (exit 0) で 3〜4 章を飛ばした場合** — `resolve-merge.sh` の
+  `git merge` が merge commit を作成済み (`MERGE_HEAD` は既に消えている) なので、
+  ファイル一覧を渡さず push 前チェックリストだけを実行させる:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD"
+  ```
 
 このスクリプトが強制する順序 (手動での代替手順を組み立てない):
 
-1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+1. `MERGE_HEAD` の有無で分岐する。存在すれば 2〜5 (conflict 解決パス)、なければ
+   ファイル一覧が空であることだけ確認して 6 のチェックリストに直行する
+   (`MERGE_HEAD` なしでファイル一覧が渡されていたらエラーで停止する — exit code の
+   取り違えを検知するため)
 2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
 3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
    `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
@@ -178,7 +197,7 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 ```markdown
 ### conflict 解決完了
 
-- 解決方針: <merge / rebase>
+- 解決方針: merge
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
   - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)

--- a/.claude/skills/pr-conflict-resolver/SKILL.md
+++ b/.claude/skills/pr-conflict-resolver/SKILL.md
@@ -3,8 +3,9 @@ name: pr-conflict-resolver
 description: |
   GitHub PR で発生した merge conflict を自動修正するための手順とベストプラクティス。
   PR コメントで `@claude` 経由で呼ばれた conflict 解決タスクや、ローカルでの rebase / merge
-  conflict を解決するときに必ず参照する。チェックアウト → merge / rebase → conflict 解決 →
-  lock ファイル再生成 → テスト → push までの一連の安全な流れを定義する。
+  conflict を解決するときに必ず参照する。チェックアウト → merge → conflict 解決 →
+  lock ファイル再生成 → 検証 → commit で merge を確定 → push までの一連の安全な流れを、
+  同梱スクリプト (`scripts/*.sh`) の決定的な実行として定義する。
 allowed-tools:
   - Bash
   - Read
@@ -16,18 +17,57 @@ allowed-tools:
 # PR conflict resolver
 
 PR のターゲットブランチ (base) と head ブランチの間で発生した merge conflict を、機能を欠落させず
-安全に解決するための手順。Claude Code Action から呼び出される前提で、すべて非対話で完結すること。
+安全に解決するための手順。
+
+## 実行環境前提
+
+本スキルは **対話ローカル実行 / ヘッドレス実行 (Claude Code Action 等) の両方**で使う。
+呼び出し元が人間かどうかに関わらず、以降の手順は同一とする:
+
+- 判断が必要な分岐 (ソース conflict の統合方針、撤退判断) で**人間に質問して止まる設計にしない**。
+  ヘッドレスでは応答が来ないため、質問した時点でセッションが unattended のまま放置される。
+- 継続不能なときは 4 章「エスカレーション」の **`needs-human` ラベル + 構造化コメント**で停止する。
+  これは対話環境でも同じ挙動にする (人間に質問するのではなく、判断材料を残して停止し、人間の
+  タイミングでコメントを読んでもらう)。
+- 決定的な多段操作 (PR 情報抽出・merge 実行・lockfile 再生成・検証・push 前確定) は
+  すべて `scripts/*.sh` に閉じ込めてある。**フラグを追加したり、同等のコマンドを手で
+  組み立てて代替したりしない** — 実行者ごとの手順のブレをなくすための決定的スクリプトなので、
+  そのまま実行する。
+
+## 同梱スクリプトと権限
+
+```text
+scripts/
+├── pr-context.sh       # 0. PR 情報の取得
+├── resolve-merge.sh    # 2. base の merge 実行 + conflict 検出
+├── regen-lockfiles.sh  # 3. lockfile の再生成
+├── verify.sh           # 4. 検証チェーン
+└── finalize.sh         # 5. commit で merge 確定 → push 前チェック → push
+```
+
+| script | 役割 | exit code |
+|---|---|---|
+| `pr-context.sh <PR番号>` | `gh pr view --json` で `PR_NUMBER`/`PR_HEAD`/`PR_BASE`/`PR_TITLE`/`PR_URL`/`PR_HEAD_SHA` を `eval` 可能な `NAME=value` 形式で stdout に出力 | 0=成功、127=`gh`/`jq` 不在、1=PR 取得失敗、2=usage |
+| `resolve-merge.sh <base-branch>` | `origin/<base>` を `--no-ff --no-edit` で merge。stdout は conflict ファイル一覧のみ (git 自身の進捗メッセージは stderr に retarget 済み) | 0=conflict なし (merge 完了済み)、10=conflict あり (stdout に一覧)、その他=想定外の merge 失敗 |
+| `regen-lockfiles.sh <path...>` | 渡された各パスの basename でエコシステムを判定し `case` 文で再生成 (`package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` / `bun.lock(b)` / `Cargo.lock` / `poetry.lock` / `uv.lock` / `go.sum` / `Gemfile.lock`)。未知の lockfile は再生成せずエラー | 0=全件成功、1=1件以上失敗、2=usage |
+| `verify.sh` | repo 検出 (`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml`/`Makefile`) に応じて tsc/lint/test 等を実行。**`\|\| true` は使わない** — 各チェックの exit code をそのまま保持する | 0=全チェック PASS (未検出時も PASS 扱い)、1=1件以上 FAIL |
+| `finalize.sh <push-branch> <resolved-file...>` | conflict marker の残存チェック → `git add` → `git commit` で merge を確定 → push 前チェックリスト → `git push` | 0=push 完了、1=チェックリスト不通過または push 失敗、2=usage |
+
+`scripts/*.sh` は `bash "${CLAUDE_SKILL_DIR}/scripts/<name>.sh" <args>` で呼び出す。
+最小依存 (`bash`, `git`, `gh`, `jq`) のみを前提とし、Python/Node 等の追加ランタイムは使わない。
 
 ## 0. 前提情報の確認
 
-呼び出し元のコメントから以下を取得する:
+呼び出し元のコメントに PR 番号があればそれを使う。明示的な解決方針の指示 (例:「lock ファイルは
+theirs を採用」) があれば以降の手順より優先する。
 
-- **PR 番号** (`#N`)
-- **head ブランチ** (作業対象)
-- **base ブランチ** (merge 元)
-- 解決方針の明示的な指示があれば優先する (例: 「lock ファイルは theirs を採用」)
+`scripts/pr-context.sh <PR番号> を正確に実行。フラグ追加禁止。`
 
-不明な場合は `gh pr view <N> --json number,headRefName,baseRefName,title` で取得する。
+```bash
+eval "$(bash "${CLAUDE_SKILL_DIR}/scripts/pr-context.sh" <PR番号>)"
+```
+
+以降 `$PR_NUMBER` / `$PR_HEAD` / `$PR_BASE` / `$PR_TITLE` / `$PR_URL` / `$PR_HEAD_SHA` を使う。
 
 ## 1. ブランチをチェックアウト
 
@@ -38,47 +78,48 @@ git pull --ff-only origin "$PR_HEAD"
 ```
 
 `--ff-only` は他者の push を上書きしないための安全策。fast-forward できないときは
-push が走った可能性があるので一度 `git status` で状態を確認し、想定外であれば停止する。
+push が走った可能性があるので `git status` で状態を確認し、想定外であれば
+4 章の手順でエスカレーションする (無理に `--force` で追従しない)。
 
-## 2. base を merge
+## 2. base を merge して conflict を検出
 
-rebase ではなく **merge** を既定とする。理由:
+rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
+壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
+希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
 
-- PR の commit 履歴と署名 (Co-Authored-By 等) を壊さない
-- PR がレビュー中の場合、force-push は差分を見失わせるため避ける
-
-```bash
-merge_status=0
-git merge --no-ff --no-edit "origin/$PR_BASE" || merge_status=$?
-if [ "$merge_status" -ne 0 ]; then
-  if git diff --name-only --diff-filter=U | grep -q .; then
-    echo "merge conflict を検知。解決ステップへ進行。"
-  else
-    echo "merge が conflict 以外の理由で失敗。処理を中断。" >&2
-    exit "$merge_status"
-  fi
-fi
-```
-
-`|| true` で全エラーを握り潰すと、認証エラーや壊れた ref 等の異常時にも誤って
-解決処理へ進んでしまう。上記のように **conflict (未マージファイルあり) のときだけ継続**し、
-それ以外の非ゼロ終了は中断する。特別な指示で rebase を希望される場合のみ
-`git rebase origin/$PR_BASE` を選択する。
-
-## 3. conflict 箇所の特定
+`scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git diff --name-only --diff-filter=U
+bash "${CLAUDE_SKILL_DIR}/scripts/resolve-merge.sh" "$PR_BASE"
 ```
 
-ファイル種別別に処理戦略を切り替える:
+exit code で分岐する:
+
+- **0** — conflict なし。merge commit は作成済み。3〜4 章を飛ばして 5 章 (`finalize.sh`) へ進む。
+- **10** — conflict あり。stdout に conflict ファイル一覧 (1 行 1 ファイル) が出力される。
+  3 章に進んで各ファイルを解決する。
+- **それ以外** — 認証エラーや壊れた ref 等、merge conflict 以外の理由での失敗。
+  **conflict 解決フローに進まない**。4 章の手順でエスカレーションする。
+
+## 3. conflict 箇所を種別ごとに解決する
+
+`resolve-merge.sh` が出力した一覧をファイル種別で振り分ける:
 
 | ファイル種別 | 戦略 |
 |------------|------|
-| ソースコード | 後述「ソース conflict 解決ガイドライン」に従い手で解決 |
-| lock ファイル (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | conflict マーカーごと削除し、対応するパッケージマネージャで再生成 |
+| ソースコード | 下記「ソース conflict 解決ガイドライン」に従い Edit ツールで手で解決 |
+| lock ファイル (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock(b)`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | `scripts/regen-lockfiles.sh` に渡して再生成する (手で marker を編集しない) |
 | 生成物 (`dist/`, `build/`, `*.min.js`, snapshot) | `.gitignore` 漏れがないか確認した上で、可能ならビルドし直して上書き |
-| バイナリ | `git checkout --theirs` または `--ours` で base を採用するのが基本。理由をコメントで残す |
+| バイナリ | `git checkout --theirs <path>` または `--ours <path>` で base/head どちらかを採用。採用理由を最終コメントに残す |
+
+lock ファイルは `scripts/regen-lockfiles.sh を正確に実行。フラグ追加禁止。`
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile のパス...>
+```
+
+未知の lockfile 名 (`case` の `*)` 分岐) は再生成コマンドを推測せず失敗する。その場合は
+手動解決に切り替えるか、4 章の手順でエスカレーションする。
 
 ### ソース conflict 解決ガイドライン
 
@@ -86,66 +127,52 @@ git diff --name-only --diff-filter=U
 2. **関数/ブロック単位で統合**: 片側削除を安易に選ばない。同じ箇所への重複編集は **両方の機能を残す**
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
-5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で確認
+5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
+   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
-4 章「無理しない撤退判断」に従って PR にコメントしてエスカレーションする。
-
-### lock ファイルの再生成
-
-各エコシステムごとに対応コマンドが異なる:
-
-```bash
-# package-lock.json
-rm -f package-lock.json && npm install --package-lock-only --ignore-scripts
-
-# pnpm
-rm -f pnpm-lock.yaml && pnpm install --lockfile-only --ignore-scripts
-
-# yarn (berry / classic で挙動が違うので存在するコマンドを使う)
-rm -f yarn.lock && yarn install --mode update-lockfile 2>/dev/null || yarn install --ignore-scripts
-
-# bun
-rm -f bun.lock bun.lockb && bun install --frozen-lockfile=false --ignore-scripts
-
-# Cargo
-cargo update --workspace --offline 2>/dev/null || cargo generate-lockfile
-
-# uv
-uv lock
-
-# poetry
-poetry lock --no-update
-
-# go
-go mod tidy
-```
-
-`--ignore-scripts` を付けるのは untrusted な postinstall を防ぐため。
-リポジトリ固有の `package.json` scripts に必要な処理があれば、CI 上で別途実行されるのでここでは省略してよい。
+4 章「エスカレーション」に従って停止する。ユーザに質問して応答を待つ設計にはしない。
 
 ## 4. 検証
 
-push 前に最低限以下を実行し、conflict 解決の副作用がないことを確認する。
+`scripts/verify.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-# 静的検証 (リポジトリにある場合のみ)
-[ -f package.json ] && npx --no-install tsc --noEmit 2>/dev/null || true
-[ -f package.json ] && npm run lint --if-present
-[ -f package.json ] && npm test --if-present -- --run 2>/dev/null || npm test --if-present
-[ -f Makefile ] && grep -qE '^test:' Makefile && make test
+bash "${CLAUDE_SKILL_DIR}/scripts/verify.sh"
 ```
 
-タイムアウトが発生したり、テスト基盤の起動に外部依存がある場合は **無理に通そうとせず**、
-PR コメントでその旨を報告して push に進む。CI 側で再走するため二重に時間を使わない。
+exit 0 (`RESULT: PASS`) でなければ **conflict 解決の副作用がある**とみなし、5 章に進まない。
+出力の各行 (`<name>: PASS|FAIL`) は完了コメントにそのまま転記する — 実行していないチェックを
+PASS と書かない。タイムアウトや外部依存で特定チェックが実行不能な場合は `verify.sh` の出力
+どおりに (`FAIL` として) 報告し、CI 側の再走に委ねる旨を追記する。**`\|\| true` 等で失敗を
+握り潰して push に進まない。**
 
-## 5. push と報告
+## 5. commit で merge を確定し push する
+
+`scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git push origin "$PR_HEAD"
+bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
 ```
 
-force-push (`--force-with-lease` も含む) は merge コミットを使う限り不要。
+このスクリプトが強制する順序 (手動での代替手順を組み立てない):
+
+1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
+3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
+   `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
+   検知できない)
+4. `git add -- <ファイル一覧>` (`git add -A` は使わない — 無関係な変更を巻き込まないため)
+5. `git commit --no-edit` で merge commit を確定
+6. push 前チェックリスト (working tree clean / `MERGE_HEAD` 消滅 / unmerged パスなし /
+   想定ブランチに HEAD がある)
+7. `git push origin "$PR_HEAD"` (force push は使わない — merge commit である限り不要)
+
+exit 0 で完了。exit 1 の場合、**merge commit は既にローカルに作成されている**ことがあるため
+(2〜3 のチェック不通過ならまだ未作成、6 のチェック不通過なら作成済みでの停止)、
+stderr のメッセージを読んでから対応する。盲目的にスクリプトを再実行しない。
+
 push 後、PR に以下フォーマットで結果コメントを残す:
 
 ```markdown
@@ -154,40 +181,54 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 - 解決方針: <merge / rebase>
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
-  - `package-lock.json` — 再生成
-- 検証結果:
-  - tsc: ✅
-  - lint: ⏭ (CI に委譲)
-  - test: ⚠ <一部 skip した場合の理由>
+  - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)
+- 検証結果 (`verify.sh` の出力をそのまま転記):
+  - tsc: PASS
+  - lint: PASS
+  - test: FAIL <理由>
 - 残課題: <あれば箇条書き / なければ「なし」>
 
 push: `<commit-sha>`
 ```
 
-## 無理しない撤退判断
+## エスカレーション (無理しない撤退)
 
-次の条件のいずれかに該当するときは **conflict を解決せず**、PR に方針をコメントして撤退する:
+次のいずれかに該当するときは **その場で解決を試み続けず**、`needs-human` ラベル + 構造化
+コメントで停止する:
 
 1. 機能仕様レベルで相反する変更 (双方の機能を両立させると要件矛盾になる)
 2. 同一テストケースに対する期待値が両側で食い違う
-3. 巨大な自動生成物 (e.g. protobuf, GraphQL schema, OpenAPI) の手解決が現実的でない
+3. 巨大な自動生成物 (protobuf, GraphQL schema, OpenAPI 等) の手解決が現実的でない
 4. `secrets` / 認証情報 / migration 順序など、誤った解決が破壊的になるもの
-5. 5 回以上修正を試みても CI / 型チェックが通らない
+5. `regen-lockfiles.sh` が未知の lockfile でエラー終了し、手動解決も安全に行えない
+6. `verify.sh` が 5 回以上修正を試みても `RESULT: PASS` にならない
+7. `resolve-merge.sh` が exit 10 (conflict) 以外の非ゼロで失敗した (2 章)
 
-撤退コメントには以下を含める:
+手順:
 
-- conflict が起きているファイルと衝突箇所の概要
-- 両側の変更の意図 (commit log を参照した推定で可)
-- 推奨される解決方針 (どちらを採用すべきか、または人手で merge すべき理由)
-- 自動解決を断念した理由
+1. `gh label create needs-human --color FBCA04 2>/dev/null || true` (既存なら no-op 扱い)
+2. `gh pr edit "$PR_NUMBER" --add-label needs-human`
+3. コメント本文を一時ファイル (例: `/tmp/escalation-comment.md`) に Write ツールで書き出し、
+   `gh pr comment "$PR_NUMBER" --body-file <path>` で投稿する。本文の形式:
 
-## チェックリスト (push 前)
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか。conflict が起きているファイルと衝突箇所の概要、
+両側の変更意図の推定、推奨される解決方針を含める>
 
-- [ ] `git diff --name-only --diff-filter=U` が空である (= 全 conflict 解決済み)
-- [ ] `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で残マーカーなし
-- [ ] lock ファイルは整合性が取れている
-- [ ] 型 / lint / 単体テストが通る (もしくは通らない理由を報告予定)
-- [ ] commit メッセージは `.gitmessage` の絵文字プレフィックス規約に従っている
-  - merge commit の場合は既定メッセージで可
-  - 追加修正の commit は `:recycle: Resolve conflicts with <base>` などを使う
-- [ ] secrets / 認証情報を含むファイルを誤って追加していない
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "conflict", "detail": "<1-2 文>", "attempts": <試行回数>, "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+ユーザに質問して応答を待つ設計にはしない — コメント投稿とラベル付与をもって処理を終了する。
+`needs-human` 対応後の再開は人間または別トリガに委ねる。
+
+## ガードレール
+
+- **destructive git 禁止**: `push --force*` / `reset --hard` を使わない。merge commit は
+  常に追加コミットとして扱う
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類が conflict
+  していたら 3 の条件でエスカレーションする
+- **`.github/workflows/` の conflict は自動解決しない**: エスカレーションする (security-block 相当)
+- **PR を merge しない**: merge は常に人間ゲート

--- a/.claude/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# finalize.sh - stage resolved conflict files, complete the in-progress
+# merge commit, run a pre-push safety checklist, and push.
+#
+# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+#
+# This is the step the previous prose-only workflow was missing entirely:
+# without `git add` + `git commit`, a resolved merge stays half-finished
+# (MERGE_HEAD still set, paths still "unmerged" in the index) and a
+# subsequent `git push` either fails outright or - worse - pushes a branch
+# that silently dropped the merge. This script refuses to push unless the
+# merge is actually complete.
+#
+# Exit codes:
+#   0 - merge committed, checklist passed, pushed
+#   1 - refused to proceed (see stderr for which checklist item failed) or
+#       `git push` itself failed
+#   2 - usage error
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+  exit 2
+fi
+
+branch="$1"
+shift
+resolved_files=("$@")
+
+git_dir=$(git rev-parse --git-dir)
+
+# 0. There must actually be a merge in progress. Committing here otherwise
+#    would create an unrelated, confusing commit instead of finalizing one.
+if [ ! -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
+  exit 1
+fi
+
+# 1. Every currently-unmerged path must be covered by the caller's file list.
+#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+#    regardless of its content, so after staging this check would always
+#    come back empty and prove nothing about whether resolution happened.
+unmerged=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$unmerged" ]; then
+  missing=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    found=0
+    for rf in "${resolved_files[@]}"; do
+      [ "$rf" = "$path" ] && found=1 && break
+    done
+    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+  done <<<"$unmerged"
+  if [ -n "$missing" ]; then
+    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+    printf '  %s\n' "$missing" >&2
+    exit 1
+  fi
+fi
+
+# 2. Refuse to stage any resolved file that still contains literal conflict
+#    markers. This is the check that actually catches "claimed resolved but
+#    wasn't" - staging alone would happily clear the unmerged flag on a file
+#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+#    slips through unnoticed.
+marker_hit=0
+for f in "${resolved_files[@]}"; do
+  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
+    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+    marker_hit=1
+  fi
+done
+if [ "$marker_hit" -ne 0 ]; then
+  echo "refusing to stage files with unresolved conflict markers" >&2
+  exit 1
+fi
+
+# 3. Stage exactly the files the caller says it resolved. Deliberately not
+#    `git add -A`, which could sweep in unrelated stray changes.
+git add -- "${resolved_files[@]}"
+
+# 4. Sanity check: staging should have cleared every unmerged path. If not,
+#    something outside this script's model changed the index concurrently.
+remaining=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$remaining" ]; then
+  echo "error: unmerged paths remain after staging (unexpected):" >&2
+  printf '  %s\n' "$remaining" >&2
+  exit 1
+fi
+
+# 5. Complete the merge commit (uses the pre-populated merge message).
+git commit --no-edit
+
+# 6. Pre-push checklist. Every item must hold before this script pushes
+#    anything. Content-level marker scanning already happened in step 2,
+#    pre-commit; this is git-state verification only.
+checklist_failed=0
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: [checklist] working tree not clean after merge commit" >&2
+  git status --porcelain >&2
+  checklist_failed=1
+fi
+
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: [checklist] MERGE_HEAD still present after commit; merge did not complete" >&2
+  checklist_failed=1
+fi
+
+if git diff --name-only --diff-filter=U | grep -q .; then
+  echo "error: [checklist] unmerged paths still present" >&2
+  checklist_failed=1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "$branch" ]; then
+  echo "error: [checklist] expected HEAD on '$branch', but it is on '$current_branch'" >&2
+  checklist_failed=1
+fi
+
+if [ "$checklist_failed" -ne 0 ]; then
+  echo "error: pre-push checklist failed; refusing to push (merge commit was already created locally - fix the issue above and push manually once verified, do not re-run this script blindly)" >&2
+  exit 1
+fi
+
+# 7. Push. No --force / --force-with-lease: a merge commit never needs
+#    history rewriting.
+git push origin "$branch"

--- a/.claude/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -2,7 +2,7 @@
 # finalize.sh - stage resolved conflict files, complete the in-progress
 # merge commit, run a pre-push safety checklist, and push.
 #
-# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+# Usage: finalize.sh <push-branch> [<resolved-file> ...]
 #
 # This is the step the previous prose-only workflow was missing entirely:
 # without `git add` + `git commit`, a resolved merge stays half-finished
@@ -11,15 +11,24 @@
 # that silently dropped the merge. This script refuses to push unless the
 # merge is actually complete.
 #
+# Two entry states, both ending at the same pre-push checklist + push:
+#   - Conflicted merge (MERGE_HEAD present): caller passes every resolved
+#     file; this script verifies coverage + no leftover markers, stages,
+#     and commits.
+#   - Already-clean merge (MERGE_HEAD absent, e.g. resolve-merge.sh exited 0
+#     with no conflicts and its own `git merge` already created the commit):
+#     caller passes zero resolved files; this script skips straight to the
+#     checklist instead of erroring out on "no merge in progress".
+#
 # Exit codes:
-#   0 - merge committed, checklist passed, pushed
+#   0 - merge committed (or already committed), checklist passed, pushed
 #   1 - refused to proceed (see stderr for which checklist item failed) or
 #       `git push` itself failed
 #   2 - usage error
 set -euo pipefail
 
-if [ "$#" -lt 2 ]; then
-  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <push-branch> [<resolved-file> ...]" >&2
   exit 2
 fi
 
@@ -29,67 +38,79 @@ resolved_files=("$@")
 
 git_dir=$(git rev-parse --git-dir)
 
-# 0. There must actually be a merge in progress. Committing here otherwise
-#    would create an unrelated, confusing commit instead of finalizing one.
-if [ ! -f "$git_dir/MERGE_HEAD" ]; then
-  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
-  exit 1
-fi
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  # 1. Every currently-unmerged path must be covered by the caller's file list.
+  #    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+  #    regardless of its content, so after staging this check would always
+  #    come back empty and prove nothing about whether resolution happened.
+  unmerged=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$unmerged" ]; then
+    missing=""
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      found=0
+      for rf in "${resolved_files[@]}"; do
+        [ "$rf" = "$path" ] && found=1 && break
+      done
+      [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+    done <<<"$unmerged"
+    if [ -n "$missing" ]; then
+      echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+      printf '  %s\n' "$missing" >&2
+      exit 1
+    fi
+  fi
 
-# 1. Every currently-unmerged path must be covered by the caller's file list.
-#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
-#    regardless of its content, so after staging this check would always
-#    come back empty and prove nothing about whether resolution happened.
-unmerged=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$unmerged" ]; then
-  missing=""
-  while IFS= read -r path; do
-    [ -z "$path" ] && continue
-    found=0
-    for rf in "${resolved_files[@]}"; do
-      [ "$rf" = "$path" ] && found=1 && break
-    done
-    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
-  done <<<"$unmerged"
-  if [ -n "$missing" ]; then
-    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
-    printf '  %s\n' "$missing" >&2
+  # 2. Refuse to stage any resolved file that still contains literal conflict
+  #    markers. This is the check that actually catches "claimed resolved but
+  #    wasn't" - staging alone would happily clear the unmerged flag on a file
+  #    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+  #    slips through unnoticed. Git's real markers are always `<<<<<<< <ref>`,
+  #    a bare `=======`, and `>>>>>>> <ref>` - anchoring on the trailing space
+  #    (outer markers) / end-of-line (middle separator) avoids false-positives
+  #    on unrelated content that merely starts with 7+ of these characters
+  #    (e.g. a longer Markdown Setext heading underline).
+  marker_hit=0
+  for f in "${resolved_files[@]}"; do
+    if [ -f "$f" ] && grep -ncE '^<<<<<<< |^=======$|^>>>>>>> ' -- "$f" >/dev/null 2>&1; then
+      echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+      marker_hit=1
+    fi
+  done
+  if [ "$marker_hit" -ne 0 ]; then
+    echo "refusing to stage files with unresolved conflict markers" >&2
     exit 1
   fi
-fi
 
-# 2. Refuse to stage any resolved file that still contains literal conflict
-#    markers. This is the check that actually catches "claimed resolved but
-#    wasn't" - staging alone would happily clear the unmerged flag on a file
-#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
-#    slips through unnoticed.
-marker_hit=0
-for f in "${resolved_files[@]}"; do
-  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
-    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
-    marker_hit=1
+  # 3. Stage exactly the files the caller says it resolved. Deliberately not
+  #    `git add -A`, which could sweep in unrelated stray changes.
+  git add -- "${resolved_files[@]}"
+
+  # 4. Sanity check: staging should have cleared every unmerged path. If not,
+  #    something outside this script's model changed the index concurrently.
+  remaining=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$remaining" ]; then
+    echo "error: unmerged paths remain after staging (unexpected):" >&2
+    printf '  %s\n' "$remaining" >&2
+    exit 1
   fi
-done
-if [ "$marker_hit" -ne 0 ]; then
-  echo "refusing to stage files with unresolved conflict markers" >&2
-  exit 1
+
+  # 5. Complete the merge commit (uses the pre-populated merge message).
+  git commit --no-edit
+else
+  # 1'. MERGE_HEAD absent: either resolve-merge.sh already completed a
+  # conflict-free merge (its own `git merge` auto-commits and clears
+  # MERGE_HEAD), or this call is confused about which exit code it followed.
+  # resolve-merge.sh only ever produces a resolved-file list on exit 10
+  # (conflicts); on exit 0 there is nothing to resolve, so a non-empty list
+  # here means the caller thinks there was a conflict when there wasn't.
+  if [ "${#resolved_files[@]}" -gt 0 ]; then
+    echo "error: no merge in progress (MERGE_HEAD not found), but resolved file(s) were passed: ${resolved_files[*]}" >&2
+    echo "       resolve-merge.sh only produces a file list on exit 10 (conflicts); on exit 0 there is nothing to resolve" >&2
+    exit 1
+  fi
+  echo "no merge in progress (MERGE_HEAD not found); treating this as an already-committed, conflict-free merge and proceeding to the pre-push checklist" >&2
 fi
-
-# 3. Stage exactly the files the caller says it resolved. Deliberately not
-#    `git add -A`, which could sweep in unrelated stray changes.
-git add -- "${resolved_files[@]}"
-
-# 4. Sanity check: staging should have cleared every unmerged path. If not,
-#    something outside this script's model changed the index concurrently.
-remaining=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$remaining" ]; then
-  echo "error: unmerged paths remain after staging (unexpected):" >&2
-  printf '  %s\n' "$remaining" >&2
-  exit 1
-fi
-
-# 5. Complete the merge commit (uses the pre-populated merge message).
-git commit --no-edit
 
 # 6. Pre-push checklist. Every item must hold before this script pushes
 #    anything. Content-level marker scanning already happened in step 2,

--- a/.claude/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# pr-context.sh - resolve a PR number into eval-able shell variable
+# assignments (head/base branch, title, url, head SHA).
+#
+# Usage: pr-context.sh <pr-number>
+# Requires: gh (authenticated), jq
+#
+# Output (stdout): one `NAME=value` assignment per line, each value shell-
+# quoted with bash's `printf %q` so the whole output is safe to consume with
+# `eval "$(bash pr-context.sh <n>)"` even if a title/branch contains spaces
+# or quotes.
+#
+# Exported names:
+#   PR_NUMBER   - the PR number, as returned by gh (validated integer)
+#   PR_HEAD     - head branch name (what to check out / push back to)
+#   PR_BASE     - base branch name (what to merge in)
+#   PR_TITLE    - PR title (for status comments)
+#   PR_URL      - PR URL (for status comments)
+#   PR_HEAD_SHA - head branch's commit SHA at fetch time (drift/race check:
+#                 compare against HEAD after checkout before pushing)
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+pr="$1"
+
+if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+  echo "error: PR number must be a positive integer, got: '$pr'" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found on PATH" >&2
+  exit 127
+fi
+
+if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+  exit 1
+fi
+
+pr_number=$(jq -r '.number' <<<"$json")
+pr_head=$(jq -r '.headRefName' <<<"$json")
+pr_base=$(jq -r '.baseRefName' <<<"$json")
+pr_title=$(jq -r '.title' <<<"$json")
+pr_url=$(jq -r '.url' <<<"$json")
+pr_head_sha=$(jq -r '.headRefOid' <<<"$json")
+
+if [ -z "$pr_head" ] || [ "$pr_head" = "null" ] || [ -z "$pr_base" ] || [ "$pr_base" = "null" ]; then
+  echo "error: gh returned an incomplete PR record for #$pr (headRefName/baseRefName missing)" >&2
+  exit 1
+fi
+
+printf 'PR_NUMBER=%q\n' "$pr_number"
+printf 'PR_HEAD=%q\n' "$pr_head"
+printf 'PR_BASE=%q\n' "$pr_base"
+printf 'PR_TITLE=%q\n' "$pr_title"
+printf 'PR_URL=%q\n' "$pr_url"
+printf 'PR_HEAD_SHA=%q\n' "$pr_head_sha"

--- a/.claude/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -20,6 +20,24 @@
 #                 compare against HEAD after checkout before pushing)
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `gh pr view` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <pr-number>" >&2
   exit 2
@@ -42,8 +60,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 127
 fi
 
-if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
-  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+# Deliberately NOT `2>&1`: merging stderr into the captured JSON means any
+# warning gh writes to stderr (deprecation notice, etc.) corrupts the value
+# `jq` parses below, even when the PR lookup itself succeeded. Let stderr
+# surface on its own; only stdout is captured as the JSON payload.
+if ! json=$(run_with_timeout 30 gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, no access, or timed out)" >&2
   exit 1
 fi
 

--- a/.claude/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# regen-lockfiles.sh - regenerate conflicted dependency lockfiles instead of
+# hand-editing conflict markers inside generated content.
+#
+# Usage: regen-lockfiles.sh <lockfile-path> [<lockfile-path> ...]
+#
+# Each path's basename selects the ecosystem-specific regeneration command
+# (the `case` below). An unrecognized lockfile name fails loudly rather than
+# being silently skipped, so the caller never pushes a file that still has
+# `<<<<<<<` markers in it.
+#
+# --ignore-scripts (npm/pnpm/yarn/bun) is deliberate: it stops untrusted
+# postinstall hooks from executing during unattended conflict resolution.
+# Repository-specific postinstall steps still run in CI afterward.
+set -uo pipefail
+# NOTE: no `-e` at the top level on purpose. With N conflicted lockfiles we
+# want to attempt every one and report which failed, not abort after the
+# first failure and leave the rest un-attempted. Exit status is computed
+# explicitly from the per-file results below.
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <lockfile-path> [<lockfile-path> ...]" >&2
+  exit 2
+fi
+
+status=0
+
+for path in "$@"; do
+  if [ ! -e "$path" ]; then
+    echo "error: '$path' does not exist (conflict marker removal or a prior step may have deleted it)" >&2
+    status=1
+    continue
+  fi
+
+  base=$(basename -- "$path")
+  dir=$(dirname -- "$path")
+
+  echo "== regenerating $path ==" >&2
+
+  (
+    set -e
+    cd "$dir"
+    case "$base" in
+      package-lock.json)
+        rm -f package-lock.json
+        npm install --package-lock-only --ignore-scripts
+        ;;
+      pnpm-lock.yaml)
+        rm -f pnpm-lock.yaml
+        pnpm install --lockfile-only --ignore-scripts
+        ;;
+      yarn.lock)
+        rm -f yarn.lock
+        yarn install --mode update-lockfile --ignore-scripts 2>/dev/null \
+          || yarn install --ignore-scripts
+        ;;
+      bun.lock | bun.lockb)
+        rm -f bun.lock bun.lockb
+        bun install --frozen-lockfile=false --ignore-scripts
+        ;;
+      Cargo.lock)
+        cargo update --workspace --offline 2>/dev/null \
+          || cargo generate-lockfile
+        ;;
+      poetry.lock)
+        poetry lock --no-update
+        ;;
+      uv.lock)
+        uv lock
+        ;;
+      go.sum)
+        go mod tidy
+        ;;
+      Gemfile.lock)
+        bundle lock --update
+        ;;
+      *)
+        echo "error: unsupported lockfile '$base' - resolve manually, do not guess a regen command" >&2
+        exit 1
+        ;;
+    esac
+  )
+  file_status=$?
+
+  if [ "$file_status" -ne 0 ]; then
+    echo "error: regeneration failed for '$path' (exit $file_status)" >&2
+    status=1
+  fi
+done
+
+exit "$status"

--- a/.claude/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -63,15 +63,30 @@ for path in "$@"; do
           || cargo generate-lockfile
         ;;
       poetry.lock)
+        # poetry/uv/go/bundle all parse the existing lockfile before
+        # resolving, so a conflict-marker-tainted file aborts even
+        # `--no-update` mode. Remove it first, matching the fallback the
+        # npm/pnpm/yarn/bun/Cargo.lock branches above already use.
+        rm -f poetry.lock
         poetry lock --no-update
         ;;
       uv.lock)
+        rm -f uv.lock
         uv lock
         ;;
       go.sum)
+        rm -f go.sum
         go mod tidy
+        # `go mod tidy` can also rewrite go.mod (missing/unused
+        # requirements). go.mod isn't part of the caller's resolved-file
+        # list (only go.sum was conflicted), so stage it here - otherwise
+        # finalize.sh's pre-push "working tree clean" checklist fails after
+        # the merge commit has already been created, since go.mod would be
+        # left modified but uncommitted.
+        git add -- go.mod
         ;;
       Gemfile.lock)
+        rm -f Gemfile.lock
         bundle lock --update
         ;;
       *)

--- a/.claude/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -21,6 +21,24 @@
 #        report the actual error.
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `git fetch` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <base-branch>" >&2
   exit 2
@@ -28,8 +46,8 @@ fi
 
 base="$1"
 
-if ! git fetch origin "$base"; then
-  echo "error: 'git fetch origin $base' failed" >&2
+if ! run_with_timeout 30 git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed (or timed out)" >&2
   exit 1
 fi
 

--- a/.claude/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# resolve-merge.sh - merge a base branch into the currently checked-out
+# branch and report conflicts via a distinct exit code, instead of a prose
+# "if conflict, continue" convention that's easy to get wrong.
+#
+# Usage: resolve-merge.sh <base-branch>
+#
+# Precondition: the PR head branch is already checked out and up to date
+# (see pr-context.sh for PR_HEAD/PR_BASE, then `git checkout "$PR_HEAD"`
+# separately). This script does not check out anything itself.
+#
+# Exit codes:
+#   0  - merge completed with NO conflicts. A merge commit already exists;
+#        skip straight to finalize.sh (there is nothing to `git add`).
+#   10 - merge produced conflicts. Conflicted file paths are printed to
+#        stdout, one per line. Resolve each one (regen-lockfiles.sh for
+#        lockfiles, manual edit for source), THEN call finalize.sh.
+#   *  - any other exit code is an unexpected merge failure (auth error,
+#        unknown ref, corrupt repo, uncommitted local changes blocking the
+#        merge, ...). Do NOT treat this as "conflicts to resolve" - stop and
+#        report the actual error.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <base-branch>" >&2
+  exit 2
+fi
+
+base="$1"
+
+if ! git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed" >&2
+  exit 1
+fi
+
+merge_status=0
+# `git merge` writes its own progress ("Auto-merging ...", "CONFLICT ...")
+# to stdout, which would otherwise corrupt this script's stdout contract
+# (conflicted-file-list only). Redirect it to stderr instead.
+git merge --no-ff --no-edit "origin/$base" >&2 || merge_status=$?
+
+if [ "$merge_status" -eq 0 ]; then
+  echo "merge completed with no conflicts" >&2
+  exit 0
+fi
+
+conflicts=$(git diff --name-only --diff-filter=U || true)
+
+if [ -z "$conflicts" ]; then
+  echo "error: git merge failed (exit $merge_status) for a reason other than conflicts; not proceeding to conflict resolution" >&2
+  exit "$merge_status"
+fi
+
+printf '%s\n' "$conflicts"
+exit 10

--- a/.claude/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/verify.sh
@@ -44,11 +44,20 @@ if [ -f package.json ]; then
   if [ -f tsconfig.json ]; then
     run_check tsc npx --no-install tsc --noEmit
   fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
-    run_check lint npm run lint --if-present
-  fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
-    run_check test npm test --if-present
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+      run_check lint npm run lint --if-present
+    fi
+    if jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+      # CI=true is the de-facto standard signal (jest, vitest, mocha, ava,
+      # ...) for "don't enter watch mode". A bare `npm test` invoking a
+      # watch-by-default runner would otherwise hang here indefinitely
+      # (never emit PASS/FAIL, never reach the trailing RESULT line) in an
+      # unattended run.
+      run_check test env CI=true npm test --if-present
+    fi
+  else
+    echo "warning: jq not found; cannot detect package.json scripts.lint/scripts.test - lint/test checks skipped without running them" >&2
   fi
 fi
 

--- a/.claude/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/.claude/skills/pr-conflict-resolver/scripts/verify.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# verify.sh - run the applicable verification chain (typecheck / lint / test)
+# for whatever stacks are detected in the current working tree, and report a
+# structured, truthful pass/fail summary.
+#
+# Usage: verify.sh
+#
+# THIS SCRIPT NEVER SWALLOWS A CHECK'S EXIT CODE. The previous prose workflow
+# piped `tsc --noEmit` through `|| true`, so a broken build could still be
+# reported as a passing "tsc: ✅" in the PR comment. Every check below keeps
+# its real exit status; a single failing check makes the whole script exit 1.
+#
+# Output (stdout): one line per check that ran, `<name>: PASS|FAIL`, followed
+# by a trailing `RESULT: PASS|FAIL` line. Use this output verbatim as the
+# source of truth for any completion comment - never assert a check passed
+# without pointing at its line here.
+#
+# Exit codes:
+#   0 - every detected check passed (including "no tooling detected")
+#   1 - at least one detected check failed
+set -uo pipefail
+# NOTE: no `-e` on purpose. The point of this script is to run every
+# applicable check and report all of their outcomes, not stop at the first
+# failure. The overall exit status is computed explicitly at the end.
+
+overall=0
+ran_any=0
+
+run_check() {
+  local name="$1"
+  shift
+  echo "-- running: $name --" >&2
+  if "$@"; then
+    echo "$name: PASS"
+  else
+    echo "$name: FAIL"
+    overall=1
+  fi
+  ran_any=1
+}
+
+# --- Node / TypeScript ---
+if [ -f package.json ]; then
+  if [ -f tsconfig.json ]; then
+    run_check tsc npx --no-install tsc --noEmit
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+    run_check lint npm run lint --if-present
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+    run_check test npm test --if-present
+  fi
+fi
+
+# --- Python ---
+if [ -f pyproject.toml ]; then
+  if command -v ruff >/dev/null 2>&1; then
+    run_check ruff ruff check .
+  fi
+  if command -v pytest >/dev/null 2>&1; then
+    run_check pytest pytest
+  fi
+fi
+
+# --- Go ---
+if [ -f go.mod ]; then
+  run_check go-build go build ./...
+  run_check go-test go test ./...
+fi
+
+# --- Rust ---
+if [ -f Cargo.toml ]; then
+  run_check cargo-check cargo check --workspace
+  run_check cargo-test cargo test --workspace
+fi
+
+# --- Make-based projects (only if no more specific check already covered it) ---
+if [ -f Makefile ] && grep -qE '^test:' Makefile; then
+  run_check make-test make test
+fi
+
+if [ "$ran_any" -eq 0 ]; then
+  echo "no known verification tooling detected (package.json/pyproject.toml/go.mod/Cargo.toml/Makefile); nothing to run" >&2
+fi
+
+if [ "$overall" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+
+exit "$overall"

--- a/skills/pr-conflict-resolver/SKILL.md
+++ b/skills/pr-conflict-resolver/SKILL.md
@@ -3,8 +3,9 @@ name: pr-conflict-resolver
 description: |
   GitHub PR で発生した merge conflict を自動修正するための手順とベストプラクティス。
   PR コメントで `@claude` 経由で呼ばれた conflict 解決タスクや、ローカルでの rebase / merge
-  conflict を解決するときに必ず参照する。チェックアウト → merge / rebase → conflict 解決 →
-  lock ファイル再生成 → テスト → push までの一連の安全な流れを定義する。
+  conflict を解決するときに必ず参照する。チェックアウト → merge → conflict 解決 →
+  lock ファイル再生成 → 検証 → commit で merge を確定 → push までの一連の安全な流れを、
+  同梱スクリプト (`scripts/*.sh`) の決定的な実行として定義する。
 claudecode:
   allowed-tools:
     - Bash
@@ -18,18 +19,57 @@ claudecode:
 # PR conflict resolver
 
 PR のターゲットブランチ (base) と head ブランチの間で発生した merge conflict を、機能を欠落させず
-安全に解決するための手順。Claude Code Action から呼び出される前提で、すべて非対話で完結すること。
+安全に解決するための手順。
+
+## 実行環境前提
+
+本スキルは **対話ローカル実行 / ヘッドレス実行 (Claude Code Action 等) の両方**で使う。
+呼び出し元が人間かどうかに関わらず、以降の手順は同一とする:
+
+- 判断が必要な分岐 (ソース conflict の統合方針、撤退判断) で**人間に質問して止まる設計にしない**。
+  ヘッドレスでは応答が来ないため、質問した時点でセッションが unattended のまま放置される。
+- 継続不能なときは 4 章「エスカレーション」の **`needs-human` ラベル + 構造化コメント**で停止する。
+  これは対話環境でも同じ挙動にする (人間に質問するのではなく、判断材料を残して停止し、人間の
+  タイミングでコメントを読んでもらう)。
+- 決定的な多段操作 (PR 情報抽出・merge 実行・lockfile 再生成・検証・push 前確定) は
+  すべて `scripts/*.sh` に閉じ込めてある。**フラグを追加したり、同等のコマンドを手で
+  組み立てて代替したりしない** — 実行者ごとの手順のブレをなくすための決定的スクリプトなので、
+  そのまま実行する。
+
+## 同梱スクリプトと権限
+
+```text
+scripts/
+├── pr-context.sh       # 0. PR 情報の取得
+├── resolve-merge.sh    # 2. base の merge 実行 + conflict 検出
+├── regen-lockfiles.sh  # 3. lockfile の再生成
+├── verify.sh           # 4. 検証チェーン
+└── finalize.sh         # 5. commit で merge 確定 → push 前チェック → push
+```
+
+| script | 役割 | exit code |
+|---|---|---|
+| `pr-context.sh <PR番号>` | `gh pr view --json` で `PR_NUMBER`/`PR_HEAD`/`PR_BASE`/`PR_TITLE`/`PR_URL`/`PR_HEAD_SHA` を `eval` 可能な `NAME=value` 形式で stdout に出力 | 0=成功、127=`gh`/`jq` 不在、1=PR 取得失敗、2=usage |
+| `resolve-merge.sh <base-branch>` | `origin/<base>` を `--no-ff --no-edit` で merge。stdout は conflict ファイル一覧のみ (git 自身の進捗メッセージは stderr に retarget 済み) | 0=conflict なし (merge 完了済み)、10=conflict あり (stdout に一覧)、その他=想定外の merge 失敗 |
+| `regen-lockfiles.sh <path...>` | 渡された各パスの basename でエコシステムを判定し `case` 文で再生成 (`package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` / `bun.lock(b)` / `Cargo.lock` / `poetry.lock` / `uv.lock` / `go.sum` / `Gemfile.lock`)。未知の lockfile は再生成せずエラー | 0=全件成功、1=1件以上失敗、2=usage |
+| `verify.sh` | repo 検出 (`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml`/`Makefile`) に応じて tsc/lint/test 等を実行。**`\|\| true` は使わない** — 各チェックの exit code をそのまま保持する | 0=全チェック PASS (未検出時も PASS 扱い)、1=1件以上 FAIL |
+| `finalize.sh <push-branch> <resolved-file...>` | conflict marker の残存チェック → `git add` → `git commit` で merge を確定 → push 前チェックリスト → `git push` | 0=push 完了、1=チェックリスト不通過または push 失敗、2=usage |
+
+`scripts/*.sh` は `bash "${CLAUDE_SKILL_DIR}/scripts/<name>.sh" <args>` で呼び出す。
+最小依存 (`bash`, `git`, `gh`, `jq`) のみを前提とし、Python/Node 等の追加ランタイムは使わない。
 
 ## 0. 前提情報の確認
 
-呼び出し元のコメントから以下を取得する:
+呼び出し元のコメントに PR 番号があればそれを使う。明示的な解決方針の指示 (例:「lock ファイルは
+theirs を採用」) があれば以降の手順より優先する。
 
-- **PR 番号** (`#N`)
-- **head ブランチ** (作業対象)
-- **base ブランチ** (merge 元)
-- 解決方針の明示的な指示があれば優先する (例: 「lock ファイルは theirs を採用」)
+`scripts/pr-context.sh <PR番号> を正確に実行。フラグ追加禁止。`
 
-不明な場合は `gh pr view <N> --json number,headRefName,baseRefName,title` で取得する。
+```bash
+eval "$(bash "${CLAUDE_SKILL_DIR}/scripts/pr-context.sh" <PR番号>)"
+```
+
+以降 `$PR_NUMBER` / `$PR_HEAD` / `$PR_BASE` / `$PR_TITLE` / `$PR_URL` / `$PR_HEAD_SHA` を使う。
 
 ## 1. ブランチをチェックアウト
 
@@ -40,47 +80,48 @@ git pull --ff-only origin "$PR_HEAD"
 ```
 
 `--ff-only` は他者の push を上書きしないための安全策。fast-forward できないときは
-push が走った可能性があるので一度 `git status` で状態を確認し、想定外であれば停止する。
+push が走った可能性があるので `git status` で状態を確認し、想定外であれば
+4 章の手順でエスカレーションする (無理に `--force` で追従しない)。
 
-## 2. base を merge
+## 2. base を merge して conflict を検出
 
-rebase ではなく **merge** を既定とする。理由:
+rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
+壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
+希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
 
-- PR の commit 履歴と署名 (Co-Authored-By 等) を壊さない
-- PR がレビュー中の場合、force-push は差分を見失わせるため避ける
-
-```bash
-merge_status=0
-git merge --no-ff --no-edit "origin/$PR_BASE" || merge_status=$?
-if [ "$merge_status" -ne 0 ]; then
-  if git diff --name-only --diff-filter=U | grep -q .; then
-    echo "merge conflict を検知。解決ステップへ進行。"
-  else
-    echo "merge が conflict 以外の理由で失敗。処理を中断。" >&2
-    exit "$merge_status"
-  fi
-fi
-```
-
-`|| true` で全エラーを握り潰すと、認証エラーや壊れた ref 等の異常時にも誤って
-解決処理へ進んでしまう。上記のように **conflict (未マージファイルあり) のときだけ継続**し、
-それ以外の非ゼロ終了は中断する。特別な指示で rebase を希望される場合のみ
-`git rebase origin/$PR_BASE` を選択する。
-
-## 3. conflict 箇所の特定
+`scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git diff --name-only --diff-filter=U
+bash "${CLAUDE_SKILL_DIR}/scripts/resolve-merge.sh" "$PR_BASE"
 ```
 
-ファイル種別別に処理戦略を切り替える:
+exit code で分岐する:
+
+- **0** — conflict なし。merge commit は作成済み。3〜4 章を飛ばして 5 章 (`finalize.sh`) へ進む。
+- **10** — conflict あり。stdout に conflict ファイル一覧 (1 行 1 ファイル) が出力される。
+  3 章に進んで各ファイルを解決する。
+- **それ以外** — 認証エラーや壊れた ref 等、merge conflict 以外の理由での失敗。
+  **conflict 解決フローに進まない**。4 章の手順でエスカレーションする。
+
+## 3. conflict 箇所を種別ごとに解決する
+
+`resolve-merge.sh` が出力した一覧をファイル種別で振り分ける:
 
 | ファイル種別 | 戦略 |
 |------------|------|
-| ソースコード | 後述「ソース conflict 解決ガイドライン」に従い手で解決 |
-| lock ファイル (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | conflict マーカーごと削除し、対応するパッケージマネージャで再生成 |
+| ソースコード | 下記「ソース conflict 解決ガイドライン」に従い Edit ツールで手で解決 |
+| lock ファイル (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock(b)`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `go.sum`) | `scripts/regen-lockfiles.sh` に渡して再生成する (手で marker を編集しない) |
 | 生成物 (`dist/`, `build/`, `*.min.js`, snapshot) | `.gitignore` 漏れがないか確認した上で、可能ならビルドし直して上書き |
-| バイナリ | `git checkout --theirs` または `--ours` で base を採用するのが基本。理由をコメントで残す |
+| バイナリ | `git checkout --theirs <path>` または `--ours <path>` で base/head どちらかを採用。採用理由を最終コメントに残す |
+
+lock ファイルは `scripts/regen-lockfiles.sh を正確に実行。フラグ追加禁止。`
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile のパス...>
+```
+
+未知の lockfile 名 (`case` の `*)` 分岐) は再生成コマンドを推測せず失敗する。その場合は
+手動解決に切り替えるか、4 章の手順でエスカレーションする。
 
 ### ソース conflict 解決ガイドライン
 
@@ -88,66 +129,52 @@ git diff --name-only --diff-filter=U
 2. **関数/ブロック単位で統合**: 片側削除を安易に選ばない。同じ箇所への重複編集は **両方の機能を残す**
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
-5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で確認
+5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
+   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
-4 章「無理しない撤退判断」に従って PR にコメントしてエスカレーションする。
-
-### lock ファイルの再生成
-
-各エコシステムごとに対応コマンドが異なる:
-
-```bash
-# package-lock.json
-rm -f package-lock.json && npm install --package-lock-only --ignore-scripts
-
-# pnpm
-rm -f pnpm-lock.yaml && pnpm install --lockfile-only --ignore-scripts
-
-# yarn (berry / classic で挙動が違うので存在するコマンドを使う)
-rm -f yarn.lock && yarn install --mode update-lockfile 2>/dev/null || yarn install --ignore-scripts
-
-# bun
-rm -f bun.lock bun.lockb && bun install --frozen-lockfile=false --ignore-scripts
-
-# Cargo
-cargo update --workspace --offline 2>/dev/null || cargo generate-lockfile
-
-# uv
-uv lock
-
-# poetry
-poetry lock --no-update
-
-# go
-go mod tidy
-```
-
-`--ignore-scripts` を付けるのは untrusted な postinstall を防ぐため。
-リポジトリ固有の `package.json` scripts に必要な処理があれば、CI 上で別途実行されるのでここでは省略してよい。
+4 章「エスカレーション」に従って停止する。ユーザに質問して応答を待つ設計にはしない。
 
 ## 4. 検証
 
-push 前に最低限以下を実行し、conflict 解決の副作用がないことを確認する。
+`scripts/verify.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-# 静的検証 (リポジトリにある場合のみ)
-[ -f package.json ] && npx --no-install tsc --noEmit 2>/dev/null || true
-[ -f package.json ] && npm run lint --if-present
-[ -f package.json ] && npm test --if-present -- --run 2>/dev/null || npm test --if-present
-[ -f Makefile ] && grep -qE '^test:' Makefile && make test
+bash "${CLAUDE_SKILL_DIR}/scripts/verify.sh"
 ```
 
-タイムアウトが発生したり、テスト基盤の起動に外部依存がある場合は **無理に通そうとせず**、
-PR コメントでその旨を報告して push に進む。CI 側で再走するため二重に時間を使わない。
+exit 0 (`RESULT: PASS`) でなければ **conflict 解決の副作用がある**とみなし、5 章に進まない。
+出力の各行 (`<name>: PASS|FAIL`) は完了コメントにそのまま転記する — 実行していないチェックを
+PASS と書かない。タイムアウトや外部依存で特定チェックが実行不能な場合は `verify.sh` の出力
+どおりに (`FAIL` として) 報告し、CI 側の再走に委ねる旨を追記する。**`\|\| true` 等で失敗を
+握り潰して push に進まない。**
 
-## 5. push と報告
+## 5. commit で merge を確定し push する
+
+`scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
 ```bash
-git push origin "$PR_HEAD"
+bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
 ```
 
-force-push (`--force-with-lease` も含む) は merge コミットを使う限り不要。
+このスクリプトが強制する順序 (手動での代替手順を組み立てない):
+
+1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
+3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
+   `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
+   検知できない)
+4. `git add -- <ファイル一覧>` (`git add -A` は使わない — 無関係な変更を巻き込まないため)
+5. `git commit --no-edit` で merge commit を確定
+6. push 前チェックリスト (working tree clean / `MERGE_HEAD` 消滅 / unmerged パスなし /
+   想定ブランチに HEAD がある)
+7. `git push origin "$PR_HEAD"` (force push は使わない — merge commit である限り不要)
+
+exit 0 で完了。exit 1 の場合、**merge commit は既にローカルに作成されている**ことがあるため
+(2〜3 のチェック不通過ならまだ未作成、6 のチェック不通過なら作成済みでの停止)、
+stderr のメッセージを読んでから対応する。盲目的にスクリプトを再実行しない。
+
 push 後、PR に以下フォーマットで結果コメントを残す:
 
 ```markdown
@@ -156,40 +183,54 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 - 解決方針: <merge / rebase>
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
-  - `package-lock.json` — 再生成
-- 検証結果:
-  - tsc: ✅
-  - lint: ⏭ (CI に委譲)
-  - test: ⚠ <一部 skip した場合の理由>
+  - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)
+- 検証結果 (`verify.sh` の出力をそのまま転記):
+  - tsc: PASS
+  - lint: PASS
+  - test: FAIL <理由>
 - 残課題: <あれば箇条書き / なければ「なし」>
 
 push: `<commit-sha>`
 ```
 
-## 無理しない撤退判断
+## エスカレーション (無理しない撤退)
 
-次の条件のいずれかに該当するときは **conflict を解決せず**、PR に方針をコメントして撤退する:
+次のいずれかに該当するときは **その場で解決を試み続けず**、`needs-human` ラベル + 構造化
+コメントで停止する:
 
 1. 機能仕様レベルで相反する変更 (双方の機能を両立させると要件矛盾になる)
 2. 同一テストケースに対する期待値が両側で食い違う
-3. 巨大な自動生成物 (e.g. protobuf, GraphQL schema, OpenAPI) の手解決が現実的でない
+3. 巨大な自動生成物 (protobuf, GraphQL schema, OpenAPI 等) の手解決が現実的でない
 4. `secrets` / 認証情報 / migration 順序など、誤った解決が破壊的になるもの
-5. 5 回以上修正を試みても CI / 型チェックが通らない
+5. `regen-lockfiles.sh` が未知の lockfile でエラー終了し、手動解決も安全に行えない
+6. `verify.sh` が 5 回以上修正を試みても `RESULT: PASS` にならない
+7. `resolve-merge.sh` が exit 10 (conflict) 以外の非ゼロで失敗した (2 章)
 
-撤退コメントには以下を含める:
+手順:
 
-- conflict が起きているファイルと衝突箇所の概要
-- 両側の変更の意図 (commit log を参照した推定で可)
-- 推奨される解決方針 (どちらを採用すべきか、または人手で merge すべき理由)
-- 自動解決を断念した理由
+1. `gh label create needs-human --color FBCA04 2>/dev/null || true` (既存なら no-op 扱い)
+2. `gh pr edit "$PR_NUMBER" --add-label needs-human`
+3. コメント本文を一時ファイル (例: `/tmp/escalation-comment.md`) に Write ツールで書き出し、
+   `gh pr comment "$PR_NUMBER" --body-file <path>` で投稿する。本文の形式:
 
-## チェックリスト (push 前)
+````markdown
+<状況の自由文: 何を試し、なぜ止まるのか。conflict が起きているファイルと衝突箇所の概要、
+両側の変更意図の推定、推奨される解決方針を含める>
 
-- [ ] `git diff --name-only --diff-filter=U` が空である (= 全 conflict 解決済み)
-- [ ] `grep -rE '^<<<<<<<|^=======|^>>>>>>>' .` で残マーカーなし
-- [ ] lock ファイルは整合性が取れている
-- [ ] 型 / lint / 単体テストが通る (もしくは通らない理由を報告予定)
-- [ ] commit メッセージは `.gitmessage` の絵文字プレフィックス規約に従っている
-  - merge commit の場合は既定メッセージで可
-  - 追加修正の commit は `:recycle: Resolve conflicts with <base>` などを使う
-- [ ] secrets / 認証情報を含むファイルを誤って追加していない
+<!-- loop-escalation:v1 -->
+```json
+{"reason": "conflict", "detail": "<1-2 文>", "attempts": <試行回数>, "next_action_hint": "<人間の最短の一手>"}
+```
+````
+
+ユーザに質問して応答を待つ設計にはしない — コメント投稿とラベル付与をもって処理を終了する。
+`needs-human` 対応後の再開は人間または別トリガに委ねる。
+
+## ガードレール
+
+- **destructive git 禁止**: `push --force*` / `reset --hard` を使わない。merge commit は
+  常に追加コミットとして扱う
+- **secrets を読まない・書かない・ログに出さない**: `.env*`, `*.tfvars`, 鍵類が conflict
+  していたら 3 の条件でエスカレーションする
+- **`.github/workflows/` の conflict は自動解決しない**: エスカレーションする (security-block 相当)
+- **PR を merge しない**: merge は常に人間ゲート

--- a/skills/pr-conflict-resolver/SKILL.md
+++ b/skills/pr-conflict-resolver/SKILL.md
@@ -86,8 +86,12 @@ push が走った可能性があるので `git status` で状態を確認し、�
 ## 2. base を merge して conflict を検出
 
 rebase ではなく **merge** を既定とする。PR の commit 履歴・署名 (Co-Authored-By 等) を
-壊さず、レビュー中の force-push による差分見失いも避けられるため。特別な指示で rebase を
-希望される場合のみ `git rebase "origin/$PR_BASE"` に切り替える。
+壊さず、レビュー中の force-push による差分見失いも避けられるため。**rebase への切り替えは
+サポートしない** — 同梱スクリプトは merge 専用に決定的な処理を組んでおり
+(`finalize.sh` は `MERGE_HEAD` の存在と非 force push を前提とする)、rebase は履歴を
+書き換えて force push が必要になる (「destructive git 禁止」のガードレールと矛盾する)
+うえ `finalize.sh` では完了処理できない。rebase を明示的に希望された場合は 4 章の手順で
+エスカレーションする。
 
 `scripts/resolve-merge.sh を正確に実行。フラグ追加禁止。`
 
@@ -130,7 +134,7 @@ bash "${CLAUDE_SKILL_DIR}/scripts/regen-lockfiles.sh" <conflict した lockfile 
 3. **import / 型定義 / API シグネチャ** は両側の変更を合算
 4. **テストファイル** は両側のケースを残し、重複は名前を変えて両立させる
 5. 解決後、conflict マーカー (`<<<<<<<`, `=======`, `>>>>>>>`) が残っていないことを
-   `grep -rnE '^<<<<<<<|^=======|^>>>>>>>' .` で確認する (`finalize.sh` も同じチェックを
+   `grep -rnE '^<<<<<<< |^=======$|^>>>>>>> ' .` で確認する (`finalize.sh` も同じチェックを
    `git add` 前に強制するが、無駄な手戻りを避けるため先に自分で確認しておく)
 
 判断が難しい場合 (相反する仕様変更、両方残すと壊れるロジック等) は **無理に解決せず**、
@@ -154,13 +158,28 @@ PASS と書かない。タイムアウトや外部依存で特定チェックが
 
 `scripts/finalize.sh を正確に実行。フラグ追加禁止。`
 
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
-```
+呼び出し方は 2 章の `resolve-merge.sh` の exit code で変わる:
+
+- **conflict あり (exit 10) で 3 章を経由した場合** — 解決した全ファイルを渡す:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD" <3章で解決した全ファイルのパス...>
+  ```
+
+- **conflict なし (exit 0) で 3〜4 章を飛ばした場合** — `resolve-merge.sh` の
+  `git merge` が merge commit を作成済み (`MERGE_HEAD` は既に消えている) なので、
+  ファイル一覧を渡さず push 前チェックリストだけを実行させる:
+
+  ```bash
+  bash "${CLAUDE_SKILL_DIR}/scripts/finalize.sh" "$PR_HEAD"
+  ```
 
 このスクリプトが強制する順序 (手動での代替手順を組み立てない):
 
-1. `MERGE_HEAD` が存在すること (merge が進行中であること) の確認
+1. `MERGE_HEAD` の有無で分岐する。存在すれば 2〜5 (conflict 解決パス)、なければ
+   ファイル一覧が空であることだけ確認して 6 のチェックリストに直行する
+   (`MERGE_HEAD` なしでファイル一覧が渡されていたらエラーで停止する — exit code の
+   取り違えを検知するため)
 2. 渡されたファイル一覧が、git が把握している unmerged パス全体をカバーしていることの確認
 3. 渡された各ファイルに conflict marker が残っていないことの確認 (`git add` 前に実施 —
    `git add` 自体は marker が残っていても unmerged 状態を消してしまうため、ここでしか
@@ -180,7 +199,7 @@ push 後、PR に以下フォーマットで結果コメントを残す:
 ```markdown
 ### conflict 解決完了
 
-- 解決方針: <merge / rebase>
+- 解決方針: merge
 - 解決したファイル:
   - `path/to/file.ts` — <統合内容を 1 行で>
   - `package-lock.json` — 再生成 (`regen-lockfiles.sh`)

--- a/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# finalize.sh - stage resolved conflict files, complete the in-progress
+# merge commit, run a pre-push safety checklist, and push.
+#
+# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+#
+# This is the step the previous prose-only workflow was missing entirely:
+# without `git add` + `git commit`, a resolved merge stays half-finished
+# (MERGE_HEAD still set, paths still "unmerged" in the index) and a
+# subsequent `git push` either fails outright or - worse - pushes a branch
+# that silently dropped the merge. This script refuses to push unless the
+# merge is actually complete.
+#
+# Exit codes:
+#   0 - merge committed, checklist passed, pushed
+#   1 - refused to proceed (see stderr for which checklist item failed) or
+#       `git push` itself failed
+#   2 - usage error
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+  exit 2
+fi
+
+branch="$1"
+shift
+resolved_files=("$@")
+
+git_dir=$(git rev-parse --git-dir)
+
+# 0. There must actually be a merge in progress. Committing here otherwise
+#    would create an unrelated, confusing commit instead of finalizing one.
+if [ ! -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
+  exit 1
+fi
+
+# 1. Every currently-unmerged path must be covered by the caller's file list.
+#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+#    regardless of its content, so after staging this check would always
+#    come back empty and prove nothing about whether resolution happened.
+unmerged=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$unmerged" ]; then
+  missing=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    found=0
+    for rf in "${resolved_files[@]}"; do
+      [ "$rf" = "$path" ] && found=1 && break
+    done
+    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+  done <<<"$unmerged"
+  if [ -n "$missing" ]; then
+    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+    printf '  %s\n' "$missing" >&2
+    exit 1
+  fi
+fi
+
+# 2. Refuse to stage any resolved file that still contains literal conflict
+#    markers. This is the check that actually catches "claimed resolved but
+#    wasn't" - staging alone would happily clear the unmerged flag on a file
+#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+#    slips through unnoticed.
+marker_hit=0
+for f in "${resolved_files[@]}"; do
+  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
+    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+    marker_hit=1
+  fi
+done
+if [ "$marker_hit" -ne 0 ]; then
+  echo "refusing to stage files with unresolved conflict markers" >&2
+  exit 1
+fi
+
+# 3. Stage exactly the files the caller says it resolved. Deliberately not
+#    `git add -A`, which could sweep in unrelated stray changes.
+git add -- "${resolved_files[@]}"
+
+# 4. Sanity check: staging should have cleared every unmerged path. If not,
+#    something outside this script's model changed the index concurrently.
+remaining=$(git diff --name-only --diff-filter=U || true)
+if [ -n "$remaining" ]; then
+  echo "error: unmerged paths remain after staging (unexpected):" >&2
+  printf '  %s\n' "$remaining" >&2
+  exit 1
+fi
+
+# 5. Complete the merge commit (uses the pre-populated merge message).
+git commit --no-edit
+
+# 6. Pre-push checklist. Every item must hold before this script pushes
+#    anything. Content-level marker scanning already happened in step 2,
+#    pre-commit; this is git-state verification only.
+checklist_failed=0
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: [checklist] working tree not clean after merge commit" >&2
+  git status --porcelain >&2
+  checklist_failed=1
+fi
+
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  echo "error: [checklist] MERGE_HEAD still present after commit; merge did not complete" >&2
+  checklist_failed=1
+fi
+
+if git diff --name-only --diff-filter=U | grep -q .; then
+  echo "error: [checklist] unmerged paths still present" >&2
+  checklist_failed=1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "$branch" ]; then
+  echo "error: [checklist] expected HEAD on '$branch', but it is on '$current_branch'" >&2
+  checklist_failed=1
+fi
+
+if [ "$checklist_failed" -ne 0 ]; then
+  echo "error: pre-push checklist failed; refusing to push (merge commit was already created locally - fix the issue above and push manually once verified, do not re-run this script blindly)" >&2
+  exit 1
+fi
+
+# 7. Push. No --force / --force-with-lease: a merge commit never needs
+#    history rewriting.
+git push origin "$branch"

--- a/skills/pr-conflict-resolver/scripts/finalize.sh
+++ b/skills/pr-conflict-resolver/scripts/finalize.sh
@@ -2,7 +2,7 @@
 # finalize.sh - stage resolved conflict files, complete the in-progress
 # merge commit, run a pre-push safety checklist, and push.
 #
-# Usage: finalize.sh <push-branch> <resolved-file> [<resolved-file> ...]
+# Usage: finalize.sh <push-branch> [<resolved-file> ...]
 #
 # This is the step the previous prose-only workflow was missing entirely:
 # without `git add` + `git commit`, a resolved merge stays half-finished
@@ -11,15 +11,24 @@
 # that silently dropped the merge. This script refuses to push unless the
 # merge is actually complete.
 #
+# Two entry states, both ending at the same pre-push checklist + push:
+#   - Conflicted merge (MERGE_HEAD present): caller passes every resolved
+#     file; this script verifies coverage + no leftover markers, stages,
+#     and commits.
+#   - Already-clean merge (MERGE_HEAD absent, e.g. resolve-merge.sh exited 0
+#     with no conflicts and its own `git merge` already created the commit):
+#     caller passes zero resolved files; this script skips straight to the
+#     checklist instead of erroring out on "no merge in progress".
+#
 # Exit codes:
-#   0 - merge committed, checklist passed, pushed
+#   0 - merge committed (or already committed), checklist passed, pushed
 #   1 - refused to proceed (see stderr for which checklist item failed) or
 #       `git push` itself failed
 #   2 - usage error
 set -euo pipefail
 
-if [ "$#" -lt 2 ]; then
-  echo "usage: $0 <push-branch> <resolved-file> [<resolved-file> ...]" >&2
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <push-branch> [<resolved-file> ...]" >&2
   exit 2
 fi
 
@@ -29,67 +38,79 @@ resolved_files=("$@")
 
 git_dir=$(git rev-parse --git-dir)
 
-# 0. There must actually be a merge in progress. Committing here otherwise
-#    would create an unrelated, confusing commit instead of finalizing one.
-if [ ! -f "$git_dir/MERGE_HEAD" ]; then
-  echo "error: no merge in progress (MERGE_HEAD not found); nothing to finalize" >&2
-  exit 1
-fi
+if [ -f "$git_dir/MERGE_HEAD" ]; then
+  # 1. Every currently-unmerged path must be covered by the caller's file list.
+  #    Checked BEFORE staging: `git add` clears a path's "unmerged" status
+  #    regardless of its content, so after staging this check would always
+  #    come back empty and prove nothing about whether resolution happened.
+  unmerged=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$unmerged" ]; then
+    missing=""
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      found=0
+      for rf in "${resolved_files[@]}"; do
+        [ "$rf" = "$path" ] && found=1 && break
+      done
+      [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
+    done <<<"$unmerged"
+    if [ -n "$missing" ]; then
+      echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
+      printf '  %s\n' "$missing" >&2
+      exit 1
+    fi
+  fi
 
-# 1. Every currently-unmerged path must be covered by the caller's file list.
-#    Checked BEFORE staging: `git add` clears a path's "unmerged" status
-#    regardless of its content, so after staging this check would always
-#    come back empty and prove nothing about whether resolution happened.
-unmerged=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$unmerged" ]; then
-  missing=""
-  while IFS= read -r path; do
-    [ -z "$path" ] && continue
-    found=0
-    for rf in "${resolved_files[@]}"; do
-      [ "$rf" = "$path" ] && found=1 && break
-    done
-    [ "$found" -eq 0 ] && missing="${missing}${path}"$'\n'
-  done <<<"$unmerged"
-  if [ -n "$missing" ]; then
-    echo "error: conflicted paths were not passed to finalize.sh and remain unresolved:" >&2
-    printf '  %s\n' "$missing" >&2
+  # 2. Refuse to stage any resolved file that still contains literal conflict
+  #    markers. This is the check that actually catches "claimed resolved but
+  #    wasn't" - staging alone would happily clear the unmerged flag on a file
+  #    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
+  #    slips through unnoticed. Git's real markers are always `<<<<<<< <ref>`,
+  #    a bare `=======`, and `>>>>>>> <ref>` - anchoring on the trailing space
+  #    (outer markers) / end-of-line (middle separator) avoids false-positives
+  #    on unrelated content that merely starts with 7+ of these characters
+  #    (e.g. a longer Markdown Setext heading underline).
+  marker_hit=0
+  for f in "${resolved_files[@]}"; do
+    if [ -f "$f" ] && grep -ncE '^<<<<<<< |^=======$|^>>>>>>> ' -- "$f" >/dev/null 2>&1; then
+      echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
+      marker_hit=1
+    fi
+  done
+  if [ "$marker_hit" -ne 0 ]; then
+    echo "refusing to stage files with unresolved conflict markers" >&2
     exit 1
   fi
-fi
 
-# 2. Refuse to stage any resolved file that still contains literal conflict
-#    markers. This is the check that actually catches "claimed resolved but
-#    wasn't" - staging alone would happily clear the unmerged flag on a file
-#    that still has `<<<<<<<` in it, which is exactly how a bad merge commit
-#    slips through unnoticed.
-marker_hit=0
-for f in "${resolved_files[@]}"; do
-  if [ -f "$f" ] && grep -ncE '^<<<<<<<|^=======|^>>>>>>>' -- "$f" >/dev/null 2>&1; then
-    echo "error: '$f' still contains conflict markers; resolve its content before finalizing" >&2
-    marker_hit=1
+  # 3. Stage exactly the files the caller says it resolved. Deliberately not
+  #    `git add -A`, which could sweep in unrelated stray changes.
+  git add -- "${resolved_files[@]}"
+
+  # 4. Sanity check: staging should have cleared every unmerged path. If not,
+  #    something outside this script's model changed the index concurrently.
+  remaining=$(git diff --name-only --diff-filter=U || true)
+  if [ -n "$remaining" ]; then
+    echo "error: unmerged paths remain after staging (unexpected):" >&2
+    printf '  %s\n' "$remaining" >&2
+    exit 1
   fi
-done
-if [ "$marker_hit" -ne 0 ]; then
-  echo "refusing to stage files with unresolved conflict markers" >&2
-  exit 1
+
+  # 5. Complete the merge commit (uses the pre-populated merge message).
+  git commit --no-edit
+else
+  # 1'. MERGE_HEAD absent: either resolve-merge.sh already completed a
+  # conflict-free merge (its own `git merge` auto-commits and clears
+  # MERGE_HEAD), or this call is confused about which exit code it followed.
+  # resolve-merge.sh only ever produces a resolved-file list on exit 10
+  # (conflicts); on exit 0 there is nothing to resolve, so a non-empty list
+  # here means the caller thinks there was a conflict when there wasn't.
+  if [ "${#resolved_files[@]}" -gt 0 ]; then
+    echo "error: no merge in progress (MERGE_HEAD not found), but resolved file(s) were passed: ${resolved_files[*]}" >&2
+    echo "       resolve-merge.sh only produces a file list on exit 10 (conflicts); on exit 0 there is nothing to resolve" >&2
+    exit 1
+  fi
+  echo "no merge in progress (MERGE_HEAD not found); treating this as an already-committed, conflict-free merge and proceeding to the pre-push checklist" >&2
 fi
-
-# 3. Stage exactly the files the caller says it resolved. Deliberately not
-#    `git add -A`, which could sweep in unrelated stray changes.
-git add -- "${resolved_files[@]}"
-
-# 4. Sanity check: staging should have cleared every unmerged path. If not,
-#    something outside this script's model changed the index concurrently.
-remaining=$(git diff --name-only --diff-filter=U || true)
-if [ -n "$remaining" ]; then
-  echo "error: unmerged paths remain after staging (unexpected):" >&2
-  printf '  %s\n' "$remaining" >&2
-  exit 1
-fi
-
-# 5. Complete the merge commit (uses the pre-populated merge message).
-git commit --no-edit
 
 # 6. Pre-push checklist. Every item must hold before this script pushes
 #    anything. Content-level marker scanning already happened in step 2,

--- a/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# pr-context.sh - resolve a PR number into eval-able shell variable
+# assignments (head/base branch, title, url, head SHA).
+#
+# Usage: pr-context.sh <pr-number>
+# Requires: gh (authenticated), jq
+#
+# Output (stdout): one `NAME=value` assignment per line, each value shell-
+# quoted with bash's `printf %q` so the whole output is safe to consume with
+# `eval "$(bash pr-context.sh <n>)"` even if a title/branch contains spaces
+# or quotes.
+#
+# Exported names:
+#   PR_NUMBER   - the PR number, as returned by gh (validated integer)
+#   PR_HEAD     - head branch name (what to check out / push back to)
+#   PR_BASE     - base branch name (what to merge in)
+#   PR_TITLE    - PR title (for status comments)
+#   PR_URL      - PR URL (for status comments)
+#   PR_HEAD_SHA - head branch's commit SHA at fetch time (drift/race check:
+#                 compare against HEAD after checkout before pushing)
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+pr="$1"
+
+if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+  echo "error: PR number must be a positive integer, got: '$pr'" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found on PATH" >&2
+  exit 127
+fi
+
+if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+  exit 1
+fi
+
+pr_number=$(jq -r '.number' <<<"$json")
+pr_head=$(jq -r '.headRefName' <<<"$json")
+pr_base=$(jq -r '.baseRefName' <<<"$json")
+pr_title=$(jq -r '.title' <<<"$json")
+pr_url=$(jq -r '.url' <<<"$json")
+pr_head_sha=$(jq -r '.headRefOid' <<<"$json")
+
+if [ -z "$pr_head" ] || [ "$pr_head" = "null" ] || [ -z "$pr_base" ] || [ "$pr_base" = "null" ]; then
+  echo "error: gh returned an incomplete PR record for #$pr (headRefName/baseRefName missing)" >&2
+  exit 1
+fi
+
+printf 'PR_NUMBER=%q\n' "$pr_number"
+printf 'PR_HEAD=%q\n' "$pr_head"
+printf 'PR_BASE=%q\n' "$pr_base"
+printf 'PR_TITLE=%q\n' "$pr_title"
+printf 'PR_URL=%q\n' "$pr_url"
+printf 'PR_HEAD_SHA=%q\n' "$pr_head_sha"

--- a/skills/pr-conflict-resolver/scripts/pr-context.sh
+++ b/skills/pr-conflict-resolver/scripts/pr-context.sh
@@ -20,6 +20,24 @@
 #                 compare against HEAD after checkout before pushing)
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `gh pr view` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <pr-number>" >&2
   exit 2
@@ -42,8 +60,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 127
 fi
 
-if ! json=$(gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid 2>&1); then
-  echo "error: 'gh pr view $pr' failed (PR not found, no auth, or no access): $json" >&2
+# Deliberately NOT `2>&1`: merging stderr into the captured JSON means any
+# warning gh writes to stderr (deprecation notice, etc.) corrupts the value
+# `jq` parses below, even when the PR lookup itself succeeded. Let stderr
+# surface on its own; only stdout is captured as the JSON payload.
+if ! json=$(run_with_timeout 30 gh pr view "$pr" --json number,headRefName,baseRefName,title,url,headRefOid); then
+  echo "error: 'gh pr view $pr' failed (PR not found, no auth, no access, or timed out)" >&2
   exit 1
 fi
 

--- a/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# regen-lockfiles.sh - regenerate conflicted dependency lockfiles instead of
+# hand-editing conflict markers inside generated content.
+#
+# Usage: regen-lockfiles.sh <lockfile-path> [<lockfile-path> ...]
+#
+# Each path's basename selects the ecosystem-specific regeneration command
+# (the `case` below). An unrecognized lockfile name fails loudly rather than
+# being silently skipped, so the caller never pushes a file that still has
+# `<<<<<<<` markers in it.
+#
+# --ignore-scripts (npm/pnpm/yarn/bun) is deliberate: it stops untrusted
+# postinstall hooks from executing during unattended conflict resolution.
+# Repository-specific postinstall steps still run in CI afterward.
+set -uo pipefail
+# NOTE: no `-e` at the top level on purpose. With N conflicted lockfiles we
+# want to attempt every one and report which failed, not abort after the
+# first failure and leave the rest un-attempted. Exit status is computed
+# explicitly from the per-file results below.
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <lockfile-path> [<lockfile-path> ...]" >&2
+  exit 2
+fi
+
+status=0
+
+for path in "$@"; do
+  if [ ! -e "$path" ]; then
+    echo "error: '$path' does not exist (conflict marker removal or a prior step may have deleted it)" >&2
+    status=1
+    continue
+  fi
+
+  base=$(basename -- "$path")
+  dir=$(dirname -- "$path")
+
+  echo "== regenerating $path ==" >&2
+
+  (
+    set -e
+    cd "$dir"
+    case "$base" in
+      package-lock.json)
+        rm -f package-lock.json
+        npm install --package-lock-only --ignore-scripts
+        ;;
+      pnpm-lock.yaml)
+        rm -f pnpm-lock.yaml
+        pnpm install --lockfile-only --ignore-scripts
+        ;;
+      yarn.lock)
+        rm -f yarn.lock
+        yarn install --mode update-lockfile --ignore-scripts 2>/dev/null \
+          || yarn install --ignore-scripts
+        ;;
+      bun.lock | bun.lockb)
+        rm -f bun.lock bun.lockb
+        bun install --frozen-lockfile=false --ignore-scripts
+        ;;
+      Cargo.lock)
+        cargo update --workspace --offline 2>/dev/null \
+          || cargo generate-lockfile
+        ;;
+      poetry.lock)
+        poetry lock --no-update
+        ;;
+      uv.lock)
+        uv lock
+        ;;
+      go.sum)
+        go mod tidy
+        ;;
+      Gemfile.lock)
+        bundle lock --update
+        ;;
+      *)
+        echo "error: unsupported lockfile '$base' - resolve manually, do not guess a regen command" >&2
+        exit 1
+        ;;
+    esac
+  )
+  file_status=$?
+
+  if [ "$file_status" -ne 0 ]; then
+    echo "error: regeneration failed for '$path' (exit $file_status)" >&2
+    status=1
+  fi
+done
+
+exit "$status"

--- a/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
+++ b/skills/pr-conflict-resolver/scripts/regen-lockfiles.sh
@@ -63,15 +63,30 @@ for path in "$@"; do
           || cargo generate-lockfile
         ;;
       poetry.lock)
+        # poetry/uv/go/bundle all parse the existing lockfile before
+        # resolving, so a conflict-marker-tainted file aborts even
+        # `--no-update` mode. Remove it first, matching the fallback the
+        # npm/pnpm/yarn/bun/Cargo.lock branches above already use.
+        rm -f poetry.lock
         poetry lock --no-update
         ;;
       uv.lock)
+        rm -f uv.lock
         uv lock
         ;;
       go.sum)
+        rm -f go.sum
         go mod tidy
+        # `go mod tidy` can also rewrite go.mod (missing/unused
+        # requirements). go.mod isn't part of the caller's resolved-file
+        # list (only go.sum was conflicted), so stage it here - otherwise
+        # finalize.sh's pre-push "working tree clean" checklist fails after
+        # the merge commit has already been created, since go.mod would be
+        # left modified but uncommitted.
+        git add -- go.mod
         ;;
       Gemfile.lock)
+        rm -f Gemfile.lock
         bundle lock --update
         ;;
       *)

--- a/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -21,6 +21,24 @@
 #        report the actual error.
 set -euo pipefail
 
+# Best-effort external timeout: this runs unattended, so a network stall on
+# `git fetch` must not block the whole conflict-resolution workflow
+# indefinitely. Prefer GNU coreutils `timeout`/`gtimeout` when present; fall
+# back to running the command directly when neither exists (e.g. a bare
+# macOS shell with no coreutils installed) rather than hard-failing every
+# invocation on a missing dependency.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <base-branch>" >&2
   exit 2
@@ -28,8 +46,8 @@ fi
 
 base="$1"
 
-if ! git fetch origin "$base"; then
-  echo "error: 'git fetch origin $base' failed" >&2
+if ! run_with_timeout 30 git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed (or timed out)" >&2
   exit 1
 fi
 

--- a/skills/pr-conflict-resolver/scripts/resolve-merge.sh
+++ b/skills/pr-conflict-resolver/scripts/resolve-merge.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# resolve-merge.sh - merge a base branch into the currently checked-out
+# branch and report conflicts via a distinct exit code, instead of a prose
+# "if conflict, continue" convention that's easy to get wrong.
+#
+# Usage: resolve-merge.sh <base-branch>
+#
+# Precondition: the PR head branch is already checked out and up to date
+# (see pr-context.sh for PR_HEAD/PR_BASE, then `git checkout "$PR_HEAD"`
+# separately). This script does not check out anything itself.
+#
+# Exit codes:
+#   0  - merge completed with NO conflicts. A merge commit already exists;
+#        skip straight to finalize.sh (there is nothing to `git add`).
+#   10 - merge produced conflicts. Conflicted file paths are printed to
+#        stdout, one per line. Resolve each one (regen-lockfiles.sh for
+#        lockfiles, manual edit for source), THEN call finalize.sh.
+#   *  - any other exit code is an unexpected merge failure (auth error,
+#        unknown ref, corrupt repo, uncommitted local changes blocking the
+#        merge, ...). Do NOT treat this as "conflicts to resolve" - stop and
+#        report the actual error.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <base-branch>" >&2
+  exit 2
+fi
+
+base="$1"
+
+if ! git fetch origin "$base"; then
+  echo "error: 'git fetch origin $base' failed" >&2
+  exit 1
+fi
+
+merge_status=0
+# `git merge` writes its own progress ("Auto-merging ...", "CONFLICT ...")
+# to stdout, which would otherwise corrupt this script's stdout contract
+# (conflicted-file-list only). Redirect it to stderr instead.
+git merge --no-ff --no-edit "origin/$base" >&2 || merge_status=$?
+
+if [ "$merge_status" -eq 0 ]; then
+  echo "merge completed with no conflicts" >&2
+  exit 0
+fi
+
+conflicts=$(git diff --name-only --diff-filter=U || true)
+
+if [ -z "$conflicts" ]; then
+  echo "error: git merge failed (exit $merge_status) for a reason other than conflicts; not proceeding to conflict resolution" >&2
+  exit "$merge_status"
+fi
+
+printf '%s\n' "$conflicts"
+exit 10

--- a/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/skills/pr-conflict-resolver/scripts/verify.sh
@@ -44,11 +44,20 @@ if [ -f package.json ]; then
   if [ -f tsconfig.json ]; then
     run_check tsc npx --no-install tsc --noEmit
   fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
-    run_check lint npm run lint --if-present
-  fi
-  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
-    run_check test npm test --if-present
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+      run_check lint npm run lint --if-present
+    fi
+    if jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+      # CI=true is the de-facto standard signal (jest, vitest, mocha, ava,
+      # ...) for "don't enter watch mode". A bare `npm test` invoking a
+      # watch-by-default runner would otherwise hang here indefinitely
+      # (never emit PASS/FAIL, never reach the trailing RESULT line) in an
+      # unattended run.
+      run_check test env CI=true npm test --if-present
+    fi
+  else
+    echo "warning: jq not found; cannot detect package.json scripts.lint/scripts.test - lint/test checks skipped without running them" >&2
   fi
 fi
 

--- a/skills/pr-conflict-resolver/scripts/verify.sh
+++ b/skills/pr-conflict-resolver/scripts/verify.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# verify.sh - run the applicable verification chain (typecheck / lint / test)
+# for whatever stacks are detected in the current working tree, and report a
+# structured, truthful pass/fail summary.
+#
+# Usage: verify.sh
+#
+# THIS SCRIPT NEVER SWALLOWS A CHECK'S EXIT CODE. The previous prose workflow
+# piped `tsc --noEmit` through `|| true`, so a broken build could still be
+# reported as a passing "tsc: ✅" in the PR comment. Every check below keeps
+# its real exit status; a single failing check makes the whole script exit 1.
+#
+# Output (stdout): one line per check that ran, `<name>: PASS|FAIL`, followed
+# by a trailing `RESULT: PASS|FAIL` line. Use this output verbatim as the
+# source of truth for any completion comment - never assert a check passed
+# without pointing at its line here.
+#
+# Exit codes:
+#   0 - every detected check passed (including "no tooling detected")
+#   1 - at least one detected check failed
+set -uo pipefail
+# NOTE: no `-e` on purpose. The point of this script is to run every
+# applicable check and report all of their outcomes, not stop at the first
+# failure. The overall exit status is computed explicitly at the end.
+
+overall=0
+ran_any=0
+
+run_check() {
+  local name="$1"
+  shift
+  echo "-- running: $name --" >&2
+  if "$@"; then
+    echo "$name: PASS"
+  else
+    echo "$name: FAIL"
+    overall=1
+  fi
+  ran_any=1
+}
+
+# --- Node / TypeScript ---
+if [ -f package.json ]; then
+  if [ -f tsconfig.json ]; then
+    run_check tsc npx --no-install tsc --noEmit
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+    run_check lint npm run lint --if-present
+  fi
+  if command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+    run_check test npm test --if-present
+  fi
+fi
+
+# --- Python ---
+if [ -f pyproject.toml ]; then
+  if command -v ruff >/dev/null 2>&1; then
+    run_check ruff ruff check .
+  fi
+  if command -v pytest >/dev/null 2>&1; then
+    run_check pytest pytest
+  fi
+fi
+
+# --- Go ---
+if [ -f go.mod ]; then
+  run_check go-build go build ./...
+  run_check go-test go test ./...
+fi
+
+# --- Rust ---
+if [ -f Cargo.toml ]; then
+  run_check cargo-check cargo check --workspace
+  run_check cargo-test cargo test --workspace
+fi
+
+# --- Make-based projects (only if no more specific check already covered it) ---
+if [ -f Makefile ] && grep -qE '^test:' Makefile; then
+  run_check make-test make test
+fi
+
+if [ "$ran_any" -eq 0 ]; then
+  echo "no known verification tooling detected (package.json/pyproject.toml/go.mod/Cargo.toml/Makefile); nothing to run" >&2
+fi
+
+if [ "$overall" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+
+exit "$overall"


### PR DESCRIPTION
## Summary

Trigger eval runs against `pr-conflict-resolver` surfaced three confirmed blocking defects in the prose-only workflow. This PR replaces the non-deterministic multi-step prose with executable scripts and rewrites the SKILL.md around calling them exactly, plus fixes the unattended-fallback design.

## Defect → fix mapping

| # | Defect (confirmed by eval) | Fix |
|---|---|---|
| 1 | Conflict resolution had **no `git add` / `git commit` step to finalize the merge** — the workflow jumped straight from "resolve conflicts" to "push", risking a push of a half-finished merge (`MERGE_HEAD` still set, paths still unmerged). | `scripts/finalize.sh`: checks every unmerged path is covered by the caller's file list, refuses to stage any file that still contains literal conflict markers (checked **before** `git add`, since staging alone clears git's "unmerged" flag regardless of content), then `git add` → `git commit --no-edit` → pre-push checklist → `git push`. |
| 2 | `tsc --noEmit` verification was piped through **`\|\| true`**, discarding its exit code — a broken typecheck could still be reported as a passing `tsc: ✅` in the completion comment. | `scripts/verify.sh`: runs the applicable tsc/lint/test/build chain per repo detection (`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml`/`Makefile`) and **never swallows a check's exit code**. Exits non-zero if any check fails; prints a truthful `<name>: PASS\|FAIL` line per check plus a `RESULT: PASS\|FAIL` summary. |
| 3 | Deterministic multi-step operations (PR context extraction, merge + conflict detection, lockfile regeneration, verification chain, pre-push checks, comment posting) were **prose**, which drifts between executors. | Extracted into `scripts/pr-context.sh`, `scripts/resolve-merge.sh`, `scripts/regen-lockfiles.sh`, `scripts/verify.sh`, `scripts/finalize.sh`. SKILL.md now instructs each step as "execute `scripts/X.sh` exactly, do not add flags" (low-freedom) instead of re-describing shell commands inline. |

## Other changes bundled into the SKILL.md rewrite

- **実行環境前提** section added up front: the skill runs identically whether invoked interactively or headless (Claude Code Action).
- **Unattended fallback unified**: judgment points that can't be resolved automatically (source-conflict semantics, retreat conditions) now stop via **`needs-human` label + a structured `loop-escalation:v1` comment** (same schema already used by `issue-driven-development`), instead of "ask the user".
- No `CRITICAL`/`MUST` overuse; body is 236 lines (well under the 500-line guideline); no reference nesting beyond one level (none added).
- Regenerated `.claude/` and `.agents/` mirrors via `node scripts/rulesync-sync.mjs`; `--check` passes.

## Verification

- `bash -n` and `shellcheck` clean on all 5 new scripts.
- End-to-end smoke test against a throwaway local repo pair (bare remote + clone), covering:
  - `resolve-merge.sh` correctly reports a real conflict via exit 10 with a clean, single-file stdout list (caught and fixed a bug where `git merge`'s own progress output leaked onto stdout).
  - `finalize.sh` refuses to stage/commit when a "resolved" file still contains literal conflict markers, **before** any commit is created (caught and fixed an ordering bug where `git add` alone cleared git's unmerged flag regardless of content).
  - `finalize.sh` successfully commits and pushes once a conflict is genuinely resolved.
  - `resolve-merge.sh` exits 0 on a conflict-free merge.
  - `verify.sh` exits 0 / `RESULT: PASS` when no known tooling is detected.
  - `verify.sh` propagates a broken `tsc` build as a non-zero exit / `RESULT: FAIL` (the actual regression test for defect #2).
- `tests/test_skill_frontmatter.py` and `tests/test_check_trigger_evals.py` (stdlib `unittest`) pass.
- `node scripts/rulesync-sync.mjs --check` passes.

## Test plan

- [x] `bash -n` + `shellcheck` on all new scripts
- [x] End-to-end smoke test in a throwaway git repo (conflict detect / marker guard / finalize+push / clean-merge / verify pass+fail paths)
- [x] `uv run --no-project python -m unittest tests.test_skill_frontmatter tests.test_check_trigger_evals`
- [x] `node scripts/rulesync-sync.mjs --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2CFHmQZWEq7ib6T85hpuR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more reliable PR conflict-resolution flow with clearer steps for merging, resolving conflicts, regenerating lockfiles, verifying changes, and finalizing updates.
  * Improved PR context handling so key PR details are gathered consistently for downstream steps.

* **Bug Fixes**
  * Strengthened merge finalization checks to prevent incomplete conflict resolutions from being committed or pushed.
  * Made verification more consistent across common project types and ensured failures are reported clearly instead of being hidden.

* **Documentation**
  * Updated the guidance to match the new, safer workflow and escalation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->