### PR TITLE
Fix test-mutation-gate portability (CLAUDE_SKILL_DIR) and TS generics false positives

### DIFF
--- a/.agents/skills/test-mutation-gate/SKILL.md
+++ b/.agents/skills/test-mutation-gate/SKILL.md
@@ -75,7 +75,7 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
 1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+2. `uv` が存在しない、またはコマンドが**起動できない** (コマンド不在・環境構築失敗等) 場合のみ、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。**起動したスクリプトの exit code は確定結果であり、fallback 条件ではない** — 0=PASS / 1=BLOCK はそのまま採用し (BLOCK を下段の再実行や手動チェックで上書きしない)、2=入力エラーは diff 入力を直して同じ段で再実行する。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -99,7 +99,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じく**起動不能時のみ** uv → python3 の順で fallback する (起動したスクリプトの exit code 0/1/2 は確定結果であり fallback 条件ではない — BLOCK の exit 1 を fallback や SKIP で上書きしない) が、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。

--- a/.agents/skills/test-mutation-gate/SKILL.md
+++ b/.agents/skills/test-mutation-gate/SKILL.md
@@ -70,10 +70,12 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 
 ### Step 2 — 静的監査実行 (3 段 fallback)
 
+以下で `<skill-dir>` は、この SKILL.md が置かれている skill ディレクトリの絶対パスを指す。Claude Code では環境変数 `${CLAUDE_SKILL_DIR}` がこれに一致する。この変数を持たないツール (Codex / OpenCode 等) では、skill 読み込み時に提示されるこの skill のベースディレクトリを使うこと — 未定義の変数を展開したまま実行するとパスが `/scripts/...` に解れて、スクリプトが一度も走らないまま下段へ静かに fallback してしまう。
+
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
+2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -97,7 +99,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。
@@ -115,7 +117,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 ### Step 4 — 計測 emit + 結果返却
 
-`scripts/emit_gate_event.sh` を呼び、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
+`bash "<skill-dir>/scripts/emit_gate_event.sh" ...` を呼び (`<skill-dir>` の解決は Step 2 と同じ)、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
 
 ---
 

--- a/.agents/skills/test-mutation-gate/references/mutation-recipes.md
+++ b/.agents/skills/test-mutation-gate/references/mutation-recipes.md
@@ -67,6 +67,26 @@ The masking above is **line-based**, not a real tokenizer:
   arrow functions are excluded from the comparison-flip regex via
   lookaround, but this is a pattern-level dodge, not a parser — unusual
   spacing or novel operators can still slip through.
+- TS/TSX generic **declaration** lines (`function f<T>()`, `type Box<T> =
+  ...`, `interface Foo<T>`, `class C<T>`) are excluded from single-char
+  `<`/`>` comparison-flip via a line-level heuristic
+  (`TS_GENERIC_DECL_LINE_RE`/`skip_generic_comparisons`), matched the same
+  way `TS_TYPE_ALIAS_LINE_RE`/`skip_type_alias_bools` guards bool-flip
+  above. This is still line-level, not a parser, so **call-site generics**
+  (`foo<Bar>(x)`), **arrow-function generics** (`const f = <T,>(...) =>
+  ...`), and **class-method generics** (`map<U>(fn)`) are not recognized by
+  this heuristic and remain a gap — a bare `<`/`>` on those lines can still
+  be picked up as a comparison-flip candidate. The inverse trade-off also
+  holds: because the skip is line-level, a *real* runtime comparison that
+  shares the declaration's physical line (a one-line body such as
+  `function isPositive<T>(x: T) { return x > 0; }`) is skipped along with
+  the generics. Restricting the skip to the `<T>` span instead would
+  re-admit type-space brackets in parameter/return annotations
+  (`x: Array<number>`, `: Map<string, T>`) — the very false positives the
+  guard removes — so the line-level form is deliberate. The cost is a
+  missed candidate (surfacing as `SKIP` when no other candidate exists,
+  never a silent pass); putting the body on its own line (standard
+  formatting) restores mutability.
 - TS type positions other than a `type X = ...` alias declaration line
   (interface fields, function parameter/return type annotations using
   literal booleans) are not distinguished from runtime bool literals — see

--- a/.agents/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/.agents/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -86,6 +86,23 @@ INT_LEFT_RE = re.compile(r"(-?\d+)\s*$")
 # positions too).
 TS_TYPE_ALIAS_LINE_RE = re.compile(r"^\s*(export\s+)?(declare\s+)?type\s+\w+\b[^=]*=")
 
+# Narrow heuristic for TS/TSX generic *declaration* lines, e.g.
+# `function identity<T>(x: T): T {`, `export type Box<T> = ...`,
+# `interface Repo<T> {`, `export default class Container<T> {`. Only used to
+# guard comparison-flip (see discover_candidates' skip_generic_comparisons
+# docstring) against COMPARISON_RE mistaking the opening `<` / closing `>` of
+# a generic parameter list for a `<`/`>` runtime comparison. Deliberately
+# limited to the declaration keyword position (function/type/interface/class,
+# optionally export/default/declare/abstract/async prefixed) immediately
+# followed by `<` - it does not attempt to catch call-site generics
+# (`foo<Bar>(x)`), arrow-function generics (`const f = <T,>(...) => ...`), or
+# class-method generics (`map<U>(fn)`), which remain a known gap (see
+# references/mutation-recipes.md).
+TS_GENERIC_DECL_LINE_RE = re.compile(
+    r"^\s*(export\s+)?(default\s+)?(declare\s+)?(abstract\s+)?(async\s+)?"
+    r"(function\s*\*?\s*[\w$]*|type\s+[\w$]+|interface\s+[\w$]+|class\s+[\w$]+)\s*<"
+)
+
 # Generic, cross-language markers that a non-zero exit was a syntax/parse
 # failure caused by the mutation breaking the file, rather than a real
 # assertion catching the behavioral change. Still counted as "caught" (the
@@ -213,7 +230,13 @@ def find_adjacent_int(masked_line, op_start, op_end):
     return None
 
 
