### PR TITLE
Neutralize forced gh color in prr entry point

### DIFF
--- a/.agents/skills/pr-review-respond/scripts/prr
+++ b/.agents/skills/pr-review-respond/scripts/prr
@@ -17,6 +17,12 @@
 
 set -euo pipefail
 
+# gh は CLICOLOR_FORCE=1 / GH_FORCE_TTY の環境だと pipe 先にも ANSI 色付き JSON を
+# 出力し、下流の jq (--argjson / parse) を静かに壊す。ここは機械処理専用の経路
+# なので、全 subcommand に先立って色と TTY 強制を無効化する。
+export CLICOLOR_FORCE=0
+unset GH_FORCE_TTY 2>/dev/null || true
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {

--- a/.claude/skills/pr-review-respond/scripts/prr
+++ b/.claude/skills/pr-review-respond/scripts/prr
@@ -17,6 +17,12 @@
 
 set -euo pipefail
 
+# gh は CLICOLOR_FORCE=1 / GH_FORCE_TTY の環境だと pipe 先にも ANSI 色付き JSON を
+# 出力し、下流の jq (--argjson / parse) を静かに壊す。ここは機械処理専用の経路
+# なので、全 subcommand に先立って色と TTY 強制を無効化する。
+export CLICOLOR_FORCE=0
+unset GH_FORCE_TTY 2>/dev/null || true
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {

--- a/skills/pr-review-respond/scripts/prr
+++ b/skills/pr-review-respond/scripts/prr
@@ -17,6 +17,12 @@
 
 set -euo pipefail
 
+# gh は CLICOLOR_FORCE=1 / GH_FORCE_TTY の環境だと pipe 先にも ANSI 色付き JSON を
+# 出力し、下流の jq (--argjson / parse) を静かに壊す。ここは機械処理専用の経路
+# なので、全 subcommand に先立って色と TTY 強制を無効化する。
+export CLICOLOR_FORCE=0
+unset GH_FORCE_TTY 2>/dev/null || true
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {


### PR DESCRIPTION
## What

`pr-review-respond` の同梱スクリプト `prr` (entry point) で、gh の強制色付き出力を無効化する (`CLICOLOR_FORCE=0` を export、`GH_FORCE_TTY` を unset)。

## Why

`CLICOLOR_FORCE=1` を export している環境では `gh api` が **pipe 先にも ANSI 色付き JSON** を出力し、`fetch_threads.sh` 内の `jq --argjson` が静かに壊れる (実際に skills#59 のレビュー対応中、この環境で `prr fetch` が再現性 100% で失敗した)。prr の全経路は機械処理専用なので、dispatcher で一度だけ色と TTY 強制を殺すのが最小修正。

同根の原因で過去に ad-hoc な PR 監視が 2 回静かに壊れており、`bash-and-api-discipline` rule に「素の出力を jq にパイプしない」として既に記録済みのクラス。今回はスクリプト側で構造的に潰す。

## Verification

- 修正前: `CLICOLOR_FORCE=1 bash prr fetch 59` → `jq: invalid JSON text passed to --argjson` で必ず失敗
- 修正後: 同条件で正常に JSON を返すことを確認
- skill frontmatter (トリガ面) は未変更のため trigger-eval 再測定は不要。単体テスト 35 件 / drift check 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcnmrjKiVvAYmDbCcixzX3

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->