### PR TITLE
fix(issue-driven-development): make lock acquisition reversible

### DIFF
--- a/.agents/skills/issue-driven-development/SKILL.md
+++ b/.agents/skills/issue-driven-development/SKILL.md
@@ -40,7 +40,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+- **C. 探索モード**: まず `"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" --reap $REPO` で失効した
   `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
   対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
@@ -67,8 +67,12 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
   のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
   または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
+呼び出しは agent の作業ディレクトリ (対象リポジトリの checkout) ではなく本 skill の
+インストール先を指す `${CLAUDE_SKILL_DIR}` を起点にする — 対象リポジトリ側に
+`scripts/acquire-lock.sh` が無い consumer 環境では cwd 相対だと解決に失敗するため:
+
 ```bash
-scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" "$OWNER/$REPO" "$NUMBER"
 ```
 
 | 終了コード | 意味 | 次のアクション |

--- a/.agents/skills/issue-driven-development/SKILL.md
+++ b/.agents/skills/issue-driven-development/SKILL.md
@@ -84,7 +84,10 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
 | `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
 
 ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
-`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human` /
+`claude-loop:1..3`)。`claude-loop:N` はこの後の CI 修正反応 (`ci-self-heal`)
+が付け替える前提のラベルで、事前作成しておかないと fresh な consumer repo で
+最初の CI 失敗反応が失敗する。
 
 **この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
 (この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は

--- a/.agents/skills/issue-driven-development/SKILL.md
+++ b/.agents/skills/issue-driven-development/SKILL.md
@@ -15,7 +15,7 @@ description: |
   Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
   CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
   単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
-  素の `git` / `gh` だけで動くこと。
+  素の `git` / `gh` / `jq` だけで動くこと。
 ---
 # issue-driven-development
 
@@ -32,6 +32,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 |---|---|---|
 | `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
 | `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+| `LOCK_LEASE_TTL_SECONDS` | `scripts/acquire-lock.sh` の lock lease 失効秒数 | no (既定 3600) |
 
 ## 入力契約
 
@@ -39,24 +40,53 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+  `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
+  対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+  reap を省略すると、クラッシュした run が握ったままの issue が永久に
+  queue へ戻らない (kanade0404/skills#31 のデッドロック)。
 
 Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
 
 ## 排他制御 (二重起動防止)
 
-ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+ラベル張り替えは atomic でないため、決定論的なロック検証を行う。手順は
+[`scripts/acquire-lock.sh`](scripts/acquire-lock.sh) に切り出し済み — **ラベルは
+最古検証に勝った run しか触らない**ことと、**lock に有効期限 (lease) を持たせる**
+ことで、旧手順にあった 2 つの非可逆バグ (kanade0404/skills#31) を構造的に潰している:
 
-0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
-1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
-2. `claude:ready` を外し `claude:in-progress` を付ける
-3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
-   - 自分が最古 → 続行
-   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+- **queue 消失**: 旧手順は「lock コメント投稿 → ラベル張替 → 最古検証」の順で、
+  敗者やクラッシュした run が `claude:in-progress` だけ外して `claude:ready` を
+  永久に失っていた。新手順は「lock コメント投稿 → 最古検証 → (勝者だけ) ラベル張替」
+  の順に入れ替え、**敗者・エラー終了はラベルを一切書き換えない**。
+- **デッドロック**: 旧手順は「最古の `claude-lock:` コメントが勝ち」を無期限に
+  適用しており、クラッシュした run のコメントが永久に勝ち続けた。新手順は
+  lock コメントに `ts=<epoch>` のリース時刻を刻み、`LOCK_LEASE_TTL_SECONDS`
+  (既定 3600 秒) を超えたコメントは勝者判定から除外する。加えて `claude:in-progress`
+  のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
+  または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
-ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
-`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+```bash
+scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+```
+
+| 終了コード | 意味 | 次のアクション |
+|---|---|---|
+| `0` | ロック取得成功。ラベルは `claude:in-progress` に変わっている | 実装に進む |
+| `3` | 既に終端 (`claude:done` / `claude:failed`) | 何もせず次の issue へ (探索モードなら次候補) |
+| `4` | 他の生存中の run が保持中 (lease 未失効) | 何もせず次の issue へ |
+| `5` | 最古検証に敗北 | 何もせず次の issue へ (自分の lock コメントは監査用に残る) |
+| `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
+
+ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+
+**この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
+(この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は
+lease 失効 + 次回 `--reap` (または該当 issue への再アクセス時の自動 reclaim) に
+委ねている。想定される正常系はあくまで `## エスカレーション` — 継続不能を検知
+できた場合は必ずそちらで `needs-human` + `claude:failed` に明示遷移すること。
 
 Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
 ([references/actions-wiring.md](references/actions-wiring.md))。

--- a/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/.agents/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,13 +1,13 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
-{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
-{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
-{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
-{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
-{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
-{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
-{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
-{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
-{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
-{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
-{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
-{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description 冒頭の主経路。lock/jq 関連の追記は判定に影響しない"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#123 の手動再実行を明示。実行環境が git/gh/jq に変わっても判定不変"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述のまま変更なし"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙 (変更なし)"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的として継続"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示 (継続)"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し (継続)"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し (継続)"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し (継続)"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し (継続)"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示 (継続)"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い (継続)"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い (継続)"}

--- a/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -84,7 +84,12 @@ gen_run_id() {
 
 ensure_labels() {
   repo="$1"
-  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+  # claude-loop:1..3 are provisioned here too: this is now the only label
+  # provisioning path before the workflow hands off to the CI-fix/review
+  # reactions, and those bounded-retry reactions assume the labels already
+  # exist (gh issue/pr edit --add-label does not auto-create labels).
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human \
+    claude-loop:1 claude-loop:2 claude-loop:3; do
     gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
   done
 }
@@ -129,6 +134,16 @@ if [ "${1:-}" = "--reap" ]; then
   # stale claude:in-progress issues once a repo has more open ones than that.
   numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
+    # Mirror the single-issue terminal check: a run that partially completes
+    # (label mutations aren't atomic) can leave BOTH claude:in-progress and a
+    # terminal label on the same issue. Without this, a later sweep would
+    # requeue an already-finished issue back onto claude:ready.
+    term_labels=$(gh issue view "$num" -R "$repo" --json labels --jq '[.labels[].name]')
+    if printf '%s' "$term_labels" \
+        | jq -e --arg d "$LABEL_DONE" --arg f "$LABEL_FAILED" \
+          'index($d) != null or index($f) != null' >/dev/null; then
+      continue
+    fi
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
       reclaim_issue "$repo" "$num" "$age" "reap sweep"

--- a/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -73,7 +73,10 @@ gen_run_id() {
   elif command -v python3 >/dev/null 2>&1; then
     python3 -c 'import uuid; print(uuid.uuid4())'
   elif command -v node >/dev/null 2>&1; then
-    node -e 'console.log(crypto.randomUUID())'
+    # Use require("crypto") rather than the global `crypto` object: the
+    # global was only added in Node 19 (stable in 20), while
+    # require("crypto").randomUUID has worked since Node 14.17/15.6.
+    node -e 'console.log(require("crypto").randomUUID())'
   else
     printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
   fi
@@ -122,7 +125,9 @@ if [ "${1:-}" = "--reap" ]; then
   now=$(date -u +%s)
   ensure_labels "$repo"
   reclaimed=0
-  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  # --limit: gh issue list defaults to 30 results, which would silently skip
+  # stale claude:in-progress issues once a repo has more open ones than that.
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then

--- a/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.agents/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Deterministic exclusive-lock acquisition for issue-driven-development.
+#
+# Fixes two known failure modes (kanade0404/skills#31):
+#   1. Queue loss: the old procedure flipped claude:ready -> claude:in-progress
+#      BEFORE the race for the lock was decided. A run that lost the race (or
+#      crashed between the flip and the win-check) removed only its own
+#      claude:in-progress and left the issue with NEITHER claude:ready NOR
+#      claude:in-progress -- nobody would ever pick it up again.
+#   2. Deadlock: "oldest claude-lock: comment wins" never expired, so a
+#      crashed owner's lock comment blocked every future run forever.
+#
+# Guarantees this script makes:
+#   - Labels are ONLY ever touched by the confirmed winner. A losing or
+#     erroring run never mutates labels, so it can never cause queue loss.
+#   - Every abnormal exit of THIS process after it flips labels to
+#     claude:in-progress restores claude:ready via an EXIT trap. This is
+#     best-effort: it protects against this script's own crashes, not a
+#     host-level kill that happens later, after the script has already
+#     exited 0 and control has passed to the caller's implementation phase.
+#   - Lock comments carry a lease timestamp (`claude-lock: <run-id>
+#     ts=<epoch>`). A claude:in-progress issue whose lease is older than
+#     LOCK_LEASE_TTL_SECONDS is detected and reclaimed back to
+#     claude:ready (with an audit comment) the NEXT time this script looks
+#     at that issue -- either via single-issue mode (manual retry / label
+#     event) or via `--reap`, which a queue-selection pass should run
+#     before picking the next claude:ready issue. This is what breaks the
+#     deadlock even after an ungraceful crash that outlives this script's
+#     own trap.
+#
+# Usage:
+#   acquire-lock.sh <owner/repo> <issue-number> [run-id]
+#   acquire-lock.sh --reap <owner/repo>
+#
+# Requires: gh (authenticated), jq. bash 4+ (uses process substitution free
+# constructs so it also runs under bash 3.2 / macOS default bash).
+#
+# Env:
+#   LOCK_LEASE_TTL_SECONDS  seconds before an unattended claude:in-progress
+#                           lock is considered abandoned and reclaimed.
+#                           Default 3600 (60 min).
+#
+# Exit codes (single-issue mode):
+#   0  lock acquired -- labels are now claude:in-progress. Prints
+#      "run_id=<uuid>" and "acquired_at=<epoch>" to stdout.
+#   3  skip: issue already terminal (claude:done or claude:failed present)
+#   4  skip: locked by another live run (lease not yet expired)
+#   5  skip: lost the race to acquire (another comment is older)
+#   2  usage error
+#   1  unexpected failure (gh/jq error). Any label mutation already made by
+#      THIS run is rolled back by the EXIT trap before returning.
+#
+# Exit codes (--reap mode): always 0. Prints "reclaimed=<n>".
+set -euo pipefail
+
+LABEL_READY="claude:ready"
+LABEL_PROGRESS="claude:in-progress"
+LABEL_DONE="claude:done"
+LABEL_FAILED="claude:failed"
+LEASE_TTL="${LOCK_LEASE_TTL_SECONDS:-3600}"
+
+usage() {
+  cat <<'EOF' >&2
+usage:
+  acquire-lock.sh <owner/repo> <issue-number> [run-id]
+  acquire-lock.sh --reap <owner/repo>
+EOF
+}
+
+gen_run_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'console.log(crypto.randomUUID())'
+  else
+    printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
+  fi
+}
+
+ensure_labels() {
+  repo="$1"
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+    gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
+  done
+}
+
+# Fetch the most recent claude-lock: comment on an issue and report its age
+# in seconds. Prints "<age>" ("" if no lock comment exists at all, which the
+# caller treats as infinitely stale).
+lock_lease_age() {
+  repo="$1" num="$2" now="$3"
+  last_lock=$(gh issue view "$num" -R "$repo" --json comments \
+    --jq '[.comments[] | select(.body | startswith("claude-lock: "))] | sort_by(.createdAt) | last')
+  if [ -z "$last_lock" ] || [ "$last_lock" = "null" ]; then
+    echo ""
+    return 0
+  fi
+  last_ts=$(printf '%s' "$last_lock" | jq -r '(.body | capture("ts=(?<ts>[0-9]+)").ts) // "0"')
+  echo $(( now - last_ts ))
+}
+
+# Reclaim a single issue's stale claude:in-progress lock back to
+# claude:ready, with an audit comment. Idempotent.
+reclaim_issue() {
+  repo="$1" num="$2" age="$3" by="$4"
+  gh issue edit "$num" -R "$repo" \
+    --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null
+  gh issue comment "$num" -R "$repo" \
+    --body "claude-lock-reclaim: lease expired (age ${age:-unknown}s > ${LEASE_TTL}s) or missing; requeued to ${LABEL_READY} by ${by}." \
+    >/dev/null
+}
+
+# --- --reap mode: sweep all claude:in-progress issues in a repo ----------
+if [ "${1:-}" = "--reap" ]; then
+  if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+  fi
+  repo="$2"
+  now=$(date -u +%s)
+  ensure_labels "$repo"
+  reclaimed=0
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  for num in $numbers; do
+    age=$(lock_lease_age "$repo" "$num" "$now")
+    if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+      reclaim_issue "$repo" "$num" "$age" "reap sweep"
+      reclaimed=$((reclaimed + 1))
+    fi
+  done
+  echo "reclaimed=${reclaimed}"
+  exit 0
+fi
+
+# --- single-issue mode ----------------------------------------------------
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  usage
+  exit 2
+fi
+
+REPO="$1"
+ISSUE="$2"
+RUN_ID="${3:-$(gen_run_id)}"
+NOW=$(date -u +%s)
+
+ensure_labels "$REPO"
+
+# State the EXIT trap uses to decide whether a rollback is owed. Both start
+# false; SWAPPED flips true right before we attempt the label flip (so a
+# partially-applied `gh issue edit` is still rolled back), WON flips true
+# only once the flip has actually succeeded.
+SWAPPED_TO_PROGRESS=0
+WON=0
+
+restore_on_failure() {
+  status=$?
+  if [ "$SWAPPED_TO_PROGRESS" = "1" ] && [ "$WON" != "1" ]; then
+    gh issue edit "$ISSUE" -R "$REPO" \
+      --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null 2>&1 || true
+    gh issue comment "$ISSUE" -R "$REPO" \
+      --body "claude-lock-restore: run ${RUN_ID} exited abnormally (status ${status}) before completing lock acquisition; requeued to ${LABEL_READY}." \
+      >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap restore_on_failure EXIT
+
+# --- stage 0: terminal check -----------------------------------------------
+labels=$(gh issue view "$ISSUE" -R "$REPO" --json labels --jq '[.labels[].name]')
+has_label() {
+  printf '%s' "$labels" | jq -e --arg l "$1" 'index($l) != null' >/dev/null
+}
+
+if has_label "$LABEL_DONE" || has_label "$LABEL_FAILED"; then
+  echo "skip: issue already terminal" >&2
+  exit 3
+fi
+
+# --- stage 0b: reap our own target issue if its lease is stale ------------
+if has_label "$LABEL_PROGRESS"; then
+  age=$(lock_lease_age "$REPO" "$ISSUE" "$NOW")
+  if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+    reclaim_issue "$REPO" "$ISSUE" "$age" "run ${RUN_ID}"
+  else
+    echo "skip: locked by an active run (lease age ${age}s <= ${LEASE_TTL}s)" >&2
+    exit 4
+  fi
+fi
+
+# --- stage 1: post our lock comment ----------------------------------------
+gh issue comment "$ISSUE" -R "$REPO" --body "claude-lock: ${RUN_ID} ts=${NOW}" >/dev/null
+
+# --- stage 2: decide the winner BEFORE touching any label -------------------
+# Only comments within the lease window count -- an ancient claude-lock:
+# comment (e.g. left by a run that has since crashed) must not block us
+# forever. This is what breaks the deadlock from kanade0404/skills#31.
+# Note: `gh --jq` only takes a single expression string (no --arg/--argjson
+# like the standalone jq binary), so we fetch raw JSON via gh and filter with
+# a separate `jq` process where $now/$ttl can be bound safely.
+oldest_run=$(gh issue view "$ISSUE" -R "$REPO" --json comments \
+  | jq -r --argjson now "$NOW" --argjson ttl "$LEASE_TTL" '
+    [.comments[]
+      | select(.body | startswith("claude-lock: "))
+      | . + {run: (.body | capture("claude-lock: (?<run>[^ ]+)").run),
+             ts: ((.body | capture("ts=(?<ts>[0-9]+)").ts // "0") | tonumber)}
+      | select(($now - .ts) <= $ttl)]
+    | sort_by(.createdAt) | first.run // empty')
+
+if [ "$oldest_run" != "$RUN_ID" ]; then
+  echo "skip: lost the race (oldest live lock is ${oldest_run:-unknown})" >&2
+  exit 5
+fi
+
+# --- stage 3: we won -- only now is it safe to flip labels -----------------
+SWAPPED_TO_PROGRESS=1
+gh issue edit "$ISSUE" -R "$REPO" \
+  --remove-label "$LABEL_READY" --add-label "$LABEL_PROGRESS" >/dev/null
+WON=1
+
+echo "run_id=${RUN_ID}"
+echo "acquired_at=${NOW}"

--- a/.agents/skills/linear-issue-driven-development/SKILL.md
+++ b/.agents/skills/linear-issue-driven-development/SKILL.md
@@ -12,6 +12,8 @@ description: |
 
   実行環境はクラウド (Anthropic 側 sandbox) を想定しているため、`gw` 等の
   dotfiles 同梱ヘルパには依存しない。素の `git` / `gh` / `curl` だけで動くこと。
+  本ループ (loop-ops 駆動) では非対象。GitHub issue は issue-driven-development
+  を使うこと — 本 skill は Linear issue 専用。
 ---
 # linear-issue-driven-development
 
@@ -25,9 +27,10 @@ Linear issue を 1 件受け取り、PR がマージ可能な状態 (CI 緑 + �
 | `LINEAR_API_KEY` | Linear GraphQL 認証 (`Settings → API → Personal API key`) |
 | `GH_TOKEN` | `gh auth login --with-token` 用 PAT (repo / workflow / write) |
 | `ANTHROPIC_API_KEY` | Routine 実行に必要 (登録時に自動設定) |
+| `LOCK_LEASE_TTL_SECONDS` | 任意。lock lease の失効秒数 (既定 3600) |
 
 Routine の secrets 欄に設定する。手元で `/linear-issue` を打つ場合は環境変数で
-渡す。未設定なら即フェイル。
+渡す。未設定なら即フェイル (`LOCK_LEASE_TTL_SECONDS` のみ未設定でも既定値で続行)。
 
 ## 入力契約
 
@@ -63,23 +66,47 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 着手前に Linear ラベルを `claude:ready` → `claude:in-progress` に張り替える。
 ただしラベル付与は atomic な compare-and-set ではないため、2 つの実行 (cron と
 手動 `/linear-issue` の併走など) が同じ `claude:ready` issue をほぼ同時取得すると
-両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う:
+両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う。
+
+**Iron Law**: ラベルは最古検証に勝った run しか触らない。敗者・エラー終了は
+`claude:ready` を絶対に失わない (kanade0404/skills#31 — 旧手順はラベル張替を
+最古検証より先に行っており、敗者やクラッシュが `claude:in-progress` だけ外して
+`claude:ready` を永久に失う queue 消失バグと、lock が無期限に有効でクラッシュ
+した run の lock が未来の全 run を負けさせ続けるデッドロックの 2 つを併発させて
+いた)。
 
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
+0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
+   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
+   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
+   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
+   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
+   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
+   監査コメントを添える) してから続行する。失効していなければ他の生存中の
+   run が保持中と判断し、何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
-   `claude-lock: <run-id>` (run-id は uuid) のコメントを 1 件付ける。
-2. `issueRemoveLabel` で `claude:ready` を外し、`issueAddLabel` で
-   `claude:in-progress` を付与する (張り替えを atomic に完了させる)。
-3. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
-   で **最古の `claude-lock:` コメントが自分の run-id か** を確認する
-   (順序を非決定にしないため orderBy は必須)。
-   - 自分が最古 → ロック取得成功、続行。
-   - 他者が最古 → 競合に負け。自分が付けた `claude:in-progress` だけ外して
-     何もせず即終了 (exit 0)。
+   `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
+   1 件付ける。**タイムスタンプは lease の起点であり必須。**
+2. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
+   で全コメントを取得。`claude-lock: ` コメントのうち `ts` が現在時刻から
+   `LOCK_LEASE_TTL_SECONDS` 以内 (＝失効していない) のものだけを対象に、
+   **最古のコメントが自分の run-id か**を確認する (順序を非決定にしないため
+   orderBy は必須。失効済みコメントを対象から除外することで、クラッシュした
+   run の lock が未来の全 run を負けさせ続けるデッドロックを防ぐ)。
+   - 自分が最古 → ロック取得成功。**ここで初めて** `issueRemoveLabel` で
+     `claude:ready` を外し `issueAddLabel` で `claude:in-progress` を付与する。
+   - 他者が最古 → 競合に負け。**ラベルは一切触らない**まま何もせず即終了
+     (exit 0)。自分の lock コメントは監査用に残してよい (lease 失効後は
+     自動的に無視されるようになる)。
 
 完了時に `claude:done`, 失敗時に `claude:failed` に張り替える (どちらの場合も
-`claude:in-progress` は外す)。
+`claude:in-progress` は外す)。**この手続きの外 (実装フェーズ中) でクラッシュ
+した場合はここでは救えない** — 次にこの issue が選ばれた時の stage 0b (lease
+reap) が唯一の救済経路になるため、Routine 側は毎回の issue 選定前に
+`claude:in-progress` かつ lease 失効済みの issue が無いか同様のチェックを
+挟むこと (省略すると kanade0404/skills#31 のデッドロックが再発する)。
 
 ラベル ID は team 単位なので、team ごとに `claude:in-progress` / `claude:done` /
 `claude:failed` が存在するか確認し、無ければ `issueLabelCreate` で作成する。
@@ -221,8 +248,12 @@ mutation { issueLabelCreate(input: { teamId: $team, name: $name }) { issueLabel 
 mutation { issueAddLabel(id: $id, labelId: $labelId) { success } }
 mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 
-# lock 検証用コメント取得 (作成時刻昇順、最古の claude-lock: を判定)
+# lock 検証用コメント取得 (作成時刻昇順、ts=<epoch> が LOCK_LEASE_TTL_SECONDS 以内の
+# claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
+
+# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }

--- a/.agents/skills/linear-issue-driven-development/SKILL.md
+++ b/.agents/skills/linear-issue-driven-development/SKILL.md
@@ -78,14 +78,20 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
 0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
-   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
-   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
-   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
-   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
-   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
-   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
-   監査コメントを添える) してから続行する。失効していなければ他の生存中の
-   run が保持中と判断し、何もせず即終了する。
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 20)` で
+   直近の複数コメントを取得し、その中で本文が `claude-lock: ` で始まる
+   **最新の 1 件**を選ぶ (`first: 1` だけを取得して判定すると、lock コメント
+   より後に別のコメント — 監査コメントや進捗報告など — が投稿されていた場合に
+   本物の lock コメントを見逃し、稼働中の issue を lock 無しと誤判定して
+   reclaim してしまう。GitHub 版 `acquire-lock.sh` の `lock_lease_age()` も
+   同様に「先にフィルタ、次に最新を選ぶ」順序を守っている)。選んだコメントの
+   `ts=<epoch>` (下記 stage 1 参照) から経過秒数を計算する。
+   `LOCK_LEASE_TTL_SECONDS` (既定 3600) を超えている、またはそもそも
+   lock コメントが (取得した範囲に) 存在しなければ **lease 失効** とみなし、
+   `issueRemoveLabel` で `claude:in-progress` を外し `issueAddLabel` で
+   `claude:ready` を再付与 (`claude-lock-reclaim: ...` の監査コメントを添える)
+   してから続行する。失効していなければ他の生存中の run が保持中と判断し、
+   何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
    `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
    1 件付ける。**タイムスタンプは lease の起点であり必須。**
@@ -252,8 +258,10 @@ mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 # claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
 
-# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
-query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
+# lease reap 用: 直近の複数コメントを取得し、本文が claude-lock: で始まる
+# 最新の1件をクライアント側で選んで失効判定する (first: 1 は lock 以外の
+# コメントに隠れて本物の lock コメントを見逃すため使わない)
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 20) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }

--- a/.claude/skills/issue-driven-development/SKILL.md
+++ b/.claude/skills/issue-driven-development/SKILL.md
@@ -92,7 +92,10 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
 | `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
 
 ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
-`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human` /
+`claude-loop:1..3`)。`claude-loop:N` はこの後の CI 修正反応 (`ci-self-heal`)
+が付け替える前提のラベルで、事前作成しておかないと fresh な consumer repo で
+最初の CI 失敗反応が失敗する。
 
 **この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
 (この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は

--- a/.claude/skills/issue-driven-development/SKILL.md
+++ b/.claude/skills/issue-driven-development/SKILL.md
@@ -48,7 +48,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+- **C. 探索モード**: まず `"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" --reap $REPO` で失効した
   `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
   対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
@@ -75,8 +75,12 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
   のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
   または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
+呼び出しは agent の作業ディレクトリ (対象リポジトリの checkout) ではなく本 skill の
+インストール先を指す `${CLAUDE_SKILL_DIR}` を起点にする — 対象リポジトリ側に
+`scripts/acquire-lock.sh` が無い consumer 環境では cwd 相対だと解決に失敗するため:
+
 ```bash
-scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" "$OWNER/$REPO" "$NUMBER"
 ```
 
 | 終了コード | 意味 | 次のアクション |

--- a/.claude/skills/issue-driven-development/SKILL.md
+++ b/.claude/skills/issue-driven-development/SKILL.md
@@ -15,7 +15,7 @@ description: |
   Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
   CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
   単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
-  素の `git` / `gh` だけで動くこと。
+  素の `git` / `gh` / `jq` だけで動くこと。
 allowed-tools:
   - Read
   - Grep
@@ -40,6 +40,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 |---|---|---|
 | `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
 | `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+| `LOCK_LEASE_TTL_SECONDS` | `scripts/acquire-lock.sh` の lock lease 失効秒数 | no (既定 3600) |
 
 ## 入力契約
 
@@ -47,24 +48,53 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+  `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
+  対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+  reap を省略すると、クラッシュした run が握ったままの issue が永久に
+  queue へ戻らない (kanade0404/skills#31 のデッドロック)。
 
 Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
 
 ## 排他制御 (二重起動防止)
 
-ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+ラベル張り替えは atomic でないため、決定論的なロック検証を行う。手順は
+[`scripts/acquire-lock.sh`](scripts/acquire-lock.sh) に切り出し済み — **ラベルは
+最古検証に勝った run しか触らない**ことと、**lock に有効期限 (lease) を持たせる**
+ことで、旧手順にあった 2 つの非可逆バグ (kanade0404/skills#31) を構造的に潰している:
 
-0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
-1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
-2. `claude:ready` を外し `claude:in-progress` を付ける
-3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
-   - 自分が最古 → 続行
-   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+- **queue 消失**: 旧手順は「lock コメント投稿 → ラベル張替 → 最古検証」の順で、
+  敗者やクラッシュした run が `claude:in-progress` だけ外して `claude:ready` を
+  永久に失っていた。新手順は「lock コメント投稿 → 最古検証 → (勝者だけ) ラベル張替」
+  の順に入れ替え、**敗者・エラー終了はラベルを一切書き換えない**。
+- **デッドロック**: 旧手順は「最古の `claude-lock:` コメントが勝ち」を無期限に
+  適用しており、クラッシュした run のコメントが永久に勝ち続けた。新手順は
+  lock コメントに `ts=<epoch>` のリース時刻を刻み、`LOCK_LEASE_TTL_SECONDS`
+  (既定 3600 秒) を超えたコメントは勝者判定から除外する。加えて `claude:in-progress`
+  のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
+  または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
-ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
-`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+```bash
+scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+```
+
+| 終了コード | 意味 | 次のアクション |
+|---|---|---|
+| `0` | ロック取得成功。ラベルは `claude:in-progress` に変わっている | 実装に進む |
+| `3` | 既に終端 (`claude:done` / `claude:failed`) | 何もせず次の issue へ (探索モードなら次候補) |
+| `4` | 他の生存中の run が保持中 (lease 未失効) | 何もせず次の issue へ |
+| `5` | 最古検証に敗北 | 何もせず次の issue へ (自分の lock コメントは監査用に残る) |
+| `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
+
+ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+
+**この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
+(この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は
+lease 失効 + 次回 `--reap` (または該当 issue への再アクセス時の自動 reclaim) に
+委ねている。想定される正常系はあくまで `## エスカレーション` — 継続不能を検知
+できた場合は必ずそちらで `needs-human` + `claude:failed` に明示遷移すること。
 
 Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
 ([references/actions-wiring.md](references/actions-wiring.md))。

--- a/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/.claude/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,13 +1,13 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
-{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
-{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
-{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
-{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
-{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
-{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
-{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
-{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
-{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
-{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
-{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
-{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description 冒頭の主経路。lock/jq 関連の追記は判定に影響しない"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#123 の手動再実行を明示。実行環境が git/gh/jq に変わっても判定不変"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述のまま変更なし"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙 (変更なし)"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的として継続"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示 (継続)"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し (継続)"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し (継続)"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し (継続)"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し (継続)"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示 (継続)"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い (継続)"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い (継続)"}

--- a/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -84,7 +84,12 @@ gen_run_id() {
 
 ensure_labels() {
   repo="$1"
-  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+  # claude-loop:1..3 are provisioned here too: this is now the only label
+  # provisioning path before the workflow hands off to the CI-fix/review
+  # reactions, and those bounded-retry reactions assume the labels already
+  # exist (gh issue/pr edit --add-label does not auto-create labels).
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human \
+    claude-loop:1 claude-loop:2 claude-loop:3; do
     gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
   done
 }
@@ -129,6 +134,16 @@ if [ "${1:-}" = "--reap" ]; then
   # stale claude:in-progress issues once a repo has more open ones than that.
   numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
+    # Mirror the single-issue terminal check: a run that partially completes
+    # (label mutations aren't atomic) can leave BOTH claude:in-progress and a
+    # terminal label on the same issue. Without this, a later sweep would
+    # requeue an already-finished issue back onto claude:ready.
+    term_labels=$(gh issue view "$num" -R "$repo" --json labels --jq '[.labels[].name]')
+    if printf '%s' "$term_labels" \
+        | jq -e --arg d "$LABEL_DONE" --arg f "$LABEL_FAILED" \
+          'index($d) != null or index($f) != null' >/dev/null; then
+      continue
+    fi
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
       reclaim_issue "$repo" "$num" "$age" "reap sweep"

--- a/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -73,7 +73,10 @@ gen_run_id() {
   elif command -v python3 >/dev/null 2>&1; then
     python3 -c 'import uuid; print(uuid.uuid4())'
   elif command -v node >/dev/null 2>&1; then
-    node -e 'console.log(crypto.randomUUID())'
+    # Use require("crypto") rather than the global `crypto` object: the
+    # global was only added in Node 19 (stable in 20), while
+    # require("crypto").randomUUID has worked since Node 14.17/15.6.
+    node -e 'console.log(require("crypto").randomUUID())'
   else
     printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
   fi
@@ -122,7 +125,9 @@ if [ "${1:-}" = "--reap" ]; then
   now=$(date -u +%s)
   ensure_labels "$repo"
   reclaimed=0
-  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  # --limit: gh issue list defaults to 30 results, which would silently skip
+  # stale claude:in-progress issues once a repo has more open ones than that.
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then

--- a/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/.claude/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Deterministic exclusive-lock acquisition for issue-driven-development.
+#
+# Fixes two known failure modes (kanade0404/skills#31):
+#   1. Queue loss: the old procedure flipped claude:ready -> claude:in-progress
+#      BEFORE the race for the lock was decided. A run that lost the race (or
+#      crashed between the flip and the win-check) removed only its own
+#      claude:in-progress and left the issue with NEITHER claude:ready NOR
+#      claude:in-progress -- nobody would ever pick it up again.
+#   2. Deadlock: "oldest claude-lock: comment wins" never expired, so a
+#      crashed owner's lock comment blocked every future run forever.
+#
+# Guarantees this script makes:
+#   - Labels are ONLY ever touched by the confirmed winner. A losing or
+#     erroring run never mutates labels, so it can never cause queue loss.
+#   - Every abnormal exit of THIS process after it flips labels to
+#     claude:in-progress restores claude:ready via an EXIT trap. This is
+#     best-effort: it protects against this script's own crashes, not a
+#     host-level kill that happens later, after the script has already
+#     exited 0 and control has passed to the caller's implementation phase.
+#   - Lock comments carry a lease timestamp (`claude-lock: <run-id>
+#     ts=<epoch>`). A claude:in-progress issue whose lease is older than
+#     LOCK_LEASE_TTL_SECONDS is detected and reclaimed back to
+#     claude:ready (with an audit comment) the NEXT time this script looks
+#     at that issue -- either via single-issue mode (manual retry / label
+#     event) or via `--reap`, which a queue-selection pass should run
+#     before picking the next claude:ready issue. This is what breaks the
+#     deadlock even after an ungraceful crash that outlives this script's
+#     own trap.
+#
+# Usage:
+#   acquire-lock.sh <owner/repo> <issue-number> [run-id]
+#   acquire-lock.sh --reap <owner/repo>
+#
+# Requires: gh (authenticated), jq. bash 4+ (uses process substitution free
+# constructs so it also runs under bash 3.2 / macOS default bash).
+#
+# Env:
+#   LOCK_LEASE_TTL_SECONDS  seconds before an unattended claude:in-progress
+#                           lock is considered abandoned and reclaimed.
+#                           Default 3600 (60 min).
+#
+# Exit codes (single-issue mode):
+#   0  lock acquired -- labels are now claude:in-progress. Prints
+#      "run_id=<uuid>" and "acquired_at=<epoch>" to stdout.
+#   3  skip: issue already terminal (claude:done or claude:failed present)
+#   4  skip: locked by another live run (lease not yet expired)
+#   5  skip: lost the race to acquire (another comment is older)
+#   2  usage error
+#   1  unexpected failure (gh/jq error). Any label mutation already made by
+#      THIS run is rolled back by the EXIT trap before returning.
+#
+# Exit codes (--reap mode): always 0. Prints "reclaimed=<n>".
+set -euo pipefail
+
+LABEL_READY="claude:ready"
+LABEL_PROGRESS="claude:in-progress"
+LABEL_DONE="claude:done"
+LABEL_FAILED="claude:failed"
+LEASE_TTL="${LOCK_LEASE_TTL_SECONDS:-3600}"
+
+usage() {
+  cat <<'EOF' >&2
+usage:
+  acquire-lock.sh <owner/repo> <issue-number> [run-id]
+  acquire-lock.sh --reap <owner/repo>
+EOF
+}
+
+gen_run_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'console.log(crypto.randomUUID())'
+  else
+    printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
+  fi
+}
+
+ensure_labels() {
+  repo="$1"
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+    gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
+  done
+}
+
+# Fetch the most recent claude-lock: comment on an issue and report its age
+# in seconds. Prints "<age>" ("" if no lock comment exists at all, which the
+# caller treats as infinitely stale).
+lock_lease_age() {
+  repo="$1" num="$2" now="$3"
+  last_lock=$(gh issue view "$num" -R "$repo" --json comments \
+    --jq '[.comments[] | select(.body | startswith("claude-lock: "))] | sort_by(.createdAt) | last')
+  if [ -z "$last_lock" ] || [ "$last_lock" = "null" ]; then
+    echo ""
+    return 0
+  fi
+  last_ts=$(printf '%s' "$last_lock" | jq -r '(.body | capture("ts=(?<ts>[0-9]+)").ts) // "0"')
+  echo $(( now - last_ts ))
+}
+
+# Reclaim a single issue's stale claude:in-progress lock back to
+# claude:ready, with an audit comment. Idempotent.
+reclaim_issue() {
+  repo="$1" num="$2" age="$3" by="$4"
+  gh issue edit "$num" -R "$repo" \
+    --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null
+  gh issue comment "$num" -R "$repo" \
+    --body "claude-lock-reclaim: lease expired (age ${age:-unknown}s > ${LEASE_TTL}s) or missing; requeued to ${LABEL_READY} by ${by}." \
+    >/dev/null
+}
+
+# --- --reap mode: sweep all claude:in-progress issues in a repo ----------
+if [ "${1:-}" = "--reap" ]; then
+  if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+  fi
+  repo="$2"
+  now=$(date -u +%s)
+  ensure_labels "$repo"
+  reclaimed=0
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  for num in $numbers; do
+    age=$(lock_lease_age "$repo" "$num" "$now")
+    if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+      reclaim_issue "$repo" "$num" "$age" "reap sweep"
+      reclaimed=$((reclaimed + 1))
+    fi
+  done
+  echo "reclaimed=${reclaimed}"
+  exit 0
+fi
+
+# --- single-issue mode ----------------------------------------------------
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  usage
+  exit 2
+fi
+
+REPO="$1"
+ISSUE="$2"
+RUN_ID="${3:-$(gen_run_id)}"
+NOW=$(date -u +%s)
+
+ensure_labels "$REPO"
+
+# State the EXIT trap uses to decide whether a rollback is owed. Both start
+# false; SWAPPED flips true right before we attempt the label flip (so a
+# partially-applied `gh issue edit` is still rolled back), WON flips true
+# only once the flip has actually succeeded.
+SWAPPED_TO_PROGRESS=0
+WON=0
+
+restore_on_failure() {
+  status=$?
+  if [ "$SWAPPED_TO_PROGRESS" = "1" ] && [ "$WON" != "1" ]; then
+    gh issue edit "$ISSUE" -R "$REPO" \
+      --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null 2>&1 || true
+    gh issue comment "$ISSUE" -R "$REPO" \
+      --body "claude-lock-restore: run ${RUN_ID} exited abnormally (status ${status}) before completing lock acquisition; requeued to ${LABEL_READY}." \
+      >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap restore_on_failure EXIT
+
+# --- stage 0: terminal check -----------------------------------------------
+labels=$(gh issue view "$ISSUE" -R "$REPO" --json labels --jq '[.labels[].name]')
+has_label() {
+  printf '%s' "$labels" | jq -e --arg l "$1" 'index($l) != null' >/dev/null
+}
+
+if has_label "$LABEL_DONE" || has_label "$LABEL_FAILED"; then
+  echo "skip: issue already terminal" >&2
+  exit 3
+fi
+
+# --- stage 0b: reap our own target issue if its lease is stale ------------
+if has_label "$LABEL_PROGRESS"; then
+  age=$(lock_lease_age "$REPO" "$ISSUE" "$NOW")
+  if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+    reclaim_issue "$REPO" "$ISSUE" "$age" "run ${RUN_ID}"
+  else
+    echo "skip: locked by an active run (lease age ${age}s <= ${LEASE_TTL}s)" >&2
+    exit 4
+  fi
+fi
+
+# --- stage 1: post our lock comment ----------------------------------------
+gh issue comment "$ISSUE" -R "$REPO" --body "claude-lock: ${RUN_ID} ts=${NOW}" >/dev/null
+
+# --- stage 2: decide the winner BEFORE touching any label -------------------
+# Only comments within the lease window count -- an ancient claude-lock:
+# comment (e.g. left by a run that has since crashed) must not block us
+# forever. This is what breaks the deadlock from kanade0404/skills#31.
+# Note: `gh --jq` only takes a single expression string (no --arg/--argjson
+# like the standalone jq binary), so we fetch raw JSON via gh and filter with
+# a separate `jq` process where $now/$ttl can be bound safely.
+oldest_run=$(gh issue view "$ISSUE" -R "$REPO" --json comments \
+  | jq -r --argjson now "$NOW" --argjson ttl "$LEASE_TTL" '
+    [.comments[]
+      | select(.body | startswith("claude-lock: "))
+      | . + {run: (.body | capture("claude-lock: (?<run>[^ ]+)").run),
+             ts: ((.body | capture("ts=(?<ts>[0-9]+)").ts // "0") | tonumber)}
+      | select(($now - .ts) <= $ttl)]
+    | sort_by(.createdAt) | first.run // empty')
+
+if [ "$oldest_run" != "$RUN_ID" ]; then
+  echo "skip: lost the race (oldest live lock is ${oldest_run:-unknown})" >&2
+  exit 5
+fi
+
+# --- stage 3: we won -- only now is it safe to flip labels -----------------
+SWAPPED_TO_PROGRESS=1
+gh issue edit "$ISSUE" -R "$REPO" \
+  --remove-label "$LABEL_READY" --add-label "$LABEL_PROGRESS" >/dev/null
+WON=1
+
+echo "run_id=${RUN_ID}"
+echo "acquired_at=${NOW}"

--- a/.claude/skills/linear-issue-driven-development/SKILL.md
+++ b/.claude/skills/linear-issue-driven-development/SKILL.md
@@ -12,8 +12,9 @@ description: |
 
   実行環境はクラウド (Anthropic 側 sandbox) を想定しているため、`gw` 等の
   dotfiles 同梱ヘルパには依存しない。素の `git` / `gh` / `curl` だけで動くこと。
+  本ループ (loop-ops 駆動) では非対象。GitHub issue は issue-driven-development
+  を使うこと — 本 skill は Linear issue 専用。
 ---
-
 # linear-issue-driven-development
 
 Linear issue を 1 件受け取り、PR がマージ可能な状態 (CI 緑 + 未解消レビュー
@@ -26,9 +27,10 @@ Linear issue を 1 件受け取り、PR がマージ可能な状態 (CI 緑 + �
 | `LINEAR_API_KEY` | Linear GraphQL 認証 (`Settings → API → Personal API key`) |
 | `GH_TOKEN` | `gh auth login --with-token` 用 PAT (repo / workflow / write) |
 | `ANTHROPIC_API_KEY` | Routine 実行に必要 (登録時に自動設定) |
+| `LOCK_LEASE_TTL_SECONDS` | 任意。lock lease の失効秒数 (既定 3600) |
 
 Routine の secrets 欄に設定する。手元で `/linear-issue` を打つ場合は環境変数で
-渡す。未設定なら即フェイル。
+渡す。未設定なら即フェイル (`LOCK_LEASE_TTL_SECONDS` のみ未設定でも既定値で続行)。
 
 ## 入力契約
 
@@ -64,23 +66,47 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 着手前に Linear ラベルを `claude:ready` → `claude:in-progress` に張り替える。
 ただしラベル付与は atomic な compare-and-set ではないため、2 つの実行 (cron と
 手動 `/linear-issue` の併走など) が同じ `claude:ready` issue をほぼ同時取得すると
-両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う:
+両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う。
+
+**Iron Law**: ラベルは最古検証に勝った run しか触らない。敗者・エラー終了は
+`claude:ready` を絶対に失わない (kanade0404/skills#31 — 旧手順はラベル張替を
+最古検証より先に行っており、敗者やクラッシュが `claude:in-progress` だけ外して
+`claude:ready` を永久に失う queue 消失バグと、lock が無期限に有効でクラッシュ
+した run の lock が未来の全 run を負けさせ続けるデッドロックの 2 つを併発させて
+いた)。
 
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
+0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
+   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
+   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
+   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
+   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
+   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
+   監査コメントを添える) してから続行する。失効していなければ他の生存中の
+   run が保持中と判断し、何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
-   `claude-lock: <run-id>` (run-id は uuid) のコメントを 1 件付ける。
-2. `issueRemoveLabel` で `claude:ready` を外し、`issueAddLabel` で
-   `claude:in-progress` を付与する (張り替えを atomic に完了させる)。
-3. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
-   で **最古の `claude-lock:` コメントが自分の run-id か** を確認する
-   (順序を非決定にしないため orderBy は必須)。
-   - 自分が最古 → ロック取得成功、続行。
-   - 他者が最古 → 競合に負け。自分が付けた `claude:in-progress` だけ外して
-     何もせず即終了 (exit 0)。
+   `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
+   1 件付ける。**タイムスタンプは lease の起点であり必須。**
+2. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
+   で全コメントを取得。`claude-lock: ` コメントのうち `ts` が現在時刻から
+   `LOCK_LEASE_TTL_SECONDS` 以内 (＝失効していない) のものだけを対象に、
+   **最古のコメントが自分の run-id か**を確認する (順序を非決定にしないため
+   orderBy は必須。失効済みコメントを対象から除外することで、クラッシュした
+   run の lock が未来の全 run を負けさせ続けるデッドロックを防ぐ)。
+   - 自分が最古 → ロック取得成功。**ここで初めて** `issueRemoveLabel` で
+     `claude:ready` を外し `issueAddLabel` で `claude:in-progress` を付与する。
+   - 他者が最古 → 競合に負け。**ラベルは一切触らない**まま何もせず即終了
+     (exit 0)。自分の lock コメントは監査用に残してよい (lease 失効後は
+     自動的に無視されるようになる)。
 
 完了時に `claude:done`, 失敗時に `claude:failed` に張り替える (どちらの場合も
-`claude:in-progress` は外す)。
+`claude:in-progress` は外す)。**この手続きの外 (実装フェーズ中) でクラッシュ
+した場合はここでは救えない** — 次にこの issue が選ばれた時の stage 0b (lease
+reap) が唯一の救済経路になるため、Routine 側は毎回の issue 選定前に
+`claude:in-progress` かつ lease 失効済みの issue が無いか同様のチェックを
+挟むこと (省略すると kanade0404/skills#31 のデッドロックが再発する)。
 
 ラベル ID は team 単位なので、team ごとに `claude:in-progress` / `claude:done` /
 `claude:failed` が存在するか確認し、無ければ `issueLabelCreate` で作成する。
@@ -222,8 +248,12 @@ mutation { issueLabelCreate(input: { teamId: $team, name: $name }) { issueLabel 
 mutation { issueAddLabel(id: $id, labelId: $labelId) { success } }
 mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 
-# lock 検証用コメント取得 (作成時刻昇順、最古の claude-lock: を判定)
+# lock 検証用コメント取得 (作成時刻昇順、ts=<epoch> が LOCK_LEASE_TTL_SECONDS 以内の
+# claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
+
+# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }

--- a/.claude/skills/linear-issue-driven-development/SKILL.md
+++ b/.claude/skills/linear-issue-driven-development/SKILL.md
@@ -78,14 +78,20 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
 0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
-   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
-   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
-   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
-   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
-   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
-   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
-   監査コメントを添える) してから続行する。失効していなければ他の生存中の
-   run が保持中と判断し、何もせず即終了する。
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 20)` で
+   直近の複数コメントを取得し、その中で本文が `claude-lock: ` で始まる
+   **最新の 1 件**を選ぶ (`first: 1` だけを取得して判定すると、lock コメント
+   より後に別のコメント — 監査コメントや進捗報告など — が投稿されていた場合に
+   本物の lock コメントを見逃し、稼働中の issue を lock 無しと誤判定して
+   reclaim してしまう。GitHub 版 `acquire-lock.sh` の `lock_lease_age()` も
+   同様に「先にフィルタ、次に最新を選ぶ」順序を守っている)。選んだコメントの
+   `ts=<epoch>` (下記 stage 1 参照) から経過秒数を計算する。
+   `LOCK_LEASE_TTL_SECONDS` (既定 3600) を超えている、またはそもそも
+   lock コメントが (取得した範囲に) 存在しなければ **lease 失効** とみなし、
+   `issueRemoveLabel` で `claude:in-progress` を外し `issueAddLabel` で
+   `claude:ready` を再付与 (`claude-lock-reclaim: ...` の監査コメントを添える)
+   してから続行する。失効していなければ他の生存中の run が保持中と判断し、
+   何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
    `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
    1 件付ける。**タイムスタンプは lease の起点であり必須。**
@@ -252,8 +258,10 @@ mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 # claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
 
-# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
-query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
+# lease reap 用: 直近の複数コメントを取得し、本文が claude-lock: で始まる
+# 最新の1件をクライアント側で選んで失効判定する (first: 1 は lock 以外の
+# コメントに隠れて本物の lock コメントを見逃すため使わない)
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 20) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }

--- a/skills/issue-driven-development/SKILL.md
+++ b/skills/issue-driven-development/SKILL.md
@@ -15,7 +15,7 @@ description: |
   Linear issue (`linear-issue-driven-development`)、対話的な実装後の出荷 (`shipping`)、
   CI 修正単体 (`ci-self-heal`)、レビュー対応単体 (`pr-review-respond`)、conflict 解消
   単体 (`pr-conflict-resolver`)、PR の merge (人間ゲート)。実行環境はクラウドを想定し、
-  素の `git` / `gh` だけで動くこと。
+  素の `git` / `gh` / `jq` だけで動くこと。
 claudecode:
   allowed-tools:
     - Read
@@ -42,6 +42,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 |---|---|---|
 | `GH_TOKEN` (or `gh auth` 済み) | clone / label / PR 操作 | yes |
 | `LOOP_OPS_TOKEN` | 計測イベント送信 (emit-event.sh) | no (無ければ送信を skip) |
+| `LOCK_LEASE_TTL_SECONDS` | `scripts/acquire-lock.sh` の lock lease 失効秒数 | no (既定 3600) |
 
 ## 入力契約
 
@@ -49,24 +50,53 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: 対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
+- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+  `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
+  対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
+  reap を省略すると、クラッシュした run が握ったままの issue が永久に
+  queue へ戻らない (kanade0404/skills#31 のデッドロック)。
 
 Linear 版と違い**対象リポジトリの解決は不要** (issue が属する repo がそのまま対象)。
 
 ## 排他制御 (二重起動防止)
 
-ラベル張り替えは atomic でないため、Linear 版と同じロック検証を行う:
+ラベル張り替えは atomic でないため、決定論的なロック検証を行う。手順は
+[`scripts/acquire-lock.sh`](scripts/acquire-lock.sh) に切り出し済み — **ラベルは
+最古検証に勝った run しか触らない**ことと、**lock に有効期限 (lease) を持たせる**
+ことで、旧手順にあった 2 つの非可逆バグ (kanade0404/skills#31) を構造的に潰している:
 
-0. issue のラベルに `claude:done` / `claude:failed` があれば処理済み — 即終了
-1. `claude-lock: <run-id>` (run-id は uuid) をコメントとして 1 件投稿する
-2. `claude:ready` を外し `claude:in-progress` を付ける
-3. コメントを**作成日昇順**で取得し、最古の `claude-lock:` が自分の run-id か確認する
-   - 自分が最古 → 続行
-   - 他者が最古 → 自分の付けた `claude:in-progress` を外して即終了 (exit 0)
+- **queue 消失**: 旧手順は「lock コメント投稿 → ラベル張替 → 最古検証」の順で、
+  敗者やクラッシュした run が `claude:in-progress` だけ外して `claude:ready` を
+  永久に失っていた。新手順は「lock コメント投稿 → 最古検証 → (勝者だけ) ラベル張替」
+  の順に入れ替え、**敗者・エラー終了はラベルを一切書き換えない**。
+- **デッドロック**: 旧手順は「最古の `claude-lock:` コメントが勝ち」を無期限に
+  適用しており、クラッシュした run のコメントが永久に勝ち続けた。新手順は
+  lock コメントに `ts=<epoch>` のリース時刻を刻み、`LOCK_LEASE_TTL_SECONDS`
+  (既定 3600 秒) を超えたコメントは勝者判定から除外する。加えて `claude:in-progress`
+  のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
+  または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
-ラベルが repo に無ければ `gh label create` で作る (`claude:ready` / `claude:in-progress` /
-`claude:done` / `claude:failed` / `needs-human` / `claude-loop:1..3`)。
+```bash
+scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+```
+
+| 終了コード | 意味 | 次のアクション |
+|---|---|---|
+| `0` | ロック取得成功。ラベルは `claude:in-progress` に変わっている | 実装に進む |
+| `3` | 既に終端 (`claude:done` / `claude:failed`) | 何もせず次の issue へ (探索モードなら次候補) |
+| `4` | 他の生存中の run が保持中 (lease 未失効) | 何もせず次の issue へ |
+| `5` | 最古検証に敗北 | 何もせず次の issue へ (自分の lock コメントは監査用に残る) |
+| `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
+
+ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+
+**この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
+(この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は
+lease 失効 + 次回 `--reap` (または該当 issue への再アクセス時の自動 reclaim) に
+委ねている。想定される正常系はあくまで `## エスカレーション` — 継続不能を検知
+できた場合は必ずそちらで `needs-human` + `claude:failed` に明示遷移すること。
 
 Actions 起動の場合はさらに workflow 側の `concurrency` グループが二重起動を防ぐ
 ([references/actions-wiring.md](references/actions-wiring.md))。

--- a/skills/issue-driven-development/SKILL.md
+++ b/skills/issue-driven-development/SKILL.md
@@ -94,7 +94,10 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
 | `1` / `2` | 予期しない失敗 / 使用法エラー | ラベルは script 内の `trap` が復元済み。ログを見てリトライ判断 |
 
 ラベルが repo に無ければ script が `gh label create` で作る (`claude:ready` /
-`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human`)。
+`claude:in-progress` / `claude:done` / `claude:failed` / `needs-human` /
+`claude-loop:1..3`)。`claude-loop:N` はこの後の CI 修正反応 (`ci-self-heal`)
+が付け替える前提のラベルで、事前作成しておかないと fresh な consumer repo で
+最初の CI 失敗反応が失敗する。
 
 **この trap が保護しないもの**: script 自身は `exit 0` で戻った後、実装フェーズ
 (この SKILL の 3〜5 節) の異常終了までは面倒を見ない。そこで死んだ run の復旧は

--- a/skills/issue-driven-development/SKILL.md
+++ b/skills/issue-driven-development/SKILL.md
@@ -50,7 +50,7 @@ GitHub issue 1 件を「merge 可能な PR の材料」に変えるスキル。*
 
 - **A. トリガペイロード** (Actions の labeled イベント / Routine): `owner/repo` と issue 番号が渡される
 - **B. 手動**: `owner/repo#123` 形式の識別子
-- **C. 探索モード**: まず `scripts/acquire-lock.sh --reap $REPO` で失効した
+- **C. 探索モード**: まず `"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" --reap $REPO` で失効した
   `claude:in-progress` (crash した run) を `claude:ready` へ差し戻してから、
   対象 repo で `claude:ready` ラベルの issue を作成日昇順で 1 件取る:
   `gh issue list -R $REPO --label claude:ready --state open --json number --jq 'sort_by(.number) | .[0].number'`
@@ -77,8 +77,12 @@ Linear 版と違い**対象リポジトリの解決は不要** (issue が属す�
   のまま放置された issue は、次にこの issue へ触れたタイミング (単発呼び出し、
   または探索モードの `--reap` 事前スイープ) で自動的に `claude:ready` へ差し戻す。
 
+呼び出しは agent の作業ディレクトリ (対象リポジトリの checkout) ではなく本 skill の
+インストール先を指す `${CLAUDE_SKILL_DIR}` を起点にする — 対象リポジトリ側に
+`scripts/acquire-lock.sh` が無い consumer 環境では cwd 相対だと解決に失敗するため:
+
 ```bash
-scripts/acquire-lock.sh "$OWNER/$REPO" "$NUMBER"
+"${CLAUDE_SKILL_DIR}/scripts/acquire-lock.sh" "$OWNER/$REPO" "$NUMBER"
 ```
 
 | 終了コード | 意味 | 次のアクション |

--- a/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
+++ b/skills/issue-driven-development/evals/issue-driven-development-trigger-results-2026-07-06.jsonl
@@ -1,13 +1,13 @@
-{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description の主経路 (圧縮後も明示)"}
-{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#N の手動再実行を明示"}
-{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述"}
-{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙"}
-{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的"}
-{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示"}
-{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し"}
-{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し"}
-{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し"}
-{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し"}
-{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示"}
-{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い"}
-{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い"}
+{"id":"t01","predicted":true,"actual":true,"reason":"claude:ready ラベル処理は description 冒頭の主経路。lock/jq 関連の追記は判定に影響しない"}
+{"id":"t02","predicted":true,"actual":true,"reason":"owner/repo#123 の手動再実行を明示。実行環境が git/gh/jq に変わっても判定不変"}
+{"id":"t03","predicted":true,"actual":true,"reason":"issue→PR ヘッドレス完遂は中核記述のまま変更なし"}
+{"id":"t04","predicted":true,"actual":true,"reason":"「この issue やっておいて」を明示列挙 (変更なし)"}
+{"id":"t05","predicted":true,"actual":true,"reason":"無人での issue 委譲は主目的として継続"}
+{"id":"t06","predicted":true,"actual":true,"reason":"Routine 起動を主経路として明示 (継続)"}
+{"id":"f01","predicted":false,"actual":false,"reason":"negative space で linear-issue-driven-development を名指し (継続)"}
+{"id":"f02","predicted":false,"actual":false,"reason":"negative space で shipping を名指し (継続)"}
+{"id":"f03","predicted":false,"actual":false,"reason":"negative space で ci-self-heal を名指し (継続)"}
+{"id":"f04","predicted":false,"actual":false,"reason":"negative space で pr-review-respond を名指し (継続)"}
+{"id":"f05","predicted":false,"actual":false,"reason":"「PR の merge (人間ゲート)」を範囲外に明示 (継続)"}
+{"id":"f06","predicted":false,"actual":false,"reason":"issue テンプレ作成は処理対象の語彙に無い (継続)"}
+{"id":"f07","predicted":false,"actual":false,"reason":"トリアージは実装自走の語彙に無い (継続)"}

--- a/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -84,7 +84,12 @@ gen_run_id() {
 
 ensure_labels() {
   repo="$1"
-  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+  # claude-loop:1..3 are provisioned here too: this is now the only label
+  # provisioning path before the workflow hands off to the CI-fix/review
+  # reactions, and those bounded-retry reactions assume the labels already
+  # exist (gh issue/pr edit --add-label does not auto-create labels).
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human \
+    claude-loop:1 claude-loop:2 claude-loop:3; do
     gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
   done
 }
@@ -129,6 +134,16 @@ if [ "${1:-}" = "--reap" ]; then
   # stale claude:in-progress issues once a repo has more open ones than that.
   numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
+    # Mirror the single-issue terminal check: a run that partially completes
+    # (label mutations aren't atomic) can leave BOTH claude:in-progress and a
+    # terminal label on the same issue. Without this, a later sweep would
+    # requeue an already-finished issue back onto claude:ready.
+    term_labels=$(gh issue view "$num" -R "$repo" --json labels --jq '[.labels[].name]')
+    if printf '%s' "$term_labels" \
+        | jq -e --arg d "$LABEL_DONE" --arg f "$LABEL_FAILED" \
+          'index($d) != null or index($f) != null' >/dev/null; then
+      continue
+    fi
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
       reclaim_issue "$repo" "$num" "$age" "reap sweep"

--- a/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -73,7 +73,10 @@ gen_run_id() {
   elif command -v python3 >/dev/null 2>&1; then
     python3 -c 'import uuid; print(uuid.uuid4())'
   elif command -v node >/dev/null 2>&1; then
-    node -e 'console.log(crypto.randomUUID())'
+    # Use require("crypto") rather than the global `crypto` object: the
+    # global was only added in Node 19 (stable in 20), while
+    # require("crypto").randomUUID has worked since Node 14.17/15.6.
+    node -e 'console.log(require("crypto").randomUUID())'
   else
     printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
   fi
@@ -122,7 +125,9 @@ if [ "${1:-}" = "--reap" ]; then
   now=$(date -u +%s)
   ensure_labels "$repo"
   reclaimed=0
-  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  # --limit: gh issue list defaults to 30 results, which would silently skip
+  # stale claude:in-progress issues once a repo has more open ones than that.
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --limit 1000 --json number --jq '.[].number')
   for num in $numbers; do
     age=$(lock_lease_age "$repo" "$num" "$now")
     if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then

--- a/skills/issue-driven-development/scripts/acquire-lock.sh
+++ b/skills/issue-driven-development/scripts/acquire-lock.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Deterministic exclusive-lock acquisition for issue-driven-development.
+#
+# Fixes two known failure modes (kanade0404/skills#31):
+#   1. Queue loss: the old procedure flipped claude:ready -> claude:in-progress
+#      BEFORE the race for the lock was decided. A run that lost the race (or
+#      crashed between the flip and the win-check) removed only its own
+#      claude:in-progress and left the issue with NEITHER claude:ready NOR
+#      claude:in-progress -- nobody would ever pick it up again.
+#   2. Deadlock: "oldest claude-lock: comment wins" never expired, so a
+#      crashed owner's lock comment blocked every future run forever.
+#
+# Guarantees this script makes:
+#   - Labels are ONLY ever touched by the confirmed winner. A losing or
+#     erroring run never mutates labels, so it can never cause queue loss.
+#   - Every abnormal exit of THIS process after it flips labels to
+#     claude:in-progress restores claude:ready via an EXIT trap. This is
+#     best-effort: it protects against this script's own crashes, not a
+#     host-level kill that happens later, after the script has already
+#     exited 0 and control has passed to the caller's implementation phase.
+#   - Lock comments carry a lease timestamp (`claude-lock: <run-id>
+#     ts=<epoch>`). A claude:in-progress issue whose lease is older than
+#     LOCK_LEASE_TTL_SECONDS is detected and reclaimed back to
+#     claude:ready (with an audit comment) the NEXT time this script looks
+#     at that issue -- either via single-issue mode (manual retry / label
+#     event) or via `--reap`, which a queue-selection pass should run
+#     before picking the next claude:ready issue. This is what breaks the
+#     deadlock even after an ungraceful crash that outlives this script's
+#     own trap.
+#
+# Usage:
+#   acquire-lock.sh <owner/repo> <issue-number> [run-id]
+#   acquire-lock.sh --reap <owner/repo>
+#
+# Requires: gh (authenticated), jq. bash 4+ (uses process substitution free
+# constructs so it also runs under bash 3.2 / macOS default bash).
+#
+# Env:
+#   LOCK_LEASE_TTL_SECONDS  seconds before an unattended claude:in-progress
+#                           lock is considered abandoned and reclaimed.
+#                           Default 3600 (60 min).
+#
+# Exit codes (single-issue mode):
+#   0  lock acquired -- labels are now claude:in-progress. Prints
+#      "run_id=<uuid>" and "acquired_at=<epoch>" to stdout.
+#   3  skip: issue already terminal (claude:done or claude:failed present)
+#   4  skip: locked by another live run (lease not yet expired)
+#   5  skip: lost the race to acquire (another comment is older)
+#   2  usage error
+#   1  unexpected failure (gh/jq error). Any label mutation already made by
+#      THIS run is rolled back by the EXIT trap before returning.
+#
+# Exit codes (--reap mode): always 0. Prints "reclaimed=<n>".
+set -euo pipefail
+
+LABEL_READY="claude:ready"
+LABEL_PROGRESS="claude:in-progress"
+LABEL_DONE="claude:done"
+LABEL_FAILED="claude:failed"
+LEASE_TTL="${LOCK_LEASE_TTL_SECONDS:-3600}"
+
+usage() {
+  cat <<'EOF' >&2
+usage:
+  acquire-lock.sh <owner/repo> <issue-number> [run-id]
+  acquire-lock.sh --reap <owner/repo>
+EOF
+}
+
+gen_run_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'console.log(crypto.randomUUID())'
+  else
+    printf '%s-%s-%s\n' "$(date -u +%s%N)" "$$" "$RANDOM"
+  fi
+}
+
+ensure_labels() {
+  repo="$1"
+  for l in "$LABEL_READY" "$LABEL_PROGRESS" "$LABEL_DONE" "$LABEL_FAILED" needs-human; do
+    gh label create "$l" -R "$repo" --color ededed --force >/dev/null 2>&1 || true
+  done
+}
+
+# Fetch the most recent claude-lock: comment on an issue and report its age
+# in seconds. Prints "<age>" ("" if no lock comment exists at all, which the
+# caller treats as infinitely stale).
+lock_lease_age() {
+  repo="$1" num="$2" now="$3"
+  last_lock=$(gh issue view "$num" -R "$repo" --json comments \
+    --jq '[.comments[] | select(.body | startswith("claude-lock: "))] | sort_by(.createdAt) | last')
+  if [ -z "$last_lock" ] || [ "$last_lock" = "null" ]; then
+    echo ""
+    return 0
+  fi
+  last_ts=$(printf '%s' "$last_lock" | jq -r '(.body | capture("ts=(?<ts>[0-9]+)").ts) // "0"')
+  echo $(( now - last_ts ))
+}
+
+# Reclaim a single issue's stale claude:in-progress lock back to
+# claude:ready, with an audit comment. Idempotent.
+reclaim_issue() {
+  repo="$1" num="$2" age="$3" by="$4"
+  gh issue edit "$num" -R "$repo" \
+    --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null
+  gh issue comment "$num" -R "$repo" \
+    --body "claude-lock-reclaim: lease expired (age ${age:-unknown}s > ${LEASE_TTL}s) or missing; requeued to ${LABEL_READY} by ${by}." \
+    >/dev/null
+}
+
+# --- --reap mode: sweep all claude:in-progress issues in a repo ----------
+if [ "${1:-}" = "--reap" ]; then
+  if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+  fi
+  repo="$2"
+  now=$(date -u +%s)
+  ensure_labels "$repo"
+  reclaimed=0
+  numbers=$(gh issue list -R "$repo" --label "$LABEL_PROGRESS" --state open --json number --jq '.[].number')
+  for num in $numbers; do
+    age=$(lock_lease_age "$repo" "$num" "$now")
+    if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+      reclaim_issue "$repo" "$num" "$age" "reap sweep"
+      reclaimed=$((reclaimed + 1))
+    fi
+  done
+  echo "reclaimed=${reclaimed}"
+  exit 0
+fi
+
+# --- single-issue mode ----------------------------------------------------
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  usage
+  exit 2
+fi
+
+REPO="$1"
+ISSUE="$2"
+RUN_ID="${3:-$(gen_run_id)}"
+NOW=$(date -u +%s)
+
+ensure_labels "$REPO"
+
+# State the EXIT trap uses to decide whether a rollback is owed. Both start
+# false; SWAPPED flips true right before we attempt the label flip (so a
+# partially-applied `gh issue edit` is still rolled back), WON flips true
+# only once the flip has actually succeeded.
+SWAPPED_TO_PROGRESS=0
+WON=0
+
+restore_on_failure() {
+  status=$?
+  if [ "$SWAPPED_TO_PROGRESS" = "1" ] && [ "$WON" != "1" ]; then
+    gh issue edit "$ISSUE" -R "$REPO" \
+      --remove-label "$LABEL_PROGRESS" --add-label "$LABEL_READY" >/dev/null 2>&1 || true
+    gh issue comment "$ISSUE" -R "$REPO" \
+      --body "claude-lock-restore: run ${RUN_ID} exited abnormally (status ${status}) before completing lock acquisition; requeued to ${LABEL_READY}." \
+      >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap restore_on_failure EXIT
+
+# --- stage 0: terminal check -----------------------------------------------
+labels=$(gh issue view "$ISSUE" -R "$REPO" --json labels --jq '[.labels[].name]')
+has_label() {
+  printf '%s' "$labels" | jq -e --arg l "$1" 'index($l) != null' >/dev/null
+}
+
+if has_label "$LABEL_DONE" || has_label "$LABEL_FAILED"; then
+  echo "skip: issue already terminal" >&2
+  exit 3
+fi
+
+# --- stage 0b: reap our own target issue if its lease is stale ------------
+if has_label "$LABEL_PROGRESS"; then
+  age=$(lock_lease_age "$REPO" "$ISSUE" "$NOW")
+  if [ -z "$age" ] || [ "$age" -gt "$LEASE_TTL" ]; then
+    reclaim_issue "$REPO" "$ISSUE" "$age" "run ${RUN_ID}"
+  else
+    echo "skip: locked by an active run (lease age ${age}s <= ${LEASE_TTL}s)" >&2
+    exit 4
+  fi
+fi
+
+# --- stage 1: post our lock comment ----------------------------------------
+gh issue comment "$ISSUE" -R "$REPO" --body "claude-lock: ${RUN_ID} ts=${NOW}" >/dev/null
+
+# --- stage 2: decide the winner BEFORE touching any label -------------------
+# Only comments within the lease window count -- an ancient claude-lock:
+# comment (e.g. left by a run that has since crashed) must not block us
+# forever. This is what breaks the deadlock from kanade0404/skills#31.
+# Note: `gh --jq` only takes a single expression string (no --arg/--argjson
+# like the standalone jq binary), so we fetch raw JSON via gh and filter with
+# a separate `jq` process where $now/$ttl can be bound safely.
+oldest_run=$(gh issue view "$ISSUE" -R "$REPO" --json comments \
+  | jq -r --argjson now "$NOW" --argjson ttl "$LEASE_TTL" '
+    [.comments[]
+      | select(.body | startswith("claude-lock: "))
+      | . + {run: (.body | capture("claude-lock: (?<run>[^ ]+)").run),
+             ts: ((.body | capture("ts=(?<ts>[0-9]+)").ts // "0") | tonumber)}
+      | select(($now - .ts) <= $ttl)]
+    | sort_by(.createdAt) | first.run // empty')
+
+if [ "$oldest_run" != "$RUN_ID" ]; then
+  echo "skip: lost the race (oldest live lock is ${oldest_run:-unknown})" >&2
+  exit 5
+fi
+
+# --- stage 3: we won -- only now is it safe to flip labels -----------------
+SWAPPED_TO_PROGRESS=1
+gh issue edit "$ISSUE" -R "$REPO" \
+  --remove-label "$LABEL_READY" --add-label "$LABEL_PROGRESS" >/dev/null
+WON=1
+
+echo "run_id=${RUN_ID}"
+echo "acquired_at=${NOW}"

--- a/skills/linear-issue-driven-development/SKILL.md
+++ b/skills/linear-issue-driven-development/SKILL.md
@@ -12,6 +12,8 @@ description: |
 
   実行環境はクラウド (Anthropic 側 sandbox) を想定しているため、`gw` 等の
   dotfiles 同梱ヘルパには依存しない。素の `git` / `gh` / `curl` だけで動くこと。
+  本ループ (loop-ops 駆動) では非対象。GitHub issue は issue-driven-development
+  を使うこと — 本 skill は Linear issue 専用。
 ---
 
 # linear-issue-driven-development
@@ -26,9 +28,10 @@ Linear issue を 1 件受け取り、PR がマージ可能な状態 (CI 緑 + �
 | `LINEAR_API_KEY` | Linear GraphQL 認証 (`Settings → API → Personal API key`) |
 | `GH_TOKEN` | `gh auth login --with-token` 用 PAT (repo / workflow / write) |
 | `ANTHROPIC_API_KEY` | Routine 実行に必要 (登録時に自動設定) |
+| `LOCK_LEASE_TTL_SECONDS` | 任意。lock lease の失効秒数 (既定 3600) |
 
 Routine の secrets 欄に設定する。手元で `/linear-issue` を打つ場合は環境変数で
-渡す。未設定なら即フェイル。
+渡す。未設定なら即フェイル (`LOCK_LEASE_TTL_SECONDS` のみ未設定でも既定値で続行)。
 
 ## 入力契約
 
@@ -64,23 +67,47 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 着手前に Linear ラベルを `claude:ready` → `claude:in-progress` に張り替える。
 ただしラベル付与は atomic な compare-and-set ではないため、2 つの実行 (cron と
 手動 `/linear-issue` の併走など) が同じ `claude:ready` issue をほぼ同時取得すると
-両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う:
+両方が処理を始める。これを防ぐため必ず以下のロック取得検証を行う。
+
+**Iron Law**: ラベルは最古検証に勝った run しか触らない。敗者・エラー終了は
+`claude:ready` を絶対に失わない (kanade0404/skills#31 — 旧手順はラベル張替を
+最古検証より先に行っており、敗者やクラッシュが `claude:in-progress` だけ外して
+`claude:ready` を永久に失う queue 消失バグと、lock が無期限に有効でクラッシュ
+した run の lock が未来の全 run を負けさせ続けるデッドロックの 2 つを併発させて
+いた)。
 
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
+0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
+   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
+   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
+   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
+   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
+   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
+   監査コメントを添える) してから続行する。失効していなければ他の生存中の
+   run が保持中と判断し、何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
-   `claude-lock: <run-id>` (run-id は uuid) のコメントを 1 件付ける。
-2. `issueRemoveLabel` で `claude:ready` を外し、`issueAddLabel` で
-   `claude:in-progress` を付与する (張り替えを atomic に完了させる)。
-3. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
-   で **最古の `claude-lock:` コメントが自分の run-id か** を確認する
-   (順序を非決定にしないため orderBy は必須)。
-   - 自分が最古 → ロック取得成功、続行。
-   - 他者が最古 → 競合に負け。自分が付けた `claude:in-progress` だけ外して
-     何もせず即終了 (exit 0)。
+   `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
+   1 件付ける。**タイムスタンプは lease の起点であり必須。**
+2. issue を再取得し、`comments(orderBy: { field: createdAt, direction: ASC })`
+   で全コメントを取得。`claude-lock: ` コメントのうち `ts` が現在時刻から
+   `LOCK_LEASE_TTL_SECONDS` 以内 (＝失効していない) のものだけを対象に、
+   **最古のコメントが自分の run-id か**を確認する (順序を非決定にしないため
+   orderBy は必須。失効済みコメントを対象から除外することで、クラッシュした
+   run の lock が未来の全 run を負けさせ続けるデッドロックを防ぐ)。
+   - 自分が最古 → ロック取得成功。**ここで初めて** `issueRemoveLabel` で
+     `claude:ready` を外し `issueAddLabel` で `claude:in-progress` を付与する。
+   - 他者が最古 → 競合に負け。**ラベルは一切触らない**まま何もせず即終了
+     (exit 0)。自分の lock コメントは監査用に残してよい (lease 失効後は
+     自動的に無視されるようになる)。
 
 完了時に `claude:done`, 失敗時に `claude:failed` に張り替える (どちらの場合も
-`claude:in-progress` は外す)。
+`claude:in-progress` は外す)。**この手続きの外 (実装フェーズ中) でクラッシュ
+した場合はここでは救えない** — 次にこの issue が選ばれた時の stage 0b (lease
+reap) が唯一の救済経路になるため、Routine 側は毎回の issue 選定前に
+`claude:in-progress` かつ lease 失効済みの issue が無いか同様のチェックを
+挟むこと (省略すると kanade0404/skills#31 のデッドロックが再発する)。
 
 ラベル ID は team 単位なので、team ごとに `claude:in-progress` / `claude:done` /
 `claude:failed` が存在するか確認し、無ければ `issueLabelCreate` で作成する。
@@ -222,8 +249,12 @@ mutation { issueLabelCreate(input: { teamId: $team, name: $name }) { issueLabel 
 mutation { issueAddLabel(id: $id, labelId: $labelId) { success } }
 mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 
-# lock 検証用コメント取得 (作成時刻昇順、最古の claude-lock: を判定)
+# lock 検証用コメント取得 (作成時刻昇順、ts=<epoch> が LOCK_LEASE_TTL_SECONDS 以内の
+# claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
+
+# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }

--- a/skills/linear-issue-driven-development/SKILL.md
+++ b/skills/linear-issue-driven-development/SKILL.md
@@ -79,14 +79,20 @@ orchestrator (routine prompt 側) が GraphQL で 1 件選んで JSON を渡す:
 0. issue の labels を取得し、`claude:done` / `claude:failed` が既に付いて
    いれば処理済み。lock marker を書く前に即終了する (無駄な API 呼び出し回避)。
 0b. **lease reap**: labels に `claude:in-progress` が既に付いている場合、
-   `comments(orderBy: { field: createdAt, direction: DESC }, first: 1)` かつ
-   本文が `claude-lock: ` で始まるものを 1 件取得し、そのコメントの `ts=<epoch>`
-   (下記 stage 1 参照) から経過秒数を計算する。`LOCK_LEASE_TTL_SECONDS`
-   (既定 3600) を超えている、またはそもそも lock コメントが存在しなければ
-   **lease 失効** とみなし、`issueRemoveLabel` で `claude:in-progress` を外し
-   `issueAddLabel` で `claude:ready` を再付与 (`claude-lock-reclaim: ...` の
-   監査コメントを添える) してから続行する。失効していなければ他の生存中の
-   run が保持中と判断し、何もせず即終了する。
+   `comments(orderBy: { field: createdAt, direction: DESC }, first: 20)` で
+   直近の複数コメントを取得し、その中で本文が `claude-lock: ` で始まる
+   **最新の 1 件**を選ぶ (`first: 1` だけを取得して判定すると、lock コメント
+   より後に別のコメント — 監査コメントや進捗報告など — が投稿されていた場合に
+   本物の lock コメントを見逃し、稼働中の issue を lock 無しと誤判定して
+   reclaim してしまう。GitHub 版 `acquire-lock.sh` の `lock_lease_age()` も
+   同様に「先にフィルタ、次に最新を選ぶ」順序を守っている)。選んだコメントの
+   `ts=<epoch>` (下記 stage 1 参照) から経過秒数を計算する。
+   `LOCK_LEASE_TTL_SECONDS` (既定 3600) を超えている、またはそもそも
+   lock コメントが (取得した範囲に) 存在しなければ **lease 失効** とみなし、
+   `issueRemoveLabel` で `claude:in-progress` を外し `issueAddLabel` で
+   `claude:ready` を再付与 (`claude-lock-reclaim: ...` の監査コメントを添える)
+   してから続行する。失効していなければ他の生存中の run が保持中と判断し、
+   何もせず即終了する。
 1. issue に一意 lock marker を書き込む — `commentCreate` で
    `claude-lock: <run-id> ts=<epoch-seconds>` (run-id は uuid) のコメントを
    1 件付ける。**タイムスタンプは lease の起点であり必須。**
@@ -253,8 +259,10 @@ mutation { issueRemoveLabel(id: $id, labelId: $labelId) { success } }
 # claude-lock: の中で最古のものを勝者と判定する。失効済みは判定対象から除外する)
 query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: ASC }) { nodes { id body createdAt } } } }
 
-# lease reap 用: 直近の claude-lock: コメント 1 件だけを見て失効判定する
-query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 1) { nodes { id body createdAt } } } }
+# lease reap 用: 直近の複数コメントを取得し、本文が claude-lock: で始まる
+# 最新の1件をクライアント側で選んで失効判定する (first: 1 は lock 以外の
+# コメントに隠れて本物の lock コメントを見逃すため使わない)
+query { issue(id: $id) { comments(orderBy: { field: createdAt, direction: DESC }, first: 20) { nodes { id body createdAt } } } }
 
 # state 遷移 (任意)
 mutation { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }


### PR DESCRIPTION
## Summary

- `issue-driven-development` / `linear-issue-driven-development` had a lock procedure that flipped `claude:ready` → `claude:in-progress` **before** the oldest-comment race was decided, and never expired the winning lock comment. A loser or a crashed run could strip an issue's only label (queue loss), and a crashed owner's `claude-lock:` comment blocked every future run forever (deadlock).
- Decisioned the 4-stage lock procedure (`done`/`failed` check → lock comment → win-check → label flip) into `skills/issue-driven-development/scripts/acquire-lock.sh`, reordered so **labels are only ever touched by the confirmed winner**, added a lease timestamp (`claude-lock: <run-id> ts=<epoch>`, default TTL 3600s) so stale locks are excluded from the win-check and auto-reclaimed to `claude:ready`, and wrapped the label flip in `set -euo pipefail` + an `EXIT` trap that restores `claude:ready` if the process itself dies mid-flight.
- `linear-issue-driven-development` doesn't share the script (GraphQL, not `gh`), so its `SKILL.md` prose got the same reordering + lease semantics, plus a scope note marking it Linear-only / out of scope for the GitHub-issue loop (use `issue-driven-development` there).
- Verified `issue-driven-development`'s description is 884 chars (within the 1024-char rulesync/Anthropic limit; already fixed by a prior PR after a real Codex load failure) — no further compression needed. Added `jq` to its stated environment prerequisites since the new script depends on it.

## Test plan

- [x] Offline regression against a stateful mock `gh`: fresh acquire (win), terminal skip (`claude:done`/`claude:failed`), active-lock skip (fresh lease), stale-lease reclaim + reacquire in the same run (the deadlock scenario from the issue), lost-race leaves labels untouched (the queue-loss scenario from the issue), and mid-flight crash triggers the `EXIT` trap rollback to `claude:ready`.
- [x] `--reap <owner/repo>` sweep mode tested against both a stale and a live `claude:in-progress` issue.
- [x] `bash -n` on the script (source + both rulesync mirrors).
- [x] `node scripts/rulesync-sync.mjs` (regenerate) then `--check` passes.
- [x] `/usr/bin/python3 -m unittest tests.test_skill_frontmatter tests.test_check_trigger_evals` — all pass.

Closes #31


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic, lease-based GitHub issue locking with optional `LOCK_LEASE_TTL_SECONDS` (default 3600).
  * Added `--reap` support to recover stale `in-progress` issues and prevent stuck queues.
* **Bug Fixes**
  * Prevents double-start conflicts by ensuring only the winning run mutates lock labels.
  * Reclaims expired/missing leases to avoid deadlocks in exploration and subsequent acquisitions.
* **Documentation**
  * Updated workflow prerequisites to include `jq` and refreshed lock/recovery guidance for issue-driven and Linear runs.
* **Tests**
  * Refined evaluation explanation text without changing verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->