-def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_alias_bools=False):
+def discover_candidates(
+    lines,
+    comment_prefixes,
+    block_comment=None,
+    skip_type_alias_bools=False,
+    skip_generic_comparisons=False,
+):
     """Scan every added-nothing (this is a whole-file scan, not a diff) line
     of `lines` (as returned by readlines(), terminators included) and return
     an ordered, deduplicated list of mutation candidate dicts:
@@ -230,6 +253,37 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
     attempt to distinguish object/interface field type positions from
     runtime literals, since that would risk suppressing real runtime bool
     literals (e.g. `{ enabled: true }`) which are far more common.
+
+    `skip_generic_comparisons`, when True (TS/TSX files only - see call
+    site), skips *single-char* `<`/`>` comparison-flip candidates on lines
+    that are TypeScript generic declarations (`function f<T>()`,
+    `type Box<T> = ...`, `interface Foo<T>`, `class C<T>`). COMPARISON_RE has
+    no way to distinguish the opening/closing angle bracket of a generic
+    parameter list from a real `<`/`>` runtime comparison - both are a bare
+    `<` or `>` outside a string/comment. `==`/`!=`/`<=`/`>=` are never valid
+    generic-declaration syntax, so they are never skipped by this flag, even
+    on a matching line. Skipping via `continue` also skips that operator
+    match's off-by-one candidate (find_adjacent_int looks at an integer
+    adjacent to the same `<`/`>`); on a generic decl line an adjacent integer
+    is a type-position literal (e.g. `LessThan<3>`), not a runtime comparison
+    boundary, so this is the intended behavior, not a side effect to work
+    around. This is a narrow, line-level heuristic (see
+    references/mutation-recipes.md) - it only recognizes the declaration
+    keyword position (function/type/interface/class) immediately followed by
+    `<`; call-site generics, arrow-function generics, and class-method
+    generics remain a known gap.
+
+    Being line-level, the skip also swallows a *real* runtime `<`/`>`
+    comparison that shares the declaration's physical line (a one-line body:
+    `function isPositive<T>(x: T) { return x > 0; }`). This is a deliberate
+    trade-off, not an oversight: restricting the skip to the generic
+    parameter span would re-admit the far more common type-space brackets in
+    parameter/return annotations (`function f<T>(x: Array<number>):
+    Map<string, T> {`) - the very false positives this flag exists to
+    remove. The cost is a conservative false *negative* (a missed candidate,
+    surfacing as SKIP if the file has no other candidates - a visible
+    outcome, never a silent pass), and standard formatting puts bodies on
+    their own lines anyway. See references/mutation-recipes.md.
     """
     candidates = []
     seen = set()
@@ -238,6 +292,7 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
         masked = mask_line(line, comment_prefixes, block_comment)
 
         skip_bools = skip_type_alias_bools and TS_TYPE_ALIAS_LINE_RE.match(line)
+        skip_angle_comparisons = skip_generic_comparisons and TS_GENERIC_DECL_LINE_RE.match(line)
         for m in BOOL_RE.finditer(masked):
             if skip_bools:
                 continue
@@ -258,6 +313,8 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
 
         for m in COMPARISON_RE.finditer(masked):
             old_op = m.group(0)
+            if skip_angle_comparisons and old_op in ("<", ">"):
+                continue
             key = (lineno, "comparison-flip", m.start())
             if key not in seen:
                 seen.add(key)
@@ -468,9 +525,15 @@ def main(argv=None):
 
         comment_prefixes = comment_prefixes_for(impl_path)
         block_comment = block_comment_markers_for(impl_path)
-        skip_type_alias_bools = impl_path.suffix.lower() in (".ts", ".tsx")
+        is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
+        skip_type_alias_bools = is_ts
+        skip_generic_comparisons = is_ts
         all_candidates = discover_candidates(
-            original_lines, comment_prefixes, block_comment, skip_type_alias_bools
+            original_lines,
+            comment_prefixes,
+            block_comment,
+            skip_type_alias_bools=skip_type_alias_bools,
+            skip_generic_comparisons=skip_generic_comparisons,
         )
         selected = all_candidates[: args.max_mutations]
 

--- a/.agents/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/.agents/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -528,6 +528,20 @@ def main(argv=None):
         is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
         skip_type_alias_bools = is_ts
         skip_generic_comparisons = is_ts
