### PR TITLE
Pass token to update_command for API-calling tools

### DIFF
--- a/.github/workflows/consumer-update.yml
+++ b/.github/workflows/consumer-update.yml
@@ -117,6 +117,11 @@ jobs:
         if: steps.guard.outputs.pr_exists == 'false' && steps.guard.outputs.branch_exists == 'false'
         env:
           SKILLS_TAG: ${{ steps.tag.outputs.tag }}
+          # update_command 内の GitHub API を叩くツール (rulesync fetch 等) が
+          # 匿名レート制限 (60 req/h) に当たらないよう token を渡す。
+          # 実障害: rulesync fetch が runner の匿名クォータで 403 になった
+          GITHUB_TOKEN: ${{ secrets.pr_token || github.token }}
+          GH_TOKEN: ${{ secrets.pr_token || github.token }}
         run: ${{ inputs.update_command }}
 
       - name: Create pull request if changed


### PR DESCRIPTION
## What

reusable workflow `consumer-update.yml` の `update_command` ステップに `GITHUB_TOKEN` / `GH_TOKEN`(`pr_token` があればそちら)を渡す。

## Why

agegis での pull 型初回検証(workflow_dispatch)で発見した実障害: タグ解決 → guard → pin 書き換えまで設計どおり動作した後、`rulesync fetch` が **runner の匿名 API クォータ(60 req/h)** で 403 になった。rulesync は `GITHUB_TOKEN` があれば認証付きで fetch する(エラーメッセージ自身が設定を促す)ため、step env に渡すのが class-level の修正。update_command 内で API を叩く他のツールにも同様に効く。

検証ログ: https://github.com/kanade0404/agegis/actions/runs/28794129283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcnmrjKiVvAYmDbCcixzX3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated update runs by ensuring authenticated API access is used when available.
  * Reduced the chance of update steps failing due to anonymous rate limits during external requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->