+        if is_ts:
+            # Disclose the TS/TSX-only candidate exclusions up front so a
+            # SKIP (0 candidates) on a TS file is explainable by the reader -
+            # references/mutation-recipes.md promises these limitations are
+            # never silently swallowed.
+            notes.append(
+                "TS/TSX heuristics active: bool-flip candidates on type-alias "
+                "declaration lines and single-char </> comparison-flip "
+                "candidates on generic declaration lines "
+                "(function/type/interface/class) are excluded. The generic "
+                "skip is line-level, so a runtime comparison sharing a "
+                "generic declaration's line (one-line body) is excluded too - "
+                "see references/mutation-recipes.md."
+            )
         all_candidates = discover_candidates(
             original_lines,
             comment_prefixes,

--- a/.claude/skills/test-mutation-gate/SKILL.md
+++ b/.claude/skills/test-mutation-gate/SKILL.md
@@ -80,7 +80,7 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
 1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+2. `uv` が存在しない、またはコマンドが**起動できない** (コマンド不在・環境構築失敗等) 場合のみ、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。**起動したスクリプトの exit code は確定結果であり、fallback 条件ではない** — 0=PASS / 1=BLOCK はそのまま採用し (BLOCK を下段の再実行や手動チェックで上書きしない)、2=入力エラーは diff 入力を直して同じ段で再実行する。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -104,7 +104,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じく**起動不能時のみ** uv → python3 の順で fallback する (起動したスクリプトの exit code 0/1/2 は確定結果であり fallback 条件ではない — BLOCK の exit 1 を fallback や SKIP で上書きしない) が、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。

--- a/.claude/skills/test-mutation-gate/SKILL.md
+++ b/.claude/skills/test-mutation-gate/SKILL.md
@@ -75,10 +75,12 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 
 ### Step 2 — 静的監査実行 (3 段 fallback)
 
+以下で `<skill-dir>` は、この SKILL.md が置かれている skill ディレクトリの絶対パスを指す。Claude Code では環境変数 `${CLAUDE_SKILL_DIR}` がこれに一致する。この変数を持たないツール (Codex / OpenCode 等) では、skill 読み込み時に提示されるこの skill のベースディレクトリを使うこと — 未定義の変数を展開したまま実行するとパスが `/scripts/...` に解れて、スクリプトが一度も走らないまま下段へ静かに fallback してしまう。
+
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
+2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -102,7 +104,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。
@@ -120,7 +122,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 ### Step 4 — 計測 emit + 結果返却
 
-`scripts/emit_gate_event.sh` を呼び、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
+`bash "<skill-dir>/scripts/emit_gate_event.sh" ...` を呼び (`<skill-dir>` の解決は Step 2 と同じ)、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
 
 ---
 

--- a/.claude/skills/test-mutation-gate/references/mutation-recipes.md
+++ b/.claude/skills/test-mutation-gate/references/mutation-recipes.md
@@ -67,6 +67,26 @@ The masking above is **line-based**, not a real tokenizer:
   arrow functions are excluded from the comparison-flip regex via
   lookaround, but this is a pattern-level dodge, not a parser — unusual
   spacing or novel operators can still slip through.
+- TS/TSX generic **declaration** lines (`function f<T>()`, `type Box<T> =
+  ...`, `interface Foo<T>`, `class C<T>`) are excluded from single-char
+  `<`/`>` comparison-flip via a line-level heuristic
+  (`TS_GENERIC_DECL_LINE_RE`/`skip_generic_comparisons`), matched the same
+  way `TS_TYPE_ALIAS_LINE_RE`/`skip_type_alias_bools` guards bool-flip
+  above. This is still line-level, not a parser, so **call-site generics**
+  (`foo<Bar>(x)`), **arrow-function generics** (`const f = <T,>(...) =>
+  ...`), and **class-method generics** (`map<U>(fn)`) are not recognized by
+  this heuristic and remain a gap — a bare `<`/`>` on those lines can still
+  be picked up as a comparison-flip candidate. The inverse trade-off also
+  holds: because the skip is line-level, a *real* runtime comparison that
+  shares the declaration's physical line (a one-line body such as
+  `function isPositive<T>(x: T) { return x > 0; }`) is skipped along with
+  the generics. Restricting the skip to the `<T>` span instead would
+  re-admit type-space brackets in parameter/return annotations
+  (`x: Array<number>`, `: Map<string, T>`) — the very false positives the
+  guard removes — so the line-level form is deliberate. The cost is a
+  missed candidate (surfacing as `SKIP` when no other candidate exists,
+  never a silent pass); putting the body on its own line (standard
+  formatting) restores mutability.
 - TS type positions other than a `type X = ...` alias declaration line
   (interface fields, function parameter/return type annotations using
   literal booleans) are not distinguished from runtime bool literals — see

--- a/.claude/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/.claude/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -86,6 +86,23 @@ INT_LEFT_RE = re.compile(r"(-?\d+)\s*$")
 # positions too).
 TS_TYPE_ALIAS_LINE_RE = re.compile(r"^\s*(export\s+)?(declare\s+)?type\s+\w+\b[^=]*=")
 
+# Narrow heuristic for TS/TSX generic *declaration* lines, e.g.
+# `function identity<T>(x: T): T {`, `export type Box<T> = ...`,
+# `interface Repo<T> {`, `export default class Container<T> {`. Only used to
+# guard comparison-flip (see discover_candidates' skip_generic_comparisons
+# docstring) against COMPARISON_RE mistaking the opening `<` / closing `>` of
+# a generic parameter list for a `<`/`>` runtime comparison. Deliberately
+# limited to the declaration keyword position (function/type/interface/class,
+# optionally export/default/declare/abstract/async prefixed) immediately
+# followed by `<` - it does not attempt to catch call-site generics
+# (`foo<Bar>(x)`), arrow-function generics (`const f = <T,>(...) => ...`), or
+# class-method generics (`map<U>(fn)`), which remain a known gap (see
+# references/mutation-recipes.md).
+TS_GENERIC_DECL_LINE_RE = re.compile(
+    r"^\s*(export\s+)?(default\s+)?(declare\s+)?(abstract\s+)?(async\s+)?"
+    r"(function\s*\*?\s*[\w$]*|type\s+[\w$]+|interface\s+[\w$]+|class\s+[\w$]+)\s*<"
+)
+
 # Generic, cross-language markers that a non-zero exit was a syntax/parse
 # failure caused by the mutation breaking the file, rather than a real
 # assertion catching the behavioral change. Still counted as "caught" (the
@@ -213,7 +230,13 @@ def find_adjacent_int(masked_line, op_start, op_end):
     return None
 
 
-def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_alias_bools=False):
+def discover_candidates(
+    lines,
+    comment_prefixes,
+    block_comment=None,
+    skip_type_alias_bools=False,
+    skip_generic_comparisons=False,
+):
     """Scan every added-nothing (this is a whole-file scan, not a diff) line
     of `lines` (as returned by readlines(), terminators included) and return
     an ordered, deduplicated list of mutation candidate dicts:
@@ -230,6 +253,37 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
     attempt to distinguish object/interface field type positions from
     runtime literals, since that would risk suppressing real runtime bool
     literals (e.g. `{ enabled: true }`) which are far more common.
+
+    `skip_generic_comparisons`, when True (TS/TSX files only - see call
+    site), skips *single-char* `<`/`>` comparison-flip candidates on lines
+    that are TypeScript generic declarations (`function f<T>()`,
+    `type Box<T> = ...`, `interface Foo<T>`, `class C<T>`). COMPARISON_RE has
+    no way to distinguish the opening/closing angle bracket of a generic
+    parameter list from a real `<`/`>` runtime comparison - both are a bare
+    `<` or `>` outside a string/comment. `==`/`!=`/`<=`/`>=` are never valid
+    generic-declaration syntax, so they are never skipped by this flag, even
+    on a matching line. Skipping via `continue` also skips that operator
+    match's off-by-one candidate (find_adjacent_int looks at an integer
+    adjacent to the same `<`/`>`); on a generic decl line an adjacent integer
+    is a type-position literal (e.g. `LessThan<3>`), not a runtime comparison
+    boundary, so this is the intended behavior, not a side effect to work
+    around. This is a narrow, line-level heuristic (see
+    references/mutation-recipes.md) - it only recognizes the declaration
+    keyword position (function/type/interface/class) immediately followed by
+    `<`; call-site generics, arrow-function generics, and class-method
+    generics remain a known gap.
+
+    Being line-level, the skip also swallows a *real* runtime `<`/`>`
+    comparison that shares the declaration's physical line (a one-line body:
+    `function isPositive<T>(x: T) { return x > 0; }`). This is a deliberate
+    trade-off, not an oversight: restricting the skip to the generic
+    parameter span would re-admit the far more common type-space brackets in
+    parameter/return annotations (`function f<T>(x: Array<number>):
+    Map<string, T> {`) - the very false positives this flag exists to
+    remove. The cost is a conservative false *negative* (a missed candidate,
+    surfacing as SKIP if the file has no other candidates - a visible
+    outcome, never a silent pass), and standard formatting puts bodies on
+    their own lines anyway. See references/mutation-recipes.md.
     """
     candidates = []
     seen = set()
@@ -238,6 +292,7 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
         masked = mask_line(line, comment_prefixes, block_comment)
 
         skip_bools = skip_type_alias_bools and TS_TYPE_ALIAS_LINE_RE.match(line)
+        skip_angle_comparisons = skip_generic_comparisons and TS_GENERIC_DECL_LINE_RE.match(line)
         for m in BOOL_RE.finditer(masked):
             if skip_bools:
                 continue
@@ -258,6 +313,8 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
 
         for m in COMPARISON_RE.finditer(masked):
             old_op = m.group(0)
+            if skip_angle_comparisons and old_op in ("<", ">"):
+                continue
             key = (lineno, "comparison-flip", m.start())
             if key not in seen:
                 seen.add(key)
@@ -468,9 +525,15 @@ def main(argv=None):
 
         comment_prefixes = comment_prefixes_for(impl_path)
         block_comment = block_comment_markers_for(impl_path)
-        skip_type_alias_bools = impl_path.suffix.lower() in (".ts", ".tsx")
+        is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
+        skip_type_alias_bools = is_ts
+        skip_generic_comparisons = is_ts
         all_candidates = discover_candidates(
-            original_lines, comment_prefixes, block_comment, skip_type_alias_bools
+            original_lines,
+            comment_prefixes,
+            block_comment,
+            skip_type_alias_bools=skip_type_alias_bools,
+            skip_generic_comparisons=skip_generic_comparisons,
         )
         selected = all_candidates[: args.max_mutations]
 

--- a/.claude/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/.claude/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -528,6 +528,20 @@ def main(argv=None):
         is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
         skip_type_alias_bools = is_ts
         skip_generic_comparisons = is_ts
+        if is_ts:
+            # Disclose the TS/TSX-only candidate exclusions up front so a
+            # SKIP (0 candidates) on a TS file is explainable by the reader -
+            # references/mutation-recipes.md promises these limitations are
+            # never silently swallowed.
+            notes.append(
+                "TS/TSX heuristics active: bool-flip candidates on type-alias "
+                "declaration lines and single-char </> comparison-flip "
+                "candidates on generic declaration lines "
+                "(function/type/interface/class) are excluded. The generic "
+                "skip is line-level, so a runtime comparison sharing a "
+                "generic declaration's line (one-line body) is excluded too - "
+                "see references/mutation-recipes.md."
+            )
         all_candidates = discover_candidates(
             original_lines,
             comment_prefixes,

--- a/skills/test-mutation-gate/SKILL.md
+++ b/skills/test-mutation-gate/SKILL.md
@@ -64,10 +64,12 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 
 ### Step 2 — 静的監査実行 (3 段 fallback)
 
+以下で `<skill-dir>` は、この SKILL.md が置かれている skill ディレクトリの絶対パスを指す。Claude Code では環境変数 `${CLAUDE_SKILL_DIR}` がこれに一致する。この変数を持たないツール (Codex / OpenCode 等) では、skill 読み込み時に提示されるこの skill のベースディレクトリを使うこと — 未定義の変数を展開したまま実行するとパスが `/scripts/...` に解れて、スクリプトが一度も走らないまま下段へ静かに fallback してしまう。
+
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "${CLAUDE_SKILL_DIR}/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
+2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -91,7 +93,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "${CLAUDE_SKILL_DIR}/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。
@@ -109,7 +111,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 ### Step 4 — 計測 emit + 結果返却
 
-`scripts/emit_gate_event.sh` を呼び、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
+`bash "<skill-dir>/scripts/emit_gate_event.sh" ...` を呼び (`<skill-dir>` の解決は Step 2 と同じ)、判定結果を loop-ops へ記録する (best-effort、詳細は §loop-ops 計測)。Step 2.5 を実行した場合は `mutations_caught` / `mutations_total` の 2 引数も追加で渡す (未実行なら省略し後方互換を保つ)。送信の成否に関わらず、§出力フォーマットの結果ブロックを呼び出し元に返す。
 
 ---
 

--- a/skills/test-mutation-gate/SKILL.md
+++ b/skills/test-mutation-gate/SKILL.md
@@ -69,7 +69,7 @@ untracked な新規テストファイルは `--diff-file` にそのまま渡さ�
 観測可能な判定手順として、以下を**上から順に**試す。どの段で実行されたかを必ず gate 結果の `mode` に記録する (silent skip 禁止):
 
 1. `uv run --no-project python "<skill-dir>/scripts/assertion_audit.py" --diff-file <path> [--max-asserts N]` を実行する。コマンドが正常に起動すれば `mode: static-script (uv)`。
-2. `uv` が存在しない、または実行に失敗した場合、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。
+2. `uv` が存在しない、またはコマンドが**起動できない** (コマンド不在・環境構築失敗等) 場合のみ、`python3 "<skill-dir>/scripts/assertion_audit.py" --diff-file <path>` にフォールバックする。`mode: static-script (python3)`。**起動したスクリプトの exit code は確定結果であり、fallback 条件ではない** — 0=PASS / 1=BLOCK はそのまま採用し (BLOCK を下段の再実行や手動チェックで上書きしない)、2=入力エラーは diff 入力を直して同じ段で再実行する。
 3. `python3` も存在しない場合、§手動チェックリストを Claude 自身が Read/Grep のみで適用する。`mode: manual-fallback`。
 
 過去に「`python3` が実行環境に存在せず、スクリプトが一度も実走しないまま静かにゲートを素通りしていた」という実失敗がある。この段階を省略したり、実行失敗を「まあ大丈夫だろう」で握りつぶしたりしない — 3 段のどこで判定したかを結果に必ず明記する。
@@ -93,7 +93,7 @@ exit code: `PASS` = 0 / `BLOCK` = 1 / 入力エラー = 2。正規表現ベー�
 
 対象が **unit テスト** (プロセス内で完結・外部 I/O 無し) の場合のみ実行する。integration/E2E/DB テストはコスト・副作用の理由で対象外 — 実行するかどうか迷ったら対象外側に倒す (assertion 監査の Step 0 とは逆に、ここは安全側 = skip 側に倒す)。
 
-1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じ uv → python3 の順で fallback するが、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
+1. `uv run --no-project python "<skill-dir>/scripts/mutate_and_run.py" --impl-file <path> --test-cmd '<unit テストを実行するシェルコマンド>' [--max-mutations 3] [--timeout-sec 120]` を実行する (`<skill-dir>` の解決は Step 2 と同じ)。Step 2 と同じく**起動不能時のみ** uv → python3 の順で fallback する (起動したスクリプトの exit code 0/1/2 は確定結果であり fallback 条件ではない — BLOCK の exit 1 を fallback や SKIP で上書きしない) が、**手動 fallback は無い** — `python3` も無ければ手動で変異を作ることはせず `SKIP` 扱いにする (静的監査のみで判定し、その旨を notes に残す)。
 2. bool 反転 / 比較演算子反転 / off-by-one の変異を最大 `--max-mutations` 件注入し、1 件ずつ test-cmd を再実行する。全 survived を `survived: []` に列挙し、`caught`/`mutations_total` を記録する (出力形式は `scripts/mutate_and_run.py` のモジュール docstring 参照)。
 3. 変異候補が 0 件 (`SKIP`) の場合、対象コードが変異不能 seam である可能性を疑う → `references/mutation-recipes.md` の fallback (純関数抽出 → `tidy-first` の structural commit) → それも不可なら `references/waiver-fallback.md` の waiver。
 4. survived mutant が 1 件以上あれば、その行・変異種別を Step 3 の判定に持ち込む (`BLOCK`)。

--- a/skills/test-mutation-gate/references/mutation-recipes.md
+++ b/skills/test-mutation-gate/references/mutation-recipes.md
@@ -67,6 +67,26 @@ The masking above is **line-based**, not a real tokenizer:
   arrow functions are excluded from the comparison-flip regex via
   lookaround, but this is a pattern-level dodge, not a parser — unusual
   spacing or novel operators can still slip through.
+- TS/TSX generic **declaration** lines (`function f<T>()`, `type Box<T> =
+  ...`, `interface Foo<T>`, `class C<T>`) are excluded from single-char
+  `<`/`>` comparison-flip via a line-level heuristic
+  (`TS_GENERIC_DECL_LINE_RE`/`skip_generic_comparisons`), matched the same
+  way `TS_TYPE_ALIAS_LINE_RE`/`skip_type_alias_bools` guards bool-flip
+  above. This is still line-level, not a parser, so **call-site generics**
+  (`foo<Bar>(x)`), **arrow-function generics** (`const f = <T,>(...) =>
+  ...`), and **class-method generics** (`map<U>(fn)`) are not recognized by
+  this heuristic and remain a gap — a bare `<`/`>` on those lines can still
+  be picked up as a comparison-flip candidate. The inverse trade-off also
+  holds: because the skip is line-level, a *real* runtime comparison that
+  shares the declaration's physical line (a one-line body such as
+  `function isPositive<T>(x: T) { return x > 0; }`) is skipped along with
+  the generics. Restricting the skip to the `<T>` span instead would
+  re-admit type-space brackets in parameter/return annotations
+  (`x: Array<number>`, `: Map<string, T>`) — the very false positives the
+  guard removes — so the line-level form is deliberate. The cost is a
+  missed candidate (surfacing as `SKIP` when no other candidate exists,
+  never a silent pass); putting the body on its own line (standard
+  formatting) restores mutability.
 - TS type positions other than a `type X = ...` alias declaration line
   (interface fields, function parameter/return type annotations using
   literal booleans) are not distinguished from runtime bool literals — see

--- a/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -86,6 +86,23 @@ INT_LEFT_RE = re.compile(r"(-?\d+)\s*$")
 # positions too).
 TS_TYPE_ALIAS_LINE_RE = re.compile(r"^\s*(export\s+)?(declare\s+)?type\s+\w+\b[^=]*=")
 
+# Narrow heuristic for TS/TSX generic *declaration* lines, e.g.
+# `function identity<T>(x: T): T {`, `export type Box<T> = ...`,
+# `interface Repo<T> {`, `export default class Container<T> {`. Only used to
+# guard comparison-flip (see discover_candidates' skip_generic_comparisons
+# docstring) against COMPARISON_RE mistaking the opening `<` / closing `>` of
+# a generic parameter list for a `<`/`>` runtime comparison. Deliberately
+# limited to the declaration keyword position (function/type/interface/class,
+# optionally export/default/declare/abstract/async prefixed) immediately
+# followed by `<` - it does not attempt to catch call-site generics
+# (`foo<Bar>(x)`), arrow-function generics (`const f = <T,>(...) => ...`), or
+# class-method generics (`map<U>(fn)`), which remain a known gap (see
+# references/mutation-recipes.md).
+TS_GENERIC_DECL_LINE_RE = re.compile(
+    r"^\s*(export\s+)?(default\s+)?(declare\s+)?(abstract\s+)?(async\s+)?"
+    r"(function\s*\*?\s*[\w$]*|type\s+[\w$]+|interface\s+[\w$]+|class\s+[\w$]+)\s*<"
+)
+
 # Generic, cross-language markers that a non-zero exit was a syntax/parse
 # failure caused by the mutation breaking the file, rather than a real
 # assertion catching the behavioral change. Still counted as "caught" (the
@@ -213,7 +230,13 @@ def find_adjacent_int(masked_line, op_start, op_end):
     return None
 
 
-def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_alias_bools=False):
+def discover_candidates(
+    lines,
+    comment_prefixes,
+    block_comment=None,
+    skip_type_alias_bools=False,
+    skip_generic_comparisons=False,
+):
     """Scan every added-nothing (this is a whole-file scan, not a diff) line
     of `lines` (as returned by readlines(), terminators included) and return
     an ordered, deduplicated list of mutation candidate dicts:
@@ -230,6 +253,37 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
     attempt to distinguish object/interface field type positions from
     runtime literals, since that would risk suppressing real runtime bool
     literals (e.g. `{ enabled: true }`) which are far more common.
+
+    `skip_generic_comparisons`, when True (TS/TSX files only - see call
+    site), skips *single-char* `<`/`>` comparison-flip candidates on lines
+    that are TypeScript generic declarations (`function f<T>()`,
+    `type Box<T> = ...`, `interface Foo<T>`, `class C<T>`). COMPARISON_RE has
+    no way to distinguish the opening/closing angle bracket of a generic
+    parameter list from a real `<`/`>` runtime comparison - both are a bare
+    `<` or `>` outside a string/comment. `==`/`!=`/`<=`/`>=` are never valid
+    generic-declaration syntax, so they are never skipped by this flag, even
+    on a matching line. Skipping via `continue` also skips that operator
+    match's off-by-one candidate (find_adjacent_int looks at an integer
+    adjacent to the same `<`/`>`); on a generic decl line an adjacent integer
+    is a type-position literal (e.g. `LessThan<3>`), not a runtime comparison
+    boundary, so this is the intended behavior, not a side effect to work
+    around. This is a narrow, line-level heuristic (see
+    references/mutation-recipes.md) - it only recognizes the declaration
+    keyword position (function/type/interface/class) immediately followed by
+    `<`; call-site generics, arrow-function generics, and class-method
+    generics remain a known gap.
+
+    Being line-level, the skip also swallows a *real* runtime `<`/`>`
+    comparison that shares the declaration's physical line (a one-line body:
+    `function isPositive<T>(x: T) { return x > 0; }`). This is a deliberate
+    trade-off, not an oversight: restricting the skip to the generic
+    parameter span would re-admit the far more common type-space brackets in
+    parameter/return annotations (`function f<T>(x: Array<number>):
+    Map<string, T> {`) - the very false positives this flag exists to
+    remove. The cost is a conservative false *negative* (a missed candidate,
+    surfacing as SKIP if the file has no other candidates - a visible
+    outcome, never a silent pass), and standard formatting puts bodies on
+    their own lines anyway. See references/mutation-recipes.md.
     """
     candidates = []
     seen = set()
@@ -238,6 +292,7 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
         masked = mask_line(line, comment_prefixes, block_comment)
 
         skip_bools = skip_type_alias_bools and TS_TYPE_ALIAS_LINE_RE.match(line)
+        skip_angle_comparisons = skip_generic_comparisons and TS_GENERIC_DECL_LINE_RE.match(line)
         for m in BOOL_RE.finditer(masked):
             if skip_bools:
                 continue
@@ -258,6 +313,8 @@ def discover_candidates(lines, comment_prefixes, block_comment=None, skip_type_a
 
         for m in COMPARISON_RE.finditer(masked):
             old_op = m.group(0)
+            if skip_angle_comparisons and old_op in ("<", ">"):
+                continue
             key = (lineno, "comparison-flip", m.start())
             if key not in seen:
                 seen.add(key)
@@ -468,9 +525,15 @@ def main(argv=None):
 
         comment_prefixes = comment_prefixes_for(impl_path)
         block_comment = block_comment_markers_for(impl_path)
-        skip_type_alias_bools = impl_path.suffix.lower() in (".ts", ".tsx")
+        is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
+        skip_type_alias_bools = is_ts
+        skip_generic_comparisons = is_ts
         all_candidates = discover_candidates(
-            original_lines, comment_prefixes, block_comment, skip_type_alias_bools
+            original_lines,
+            comment_prefixes,
+            block_comment,
+            skip_type_alias_bools=skip_type_alias_bools,
+            skip_generic_comparisons=skip_generic_comparisons,
         )
         selected = all_candidates[: args.max_mutations]
 

--- a/skills/test-mutation-gate/scripts/mutate_and_run.py
+++ b/skills/test-mutation-gate/scripts/mutate_and_run.py
@@ -528,6 +528,20 @@ def main(argv=None):
         is_ts = impl_path.suffix.lower() in (".ts", ".tsx")
         skip_type_alias_bools = is_ts
         skip_generic_comparisons = is_ts
+        if is_ts:
+            # Disclose the TS/TSX-only candidate exclusions up front so a
+            # SKIP (0 candidates) on a TS file is explainable by the reader -
+            # references/mutation-recipes.md promises these limitations are
+            # never silently swallowed.
+            notes.append(
+                "TS/TSX heuristics active: bool-flip candidates on type-alias "
+                "declaration lines and single-char </> comparison-flip "
+                "candidates on generic declaration lines "
+                "(function/type/interface/class) are excluded. The generic "
+                "skip is line-level, so a runtime comparison sharing a "
+                "generic declaration's line (one-line body) is excluded too - "
+                "see references/mutation-recipes.md."
+            )
         all_candidates = discover_candidates(
             original_lines,
             comment_prefixes,

--- a/tests/test_mutate_and_run.py
+++ b/tests/test_mutate_and_run.py
@@ -184,7 +184,7 @@ class TsHeuristicsNoteTest(unittest.TestCase):
     silently swallowed), so a SKIP with 0 candidates on a TS file is
     explainable by the reader."""
 
-    def _run_main(self, suffix, source):
+    def _run_main(self, suffix: str, source: str) -> tuple[int, dict[str, Any]]:
         with tempfile.TemporaryDirectory() as tmp:
             impl = Path(tmp) / f"impl{suffix}"
             impl.write_text(source, encoding="utf-8")

--- a/tests/test_mutate_and_run.py
+++ b/tests/test_mutate_and_run.py
@@ -13,8 +13,12 @@ still be discovered.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -172,6 +176,45 @@ class RegressionGuardTest(unittest.TestCase):
         )
         bool_flips = [c for c in candidates if c["kind"] == "bool-flip"]
         self.assertEqual(bool_flips, [], "existing skip_type_alias_bools behavior must be unaffected by this change")
+
+
+class TsHeuristicsNoteTest(unittest.TestCase):
+    """main() must disclose the TS/TSX-only candidate exclusions in `notes`
+    (references/mutation-recipes.md promises these limitations are never
+    silently swallowed), so a SKIP with 0 candidates on a TS file is
+    explainable by the reader."""
+
+    def _run_main(self, suffix, source):
+        with tempfile.TemporaryDirectory() as tmp:
+            impl = Path(tmp) / f"impl{suffix}"
+            impl.write_text(source, encoding="utf-8")
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = MOD.main(["--impl-file", str(impl), "--test-cmd", "true"])
+            return rc, json.loads(out.getvalue())
+
+    def test_ts_file_discloses_heuristics_note(self):
+        # Generic decl line + candidate-free body -> the TS-only exclusions
+        # leave 0 candidates (SKIP); the note must say the exclusions were
+        # active so the SKIP is attributable.
+        rc, result = self._run_main(
+            ".ts", "function identity<T>(x: T): T {\n  return x;\n}\n"
+        )
+        self.assertEqual(rc, 0, "SKIP is not an error exit")
+        self.assertEqual(result["verdict"], "SKIP", "candidate-free TS file must SKIP")
+        self.assertTrue(
+            any("TS/TSX heuristics active" in n for n in result["notes"]),
+            f"expected a TS/TSX heuristics disclosure note, got: {result['notes']}",
+        )
+
+    def test_non_ts_file_has_no_ts_heuristics_note(self):
+        rc, result = self._run_main(".py", "def identity(x):\n    return x\n")
+        self.assertEqual(rc, 0, "SKIP is not an error exit")
+        self.assertEqual(result["verdict"], "SKIP", "candidate-free .py file must SKIP")
+        self.assertFalse(
+            any("TS/TSX heuristics active" in n for n in result["notes"]),
+            "the TS/TSX disclosure note must not appear for non-TS files",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mutate_and_run.py
+++ b/tests/test_mutate_and_run.py
@@ -1,0 +1,178 @@
+"""Tests for skills/test-mutation-gate/scripts/mutate_and_run.py (stdlib unittest, 依存なし).
+
+スクリプトはパッケージではないため importlib でファイルパスからロードする
+(tests/test_check_trigger_evals.py と同じ手法)。
+
+Covers the TS/TSX generic-declaration-line false-positive fix for
+comparison-flip candidates (issue #65 part 2): `function f<T>()`, `type
+Box<T> = ...`, `interface Foo<T>`, `class C<T>` must not be treated as `<`/`>`
+comparisons when `skip_generic_comparisons=True`, while real runtime
+comparisons (`if (a < b)`) and `==`/`!=`/`<=`/`>=` on the same line must
+still be discovered.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "test-mutation-gate"
+    / "scripts"
+    / "mutate_and_run.py"
+)
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mutate_and_run", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load_module()
+
+
+def discover(source: str, *, skip_generic_comparisons: bool = False, skip_type_alias_bools: bool = False):
+    """Run discover_candidates() over `source` as if it were a TS/TSX file
+    (matching the real call site's comment_prefixes/block_comment for
+    .ts/.tsx: comment_prefixes_for -> ("//",), block_comment_markers_for ->
+    ("/*", "*/")).
+    """
+    lines = source.splitlines(keepends=True)
+    comment_prefixes = MOD.comment_prefixes_for("dummy.ts")
+    block_comment = MOD.block_comment_markers_for("dummy.ts")
+    return MOD.discover_candidates(
+        lines,
+        comment_prefixes,
+        block_comment,
+        skip_type_alias_bools=skip_type_alias_bools,
+        skip_generic_comparisons=skip_generic_comparisons,
+    )
+
+
+def comparison_flip_candidates(candidates, before=None):
+    out = [c for c in candidates if c["kind"] == "comparison-flip"]
+    if before is not None:
+        out = [c for c in out if c["before"] == before]
+    return out
+
+
+def off_by_one_candidates(candidates):
+    return [c for c in candidates if c["kind"] == "off-by-one"]
+
+
+class GenericDeclarationLineSkipTest(unittest.TestCase):
+    """[new spec - must FAIL before the fix] Generic declaration lines must
+    not yield single-char '<'/'>' comparison-flip candidates when
+    skip_generic_comparisons=True."""
+
+    def test_function_generic_no_angle_bracket_candidates(self):
+        candidates = discover(
+            "function identity<T>(x: T): T {\n", skip_generic_comparisons=True
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [], "expected no </> comparison-flip candidates on a generic function decl")
+
+    def test_type_alias_generic_no_angle_bracket_candidates(self):
+        candidates = discover(
+            "export type Box<T> = { value: T };\n", skip_generic_comparisons=True
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [])
+
+    def test_interface_generic_no_angle_bracket_candidates(self):
+        candidates = discover("interface Repo<T> {\n", skip_generic_comparisons=True)
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [])
+
+    def test_default_export_class_generic_no_angle_bracket_candidates(self):
+        candidates = discover(
+            "export default class Container<T> {\n", skip_generic_comparisons=True
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [])
+
+    def test_declare_function_generic_no_angle_bracket_candidates(self):
+        candidates = discover(
+            "export declare function make<T>(x: T): T;\n", skip_generic_comparisons=True
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [])
+
+    def test_one_line_body_comparison_is_also_skipped_by_design(self):
+        # Characterization of a deliberate trade-off, not a desired ideal:
+        # the skip is line-level, so a real runtime comparison sharing the
+        # declaration's line (one-line body) is swallowed too. Span-limited
+        # skipping was rejected because it would re-admit annotation generics
+        # (`x: Array<number>`) - the original false positives. See
+        # discover_candidates' docstring and references/mutation-recipes.md;
+        # if this test breaks because the heuristic got *smarter* (e.g.
+        # AST-based), delete it along with those docs.
+        candidates = discover(
+            "function isPositive<T extends number>(x: T): boolean { return x > 0; }\n",
+            skip_generic_comparisons=True,
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(angle, [], "line-level skip swallows the one-line body comparison (documented trade-off)")
+        self.assertEqual(off_by_one_candidates(candidates), [])
+
+    def test_generic_type_alias_no_off_by_one_on_type_argument(self):
+        # `type Small<T> = LessThan<3>;` - the "3" sits immediately after the
+        # skipped "<" match; skipping the whole comparison-flip/off-by-one
+        # pair for that operator match is intended (type-position literal,
+        # not a runtime comparison boundary).
+        candidates = discover(
+            "type Small<T> = LessThan<3>;\n", skip_generic_comparisons=True
+        )
+        off_by_one = off_by_one_candidates(candidates)
+        self.assertEqual(
+            off_by_one,
+            [],
+            "expected no off-by-one candidate for the type-argument literal on a generic decl line",
+        )
+
+
+class RegressionGuardTest(unittest.TestCase):
+    """[regression guard - must PASS before AND after the fix]"""
+
+    def test_runtime_if_comparison_still_found_even_with_skip_enabled(self):
+        candidates = discover("if (a < b) {\n", skip_generic_comparisons=True)
+        angle = comparison_flip_candidates(candidates, "<")
+        self.assertEqual(len(angle), 1, "a real runtime '<' comparison must still be discovered")
+
+    def test_equality_on_generic_decl_line_still_found(self):
+        candidates = discover(
+            "function f<T>(flag = x == y) {\n", skip_generic_comparisons=True
+        )
+        eq = comparison_flip_candidates(candidates, "==")
+        self.assertEqual(len(eq), 1, "'==' on a generic decl line is not generic syntax and must still be a candidate")
+
+    def test_skip_disabled_still_finds_angle_brackets_on_generic_looking_line(self):
+        candidates = discover(
+            "function identity<T>(x: T): T {\n", skip_generic_comparisons=False
+        )
+        angle = comparison_flip_candidates(candidates, "<") + comparison_flip_candidates(candidates, ">")
+        self.assertEqual(
+            len(angle),
+            2,
+            "with skip_generic_comparisons=False (non-TS caller), generic-looking lines behave as before",
+        )
+
+    def test_skip_type_alias_bools_behavior_unchanged(self):
+        candidates = discover(
+            "type Flag = true | false;\n", skip_type_alias_bools=True
+        )
+        bool_flips = [c for c in candidates if c["kind"] == "bool-flip"]
+        self.assertEqual(bool_flips, [], "existing skip_type_alias_bools behavior must be unaffected by this change")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

issue #65 の 2 点を修正する。test-mutation-gate が実運用で「使われようとして環境差で死んでいる」ブロッカーの解消。

### 1. `${CLAUDE_SKILL_DIR}` ハードコードの除去 (SKILL.md)

**Root cause の確定**: issue 本文は「rulesync の codexcli 生成が pr-review-respond の参照を書き換えている」と推測していたが、実際には書き換えは rulesync ではなく **consumer 側 (dotfiles) の `scripts/patch-rulesync-skill-frontmatter.ts` にハードコードされた pr-review-respond 専用の文字列置換**だった (v0.6.0 ソースと dotfiles ミラーの行番号完全一致で確認)。つまり test-mutation-gate だけでなく、consumer hack に依存する構造自体が脆い。

**修正**: ソース側を target 非依存に。`<skill-dir>` を Step 2 冒頭で 1 回定義し (Claude Code では `${CLAUDE_SKILL_DIR}`、Codex/OpenCode では skill 読み込み時のベースディレクトリ)、`assertion_audit.py` / `mutate_and_run.py` / `emit_gate_event.sh` の全呼び出しを `<skill-dir>` 記法に置換。未定義変数の展開でパスが `/scripts/...` に解けて silent skip する経路を塞いだ。

frontmatter (`description`) は未変更のため trigger surface に変化はなく、trigger eval の再計測は不要 (CI ルールも frontmatter 変更時のみ発火)。

### 2. TS generics の comparison-flip 誤検知 (mutate_and_run.py)

TS/TSX の generic **宣言行** (`function f<T>()` / `type Box<T> = ...` / `interface Foo<T>` / `class C<T>`、export/default/declare/abstract/async 前置対応) では単文字 `<`/`>` を comparison-flip 候補から除外する (`TS_GENERIC_DECL_LINE_RE` + `skip_generic_comparisons`、既存の bool-flip guard `skip_type_alias_bools` と同型の行レベル heuristic)。`==`/`!=`/`<=`/`>=` は generic 構文として valid でないため除外しない。skip した演算子由来の off-by-one も一緒に skip (隣接整数は `LessThan<3>` のような型位置リテラルのため意図した挙動)。

**設計判断 (pre-PR review の Critical への回答)**: subagent レビューが「宣言と同一行の実比較 (`function isPositive<T>(x: T) { return x > 0; }` の one-line body) も巻き添えで skip される」と指摘。事実として正しいが、提案された span 限定 skip は**棄却**した — span 外に出るパラメータ/戻り値注釈の generics (`x: Array<number>`, `: Map<string, T>`、整形済みコードの宣言行で極めて一般的) が候補に再流入し、#65 の元バグが再発するため。巻き添えは保守側の false negative (候補 0 なら可視の `SKIP` になり silent pass ではない) で、標準整形では body は別行になる。この trade-off を docstring / mutation-recipes.md / characterization test に明文化した。

## 検証

- **TDD**: `tests/test_mutate_and_run.py` (11 cases) を修正前に作成し RED を確認 → 実装 → GREEN。full suite **47/47 PASS** (`uv run python3 -m unittest discover -s tests`)
- **e2e**: generic 宣言 4 種 + 実比較 2 箇所の TS fixture に対し `mutate_and_run.py --max-mutations 3` を実行、選定候補 3 件すべてが実比較行 (generic 行 0 件)、実行後のファイル復元も確認
- **gate dogfooding** (tdd Step 3.5): 静的監査 PASS (notes: test-only diff のため tautology skip = #37 の既知挙動)。mutation smoke は BLOCK — survived 3 件は全て module docstring 18 行目のテキスト変異 (line-based masking の既知限界による equivalent mutant) のため **waiver: docstring 内変異で挙動変化が原理的に不可能**。この事象は #36 (候補選定の diff 優先化) の実証例として同 issue にコメント予定
- **loop-ops 計測**: gate イベント送信・着弾確認済み (`metrics: test-mutation-gate pass`)
- `node scripts/rulesync-sync.mjs` の生成差分 (`.claude/` / `.agents/`) 同梱済み

## 関連

- Closes #65
- 同種の `${CLAUDE_SKILL_DIR}` 参照は pr-review-respond / pr-monitor / pr-conflict-resolver / issue-driven-development にも残存 (dotfiles の patch script が塞いでいるのは pr-review-respond の特定文字列のみ)。スコープ外のため follow-up issue を起票する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * TypeScript/TSXのジェネリック宣言中の`<`/`>`を比較演算子として誤検出しにくくし、スキップ方針と制限事項を明確化しました。
  * Mutation Gateの手順でスクリプト参照を`<skill-dir>`に統一し、環境変数非依存で実行されやすくしました。
* **ドキュメント**
  * MutationレシピおよびSKILL手順に、今回のスキップ挙動と注意点を追記しました。
* **テスト**
  * ジェネリック宣言の誤検出抑止、1行ボディの挙動、通常の比較検出維持の回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->