### PR TITLE
consumer pull 型リリース追随: 設計 + reusable workflow (段階移行 1/2)

### DIFF
--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -96,9 +96,16 @@ jobs:
             fi
           fi
           resume=false
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+          if gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" >/dev/null 2>&1; then
+            closed_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state closed --json number --jq length)
+            if [ "$closed_prs" != "0" ]; then
+              # 人間が close (または merge 後 branch 未削除) した PR を毎日作り直さない。
+              # 意図的に再実行したい場合は branch を削除する。
+              echo "branch $branch には closed/merged PR の履歴があるためスキップ (PR は再作成しない)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
             # 前回 run が「push 成功 → PR 作成前に失敗」した形跡。既存 branch から PR 作成のみ再試行する
-            echo "branch $branch は存在するが open PR が無いため、PR 作成のみ再実行する (自動復旧)"
+            echo "branch $branch は存在するが PR 履歴が無いため、PR 作成のみ再実行する (自動復旧)"
             resume=true
           fi
           {

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -35,6 +35,9 @@ on:
         description: 'PR 作成用 GitHub App の private key (PEM)'
         required: true
 
+# 注意: reusable workflow は caller の権限を下げることしかできない。caller 側 job にも
+#   permissions: { contents: read, pull-requests: read }
+# を明示すること (restricted default の repo では pull-requests が欠けて Gate が 403 になる)。
 permissions:
   contents: read
   pull-requests: read
@@ -177,7 +180,7 @@ jobs:
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
             echo
             echo "- pin / 取得内容を \`${TAG}\` に更新し、リポ既存スクリプトで設定を再生成"
-            if [ -n "$CURRENT" ]; then
+            if printf '%s' "$CURRENT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
               echo "- 差分: https://github.com/kanade0404/skills/compare/${CURRENT}...${TAG}"
               cur_major="${CURRENT#v}"; cur_major="${cur_major%%.*}"
               new_major="${TAG#v}"; new_major="${new_major%%.*}"
@@ -188,6 +191,9 @@ jobs:
               fi
             else
               echo "- リリースタグ: https://github.com/kanade0404/skills/releases/tag/${TAG}"
+              if [ -n "$CURRENT" ]; then
+                echo "- 注記: 現 pin を単一タグとして特定できなかったため compare リンクは省略 (current-ref-command の出力: \`${CURRENT}\`)。pin の食い違いは今回の update で修復されている。"
+              fi
             fi
             if [ -n "$PR_NOTES" ]; then
               echo

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -66,7 +66,7 @@ jobs:
           # tags API は semver 順を保証しないため全件を semver ソートして最大を採る。
           # プレリリース (v1.0.0-rc1 等ハイフン付き) は除外。
           tag=$(gh api --paginate repos/kanade0404/skills/tags --jq '.[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
           [ -n "$tag" ] || { echo "::error::kanade0404/skills に v* タグが見つからない"; exit 1; }
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -79,10 +79,6 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/skills-${TAG}"
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            echo "branch $branch が既に存在するためスキップ (冪等)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
           open_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq length)
           if [ "$open_prs" != "0" ]; then
             echo "branch $branch の open PR が既にあるためスキップ (冪等)"
@@ -96,25 +92,34 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
             fi
           fi
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+          resume=false
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            # 前回 run が「push 成功 → PR 作成前に失敗」した形跡。既存 branch から PR 作成のみ再試行する
+            echo "branch $branch は存在するが open PR が無いため、PR 作成のみ再実行する (自動復旧)"
+            resume=true
+          fi
+          {
+            echo "resume=$resume"
+            echo "current=$current"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup node
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: Enable corepack
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
         run: corepack enable
 
       - name: Setup bun
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'bun' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'bun' }}
         uses: oven-sh/setup-bun@v2
 
       - name: Run update command
-        if: ${{ steps.gate.outputs.skip == 'false' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' }}
         env:
           SKILLS_TAG: ${{ steps.latest.outputs.tag }}
           UPDATE_COMMAND: ${{ inputs.update-command }}
@@ -134,19 +139,22 @@ jobs:
           PR_NOTES: ${{ inputs.pr-notes }}
           APP_SLUG: ${{ steps.app.outputs.app-slug }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          RESUME: ${{ steps.gate.outputs.resume }}
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
-          fi
           branch="chore/skills-${TAG}"
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-          git switch -c "$branch"
-          # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
-          git add -A
-          git commit -m "chore: kanade0404/skills ${TAG} へ追随"
-          git push origin "$branch"
+          if [ "$RESUME" != "true" ]; then
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
+            fi
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+            git switch -c "$branch"
+            # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
+            git add -A
+            git commit -m "chore: kanade0404/skills ${TAG} へ追随"
+            git push origin "$branch"
+          fi
           {
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
             echo

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -37,6 +37,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pull:
@@ -76,7 +77,7 @@ jobs:
       - name: Gate (idempotency / no-op)
         id: gate
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.latest.outputs.tag }}
           CURRENT_REF_COMMAND: ${{ inputs.current-ref-command }}
         run: |
@@ -96,7 +97,14 @@ jobs:
             fi
           fi
           resume=false
-          if gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" >/dev/null 2>&1; then
+          branch_exists=false
+          if out=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" 2>&1); then
+            branch_exists=true
+          elif ! printf '%s' "$out" | grep -q 'HTTP 404'; then
+            echo "::error::branch 存在確認が 404 以外で失敗: ${out}"
+            exit 1
+          fi
+          if [ "$branch_exists" = "true" ]; then
             closed_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state closed --json number --jq length)
             if [ "$closed_prs" != "0" ]; then
               # 人間が close (または merge 後 branch 未削除) した PR を毎日作り直さない。

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -35,6 +35,9 @@ on:
         description: 'PR 作成用 GitHub App の private key (PEM)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   pull:
     runs-on: ubuntu-latest
@@ -48,14 +51,14 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.app-private-key }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          token: ${{ steps.app.outputs.token }}
+          persist-credentials: false
 
       - name: Resolve latest skills tag
         id: latest
@@ -106,7 +109,7 @@ jobs:
 
       - name: Setup node
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'lts/*'
 
@@ -116,7 +119,7 @@ jobs:
 
       - name: Setup bun
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'bun' }}
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Run update command
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' }}
@@ -153,7 +156,7 @@ jobs:
             # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
             git add -A
             git commit -m "chore: kanade0404/skills ${TAG} へ追随"
-            git push origin "$branch"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${branch}"
           fi
           {
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -86,7 +86,7 @@ jobs:
           fi
           current=""
           if [ -n "$CURRENT_REF_COMMAND" ]; then
-            current=$(bash -c "$CURRENT_REF_COMMAND")
+            current=$(bash -c "set -euo pipefail; $CURRENT_REF_COMMAND")
             if [ "$current" = "$TAG" ]; then
               echo "現 pin ($current) が最新タグと一致、スキップ (no-op)"
               echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -128,7 +128,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          bash -c "$UPDATE_COMMAND"
+          bash -c "set -euo pipefail; $UPDATE_COMMAND"
 
       - name: Create PR
         if: ${{ steps.gate.outputs.skip == 'false' }}

--- a/.github/workflows/consumer-pull.yml
+++ b/.github/workflows/consumer-pull.yml
@@ -1,0 +1,176 @@
+name: consumer pull
+
+# kanade0404/skills のリリースタグへ追随する PR を consumer リポに作る reusable workflow。
+# consumer は cron + workflow_dispatch の薄い wrapper から uses: で呼ぶ。
+# 設計: docs/adr/0001-consumer-pull-release-propagation.md /
+#       docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+on:
+  workflow_call:
+    inputs:
+      update-command:
+        description: 'SKILLS_TAG 環境変数を受けて pin 更新 + rulesync fetch/generate を行うコマンド'
+        required: true
+        type: string
+      current-ref-command:
+        description: '現在追随している skills の ref を stdout へ出すコマンド。空なら update 実行後の差分有無で no-op 判定'
+        required: false
+        type: string
+        default: ''
+      pr-notes:
+        description: 'PR body 末尾「要確認」節に載せる markdown (機械判断できない項目のチェックリスト)'
+        required: false
+        type: string
+        default: ''
+      runtime:
+        description: 'node (setup-node lts + corepack enable) / bun (setup-bun) / none'
+        required: false
+        type: string
+        default: 'node'
+      app-id:
+        description: 'PR 作成用 GitHub App の App ID'
+        required: true
+        type: string
+    secrets:
+      app-private-key:
+        description: 'PR 作成用 GitHub App の private key (PEM)'
+        required: true
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: skills-pull-${{ github.repository }}
+      cancel-in-progress: false
+    env:
+      NO_COLOR: '1'
+      CLICOLOR_FORCE: '0'
+    steps:
+      - name: Create GitHub App token
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Resolve latest skills tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # tags API は semver 順を保証しないため全件を semver ソートして最大を採る。
+          # プレリリース (v1.0.0-rc1 等ハイフン付き) は除外。
+          tag=$(gh api --paginate repos/kanade0404/skills/tags --jq '.[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          [ -n "$tag" ] || { echo "::error::kanade0404/skills に v* タグが見つからない"; exit 1; }
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Gate (idempotency / no-op)
+        id: gate
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          CURRENT_REF_COMMAND: ${{ inputs.current-ref-command }}
+        run: |
+          set -euo pipefail
+          branch="chore/skills-${TAG}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "branch $branch が既に存在するためスキップ (冪等)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          open_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq length)
+          if [ "$open_prs" != "0" ]; then
+            echo "branch $branch の open PR が既にあるためスキップ (冪等)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          current=""
+          if [ -n "$CURRENT_REF_COMMAND" ]; then
+            current=$(bash -c "$CURRENT_REF_COMMAND")
+            if [ "$current" = "$TAG" ]; then
+              echo "現 pin ($current) が最新タグと一致、スキップ (no-op)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+          fi
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Setup node
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Enable corepack
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        run: corepack enable
+
+      - name: Setup bun
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'bun' }}
+        uses: oven-sh/setup-bun@v2
+
+      - name: Run update command
+        if: ${{ steps.gate.outputs.skip == 'false' }}
+        env:
+          SKILLS_TAG: ${{ steps.latest.outputs.tag }}
+          UPDATE_COMMAND: ${{ inputs.update-command }}
+          # rulesync fetch 等が GitHub API を叩く。匿名クォータ (60req/h) 回避のため明示的に渡す
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bash -c "$UPDATE_COMMAND"
+
+      - name: Create PR
+        if: ${{ steps.gate.outputs.skip == 'false' }}
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          CURRENT: ${{ steps.gate.outputs.current }}
+          PR_NOTES: ${{ inputs.pr-notes }}
+          APP_SLUG: ${{ steps.app.outputs.app-slug }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
+          fi
+          branch="chore/skills-${TAG}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
+          git add -A
+          git commit -m "chore: kanade0404/skills ${TAG} へ追随"
+          git push origin "$branch"
+          {
+            echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
+            echo
+            echo "- pin / 取得内容を \`${TAG}\` に更新し、リポ既存スクリプトで設定を再生成"
+            if [ -n "$CURRENT" ]; then
+              echo "- 差分: https://github.com/kanade0404/skills/compare/${CURRENT}...${TAG}"
+              cur_major="${CURRENT#v}"; cur_major="${cur_major%%.*}"
+              new_major="${TAG#v}"; new_major="${new_major%%.*}"
+              if [ "$cur_major" != "$new_major" ]; then
+                echo
+                echo "> [!WARNING]"
+                echo "> **MAJOR bump** です。skill の削除 / リネーム / 挙動契約の変更を含みます。上の compare リンクで確認してから merge してください。"
+              fi
+            else
+              echo "- リリースタグ: https://github.com/kanade0404/skills/releases/tag/${TAG}"
+            fi
+            if [ -n "$PR_NOTES" ]; then
+              echo
+              echo "## 要確認 (機械判断できない項目)"
+              echo
+              echo "$PR_NOTES"
+            fi
+          } > pr-body.md
+          gh pr create -R "$GITHUB_REPOSITORY" \
+            --base "$BASE_BRANCH" --head "$branch" \
+            --title "chore: skills ${TAG} への追随" \
+            --body-file pr-body.md

--- a/docs/adr/0001-consumer-pull-release-propagation.md
+++ b/docs/adr/0001-consumer-pull-release-propagation.md
@@ -1,0 +1,32 @@
+# リリース追随を push 型 (Devin) から consumer pull 型に転換する
+
+Status: accepted (2026-07-19)
+
+skills のリリースタグを consumer リポ (agegis / dotfiles) に追随させる仕組みは、当初
+skills 側の tag push を契機に Devin API へ session を作成する push 型だった。Devin の
+クレジット枯渇で propagate が全停止する単一依存があり、かつ実作業 (pin 更新 →
+rulesync fetch/generate → PR 作成) はほぼ機械的で AI 実行の必然性が無かった。そこで
+各 consumer が日次 cron で新タグを検知して自リポに追随 PR を作る **pull 型**
+(AI を使わない決定的スクリプト。共通ロジックは skills が reusable workflow
+`consumer-pull.yml` として配布し consumer は薄い wrapper のみ) に置き換える。
+
+## Considered Options
+
+- **Devin 失敗時に Claude Code Action へ fallback** — 実行主体が変わるだけで
+  credit / rate limit 依存は残るため却下。
+- **issue 起票して人間へ fallback** — 作業が機械的で人手に落とす理由が無いため却下。
+- **Renovate custom manager + 再生成 workflow** — pin bump と rulesync 再生成の
+  2 段構えになり、hosted Renovate は任意コマンドを実行できないため却下。
+- **repository_dispatch (tag push 起点で consumer 実行)** — cross-repo token の管理が
+  残り純粋な pull にならず、日次で足りる遅延要件に対して過剰なため却下。
+
+## Consequences
+
+- Devin credit / 外部 AI サービスへの依存が構成から消える (fallback 問題自体が消滅)。
+- PR 作成には CI が起動するよう GitHub App (無期限) の installation token を使う。
+  fine-grained PAT の年次失効チョアを避けられる代わりに、App という管理対象が 1 つ増える。
+- 追随の最大遅延は cron 間隔 (日次)。急ぐ場合は consumer 側の workflow_dispatch。
+- 機械判断できない作業 (例: dotfiles のパッチスクリプト削除可否) は自動化から
+  外れ、PR body の「要人間確認」チェックリストとして人間に残る。
+
+詳細設計: [docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md](../superpowers/specs/2026-07-05-consumer-pull-propagation-design.md)

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -1,0 +1,474 @@
+# Consumer Pull 型リリース追随 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** skills のリリース追随を Devin push 型から consumer 側 cron の pull 型に置き換え、Devin credit 依存を構成から消す。
+
+**Architecture:** skills リポが reusable workflow `consumer-pull.yml` (workflow_call) を配布し、consumer (agegis / dotfiles) は cron + workflow_dispatch の薄い wrapper から `@master` 参照で呼ぶ。PR 作成は GitHub App の installation token (CI が起動するため)。検証完了後に skills 側の Devin 経路を削除する段階移行。
+
+**Tech Stack:** GitHub Actions (reusable workflow), `actions/create-github-app-token`, gh CLI, bash。consumer 側は agegis = pnpm / dotfiles = bun。
+
+**参照:** spec `docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md` / ADR `docs/adr/0001-consumer-pull-release-propagation.md`
+
+## Global Constraints
+
+- ブランチ名は `chore/skills-<tag>`、cron は `17 21 * * *` (UTC、正時回避)
+- reusable workflow の参照は `@master` 固定
+- 生成物 (`.rulesync/`, `.claude/` 等) は consumer リポ既存スクリプトで再生成し手編集しない
+- PR は作るだけで merge しない (人間が merge)
+- タグ解決は `v*` 全件の semver ソート最大値、プレリリース (`-` 付き) 除外、MAJOR も自動 PR + body 警告
+- CI 内で GitHub API を叩くツールには `GH_TOKEN` / `GITHUB_TOKEN` を明示的に渡す (匿名クォータ 60req/h で枯渇する。`.claude/rules/bash-and-api-discipline.md`)
+- 機械処理は `NO_COLOR=1` / `CLICOLOR_FORCE=0` を設定する (同 rule)
+- 段階移行: Task 1-2 (skills に追加) → Task 3-6 (App + consumer 検証) → Task 7 (Devin 経路削除)。順序を入れ替えない
+
+**現状スナップショット (2026-07-19 実機確認済み):**
+
+- skills 最新タグ: `v0.8.0`
+- agegis: `package.json` の `rulesync:fetch` = `rulesync fetch kanade0404/skills@v0.8.0 --features skills,rules` (最新に追随済み)。pnpm (`packageManager: pnpm@10.34.5`、`pnpm-lock.yaml`)。rulesync は devDependency
+- dotfiles: `rulesync.jsonc` と `rulesync-claude/rulesync.jsonc` の 2 箇所に `"ref": "v0.6.0"` (**2 マイナー遅れ**)。bun (`bun.lockb`)。両 JSONC ともコメント入りのため jq 不可、sed/grep で扱う。skills 以外の source (planetscale) に `ref` キーは無い (sed の一括置換が skills の ref だけに当たる前提)
+
+---
+
+### Task 1: reusable workflow `consumer-pull.yml` を skills リポに追加
+
+**Files:**
+- Create: `.github/workflows/consumer-pull.yml`
+
+**Interfaces:**
+- Consumes: なし (先行タスクなし)
+- Produces: workflow_call interface — inputs `update-command` (string, required) / `current-ref-command` (string, optional, default `''`) / `pr-notes` (string, optional, default `''`) / `runtime` (string, optional, default `node`) / `app-id` (string, required)、secrets `app-private-key` (required)。Task 4 / 5 の wrapper はこの名前に依存する
+
+- [ ] **Step 1: workflow ファイルを書く**
+
+`.github/workflows/consumer-pull.yml` を以下の内容で作成:
+
+```yaml
+name: consumer pull
+
+# kanade0404/skills のリリースタグへ追随する PR を consumer リポに作る reusable workflow。
+# consumer は cron + workflow_dispatch の薄い wrapper から uses: で呼ぶ。
+# 設計: docs/adr/0001-consumer-pull-release-propagation.md /
+#       docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+on:
+  workflow_call:
+    inputs:
+      update-command:
+        description: 'SKILLS_TAG 環境変数を受けて pin 更新 + rulesync fetch/generate を行うコマンド'
+        required: true
+        type: string
+      current-ref-command:
+        description: '現在追随している skills の ref を stdout へ出すコマンド。空なら update 実行後の差分有無で no-op 判定'
+        required: false
+        type: string
+        default: ''
+      pr-notes:
+        description: 'PR body 末尾「要確認」節に載せる markdown (機械判断できない項目のチェックリスト)'
+        required: false
+        type: string
+        default: ''
+      runtime:
+        description: 'node (setup-node lts + corepack enable) / bun (setup-bun) / none'
+        required: false
+        type: string
+        default: 'node'
+      app-id:
+        description: 'PR 作成用 GitHub App の App ID'
+        required: true
+        type: string
+    secrets:
+      app-private-key:
+        description: 'PR 作成用 GitHub App の private key (PEM)'
+        required: true
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: skills-pull-${{ github.repository }}
+      cancel-in-progress: false
+    env:
+      NO_COLOR: '1'
+      CLICOLOR_FORCE: '0'
+    steps:
+      - name: Create GitHub App token
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Resolve latest skills tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # tags API は semver 順を保証しないため全件を semver ソートして最大を採る。
+          # プレリリース (v1.0.0-rc1 等ハイフン付き) は除外。
+          tag=$(gh api --paginate repos/kanade0404/skills/tags --jq '.[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          [ -n "$tag" ] || { echo "::error::kanade0404/skills に v* タグが見つからない"; exit 1; }
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Gate (idempotency / no-op)
+        id: gate
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          CURRENT_REF_COMMAND: ${{ inputs.current-ref-command }}
+        run: |
+          set -euo pipefail
+          branch="chore/skills-${TAG}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "branch $branch が既に存在するためスキップ (冪等)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          open_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq length)
+          if [ "$open_prs" != "0" ]; then
+            echo "branch $branch の open PR が既にあるためスキップ (冪等)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          current=""
+          if [ -n "$CURRENT_REF_COMMAND" ]; then
+            current=$(bash -c "$CURRENT_REF_COMMAND")
+            if [ "$current" = "$TAG" ]; then
+              echo "現 pin ($current) が最新タグと一致、スキップ (no-op)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+          fi
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Setup node
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Enable corepack
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        run: corepack enable
+
+      - name: Setup bun
+        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'bun' }}
+        uses: oven-sh/setup-bun@v2
+
+      - name: Run update command
+        if: ${{ steps.gate.outputs.skip == 'false' }}
+        env:
+          SKILLS_TAG: ${{ steps.latest.outputs.tag }}
+          UPDATE_COMMAND: ${{ inputs.update-command }}
+          # rulesync fetch 等が GitHub API を叩く。匿名クォータ (60req/h) 回避のため明示的に渡す
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bash -c "$UPDATE_COMMAND"
+
+      - name: Create PR
+        if: ${{ steps.gate.outputs.skip == 'false' }}
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          CURRENT: ${{ steps.gate.outputs.current }}
+          PR_NOTES: ${{ inputs.pr-notes }}
+          APP_SLUG: ${{ steps.app.outputs.app-slug }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
+          fi
+          branch="chore/skills-${TAG}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
+          git add -A
+          git commit -m "chore: kanade0404/skills ${TAG} へ追随"
+          git push origin "$branch"
+          {
+            echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
+            echo
+            echo "- pin / 取得内容を \`${TAG}\` に更新し、リポ既存スクリプトで設定を再生成"
+            if [ -n "$CURRENT" ]; then
+              echo "- 差分: https://github.com/kanade0404/skills/compare/${CURRENT}...${TAG}"
+              cur_major="${CURRENT#v}"; cur_major="${cur_major%%.*}"
+              new_major="${TAG#v}"; new_major="${new_major%%.*}"
+              if [ "$cur_major" != "$new_major" ]; then
+                echo
+                echo "> [!WARNING]"
+                echo "> **MAJOR bump** です。skill の削除 / リネーム / 挙動契約の変更を含みます。上の compare リンクで確認してから merge してください。"
+              fi
+            else
+              echo "- リリースタグ: https://github.com/kanade0404/skills/releases/tag/${TAG}"
+            fi
+            if [ -n "$PR_NOTES" ]; then
+              echo
+              echo "## 要確認 (機械判断できない項目)"
+              echo
+              echo "$PR_NOTES"
+            fi
+          } > pr-body.md
+          gh pr create -R "$GITHUB_REPOSITORY" \
+            --base "$BASE_BRANCH" --head "$branch" \
+            --title "chore: skills ${TAG} への追随" \
+            --body-file pr-body.md
+```
+
+- [ ] **Step 2: actionlint で検証**
+
+Run: `command -v actionlint >/dev/null || brew install actionlint; actionlint .github/workflows/consumer-pull.yml`
+Expected: 出力なし (エラーゼロ)。shellcheck 由来の warning が出たら該当 shell を修正する
+
+- [ ] **Step 3: タグ解決ロジックを手元で単体実行して確認**
+
+Run:
+
+```bash
+gh api --paginate repos/kanade0404/skills/tags --jq '.[].name' \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1
+```
+
+Expected: `v0.8.0` (実行時点の最新 semver タグ)
+
+- [ ] **Step 4: Commit**
+
+commit skill の手順 (観測 → 明示パス staging → ファイル経由メッセージ) に従う:
+
+```bash
+git add .github/workflows/consumer-pull.yml
+git commit -F <scratch>/commit-msg.txt
+# メッセージ要約: "ci: consumer pull 型追随の reusable workflow を追加"
+```
+
+---
+
+### Task 2: skills 側 PR の作成 (spec / ADR / Task 1 を含む)
+
+**Files:**
+- なし (push と PR 作成のみ)
+
+**Interfaces:**
+- Consumes: Task 1 の commit 済みブランチ `docs/consumer-pull-propagation-design`
+- Produces: merge 可能な PR。merge 後に `consumer-pull.yml@master` が consumer から参照可能になる (Task 4 / 5 の前提)
+
+- [ ] **Step 1: ブランチを push して PR 作成**
+
+`shipping` skill (無ければ `gh pr create`) で PR を作る。body には spec / ADR / workflow 追加の 3 点と、「この PR では既存 `release-propagate.yml` を削除しない (段階移行、削除は検証後の別 PR)」を明記
+
+- [ ] **Step 2: CI green を確認し、レビュー対応後、人間の merge を待つ**
+
+`.claude/rules/pr-push-discipline.md` に従い CI 完了確認と監視 (`pr-monitor`) を設置。**merge されるまで Task 4 以降に進まない** (`@master` 参照が 404 になるため)
+
+---
+
+### Task 3: GitHub App の作成と consumer への配線 (人間の手作業)
+
+**Files:** なし (GitHub 設定のみ)
+
+**Interfaces:**
+- Produces: 両 consumer リポの variable `SKILLS_PULL_APP_ID` / secret `SKILLS_PULL_APP_PRIVATE_KEY`。Task 4 / 5 の wrapper はこの名前に依存する
+
+人間向けチェックリスト (エージェントは URL 提示と確認のみ、設定操作は人間):
+
+- [ ] https://github.com/settings/apps/new で App 作成。名前: `skills-release-pull`、description: 「kanade0404/skills のリリースタグに consumer リポを追随させる pull workflow の PR 作成用」、Webhook: 無効、権限: Repository permissions で Contents = Read and write / Pull requests = Read and write のみ
+- [ ] App ID を控える (App 設定画面の About に表示)
+- [ ] Private key を生成して PEM をダウンロード
+- [ ] App を自分のアカウントにインストールし、対象を **agegis と dotfiles の 2 リポに限定**
+- [ ] agegis / dotfiles 両方の Settings → Secrets and variables → Actions に登録:
+  - Variables: `SKILLS_PULL_APP_ID` = App ID
+  - Secrets: `SKILLS_PULL_APP_PRIVATE_KEY` = PEM 全文 (**改行を壊さずコピーする** — 貼り付けミスが典型的なハマりどころ)
+
+---
+
+### Task 4: agegis に wrapper `skills-pull.yml` を追加 (別リポ作業)
+
+**Files:**
+- Create (kanade0404/agegis): `.github/workflows/skills-pull.yml`
+
+**Interfaces:**
+- Consumes: Task 1 の workflow_call interface (`@master` 経由)、Task 3 の variable / secret
+- Produces: agegis の日次 pull workflow。Task 6 の「no-op ケース」検証対象
+
+- [ ] **Step 1: agegis に feature ブランチを切り、以下を作成**
+
+```yaml
+name: skills pull
+
+# kanade0404/skills の新リリースタグへ日次で追随する (pull 型)。
+# 実体は skills リポ配布の reusable workflow。
+# 設計: kanade0404/skills の docs/adr/0001-consumer-pull-release-propagation.md
+on:
+  schedule:
+    - cron: '17 21 * * *' # JST 朝 6:17。正時は GitHub cron が混雑するため回避
+  workflow_dispatch:
+
+jobs:
+  pull:
+    uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master
+    with:
+      app-id: ${{ vars.SKILLS_PULL_APP_ID }}
+      runtime: node
+      current-ref-command: |
+        grep -oE 'kanade0404/skills@v[0-9]+\.[0-9]+\.[0-9]+' package.json | head -n1 | cut -d@ -f2
+      update-command: |
+        sed -i -E 's|(kanade0404/skills@)v[0-9]+\.[0-9]+\.[0-9]+|\1'"$SKILLS_TAG"'|' package.json
+        pnpm install --frozen-lockfile
+        pnpm run rulesync:fetch
+        pnpm run rulesync:generate
+    secrets:
+      app-private-key: ${{ secrets.SKILLS_PULL_APP_PRIVATE_KEY }}
+```
+
+- [ ] **Step 2: actionlint で検証**
+
+Run: `actionlint .github/workflows/skills-pull.yml`
+Expected: 出力なし
+
+- [ ] **Step 3: commit し、PR 作成 → CI green → 人間が merge**
+
+commit 要約: `ci: skills リリースへの日次 pull 追随 workflow を追加`。agegis の CI 慣例に従う
+
+---
+
+### Task 5: dotfiles に wrapper `skills-pull.yml` を追加 (別リポ作業)
+
+**Files:**
+- Create (kanade0404/dotfiles): `.github/workflows/skills-pull.yml`
+
+**Interfaces:**
+- Consumes: Task 1 の workflow_call interface (`@master` 経由)、Task 3 の variable / secret
+- Produces: dotfiles の日次 pull workflow。Task 6 の「PR 作成 / 冪等ケース」検証対象 (現 pin v0.6.0 は 2 マイナー遅れのため初回実行で必ず PR が立つ)
+
+- [ ] **Step 1: dotfiles に feature ブランチを切り、以下を作成**
+
+```yaml
+name: skills pull
+
+# kanade0404/skills の新リリースタグへ日次で追随する (pull 型)。
+# 実体は skills リポ配布の reusable workflow。
+# 設計: kanade0404/skills の docs/adr/0001-consumer-pull-release-propagation.md
+#
+# pin は rulesync.jsonc / rulesync-claude/rulesync.jsonc の 2 箇所の "ref"。
+# 両ファイルとも JSONC (コメント入り) のため jq でなく sed / grep で扱う。
+# skills 以外の source (planetscale) に ref キーは無い前提 (追加時は sed の対象を見直す)。
+on:
+  schedule:
+    - cron: '17 21 * * *' # JST 朝 6:17。正時は GitHub cron が混雑するため回避
+  workflow_dispatch:
+
+jobs:
+  pull:
+    uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master
+    with:
+      app-id: ${{ vars.SKILLS_PULL_APP_ID }}
+      runtime: bun
+      current-ref-command: |
+        grep -oE '"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"' rulesync.jsonc | head -n1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+'
+      update-command: |
+        sed -i -E 's|"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"|"ref": "'"$SKILLS_TAG"'"|' rulesync.jsonc rulesync-claude/rulesync.jsonc
+        bun install --frozen-lockfile
+        bun run rulesync:skills:update
+        bun run rulesync:skills:claude:update
+      pr-notes: |
+        - [ ] `scripts/patch-rulesync-skill-frontmatter.ts` の削除可否を確認する。skills v0.5.0 以降は canonical 側が `claudecode:` target-section 形式になり generate が allowed-tools を保持するため、このパッチは不要になっている可能性が高い。生成差分で確認し、不要ならパッチと package.json の該当ステップを削除する commit をこの PR に追加する (確認できなければ削除せず、調査結果をコメントに残す)
+    secrets:
+      app-private-key: ${{ secrets.SKILLS_PULL_APP_PRIVATE_KEY }}
+```
+
+- [ ] **Step 2: actionlint で検証**
+
+Run: `actionlint .github/workflows/skills-pull.yml`
+Expected: 出力なし
+
+- [ ] **Step 3: commit し、PR 作成 → CI green → 人間が merge**
+
+commit 要約: `ci: skills リリースへの日次 pull 追随 workflow を追加`。dotfiles の CI 慣例に従う
+
+---
+
+### Task 6: エンドツーエンド検証 (3 ケース)
+
+**Files:** なし (workflow_dispatch 実行と観察のみ)
+
+**Interfaces:**
+- Consumes: Task 4 / 5 の merge 済み wrapper、Task 3 の App 配線
+- Produces: 検証結果の記録。**Task 7 のゲート** — 3 ケース全部が期待どおりでない限り Task 7 に進まない
+
+- [ ] **Step 1: no-op ケース (agegis)**
+
+Run: `gh workflow run skills-pull.yml -R kanade0404/agegis` → `gh run watch -R kanade0404/agegis` で完了確認
+Expected: run 成功。Gate step のログに「現 pin (v0.8.0) が最新タグと一致、スキップ (no-op)」(agegis は既に最新のため)。PR は作られない
+
+- [ ] **Step 2: PR 作成ケース (dotfiles)**
+
+Run: `gh workflow run skills-pull.yml -R kanade0404/dotfiles` → `gh run watch -R kanade0404/dotfiles`
+Expected: run 成功。`chore/skills-v0.8.0` ブランチで PR が 1 件でき、body に compare リンク (`compare/v0.6.0...v0.8.0`) とパッチ削除可否のチェックリストがある。author は `skills-release-pull[bot]`。**PR 上で dotfiles の CI が起動している** (App token の狙いどおり)
+
+- [ ] **Step 3: 冪等ケース (dotfiles 再実行)**
+
+Run: 再度 `gh workflow run skills-pull.yml -R kanade0404/dotfiles`
+Expected: run 成功。Gate step のログに「open PR が既にあるためスキップ (冪等)」。PR は増えない
+
+- [ ] **Step 4: dotfiles の追随 PR 自体をレビューして merge する (人間)**
+
+パッチスクリプト削除可否のチェックリストを処理し、CI green を確認して merge。merge 後にもう一度 dispatch し、no-op になることを確認 (agegis と同じ経路の再確認)
+
+---
+
+### Task 7: skills 側の Devin 経路削除と文書更新 (Task 6 完了がゲート)
+
+**Files:**
+- Delete: `.github/workflows/release-propagate.yml`
+- Delete: `.github/devin/consumer-update.md`
+- Modify: `RELEASING.md` (手順 4)
+
+**Interfaces:**
+- Consumes: Task 6 の検証完了
+- Produces: Devin 依存ゼロの skills リポ
+
+- [ ] **Step 1: skills リポで新ブランチを切り、2 ファイルを削除**
+
+```bash
+git switch -c ci/remove-devin-propagate master
+git rm .github/workflows/release-propagate.yml .github/devin/consumer-update.md
+```
+
+- [ ] **Step 2: RELEASING.md の手順 4 を置換**
+
+現行:
+
+```markdown
+4. consumer に告知（pin 先を `@vX.Y.Z` に上げてもらう）。
+```
+
+置換後:
+
+```markdown
+4. 追随は consumer 側 (agegis / dotfiles) の `skills-pull.yml` (日次 cron) が新タグを
+   検知して追随 PR を自動作成する。急ぐ場合は各 consumer リポで同 workflow を
+   workflow_dispatch する。仕組みは
+   [ADR 0001](docs/adr/0001-consumer-pull-release-propagation.md) を参照。
+```
+
+- [ ] **Step 3: commit・PR 作成・CI green・merge**
+
+commit 要約: `ci: Devin push 型 propagate を削除 (pull 型へ移行完了)`。body に ADR 0001 と検証結果 (Task 6) をリンク
+
+- [ ] **Step 4: 残骸の掃除 (人間)**
+
+skills リポの Settings → Secrets から `DEVIN_API_KEY` / `DEVIN_ORG_ID` を削除
+
+---
+
+## Self-Review 済み確認事項
+
+- spec の全要件 (タグ解決 / 冪等 / no-op 2 方式 / GitHub App / cron / MAJOR 警告 / pr-notes / 段階移行 / RELEASING.md / secrets 掃除) に対応するタスクがある
+- Task 4 / 5 の `current-ref-command` / `update-command` は 2026-07-19 時点の実リポ内容 (agegis package.json / dotfiles rulesync.jsonc ×2) を gh api で確認して書いた。実行時に差異があれば実物に合わせて調整し、spec との乖離は PR に書く
+- 検証 3 ケース (no-op / PR 作成 / 冪等) は現状の pin 状態 (agegis=v0.8.0=最新, dotfiles=v0.6.0=遅れ) をそのまま使い、擬似状態を作らない

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -131,7 +131,7 @@ jobs:
           fi
           current=""
           if [ -n "$CURRENT_REF_COMMAND" ]; then
-            current=$(bash -c "$CURRENT_REF_COMMAND")
+            current=$(bash -c "set -euo pipefail; $CURRENT_REF_COMMAND")
             if [ "$current" = "$TAG" ]; then
               echo "現 pin ($current) が最新タグと一致、スキップ (no-op)"
               echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -173,7 +173,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          bash -c "$UPDATE_COMMAND"
+          bash -c "set -euo pipefail; $UPDATE_COMMAND"
 
       - name: Create PR
         if: ${{ steps.gate.outputs.skip == 'false' }}

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -80,6 +80,9 @@ on:
         description: 'PR 作成用 GitHub App の private key (PEM)'
         required: true
 
+# 注意: reusable workflow は caller の権限を下げることしかできない。caller 側 job にも
+#   permissions: { contents: read, pull-requests: read }
+# を明示すること (restricted default の repo では pull-requests が欠けて Gate が 403 になる)。
 permissions:
   contents: read
   pull-requests: read
@@ -222,7 +225,7 @@ jobs:
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
             echo
             echo "- pin / 取得内容を \`${TAG}\` に更新し、リポ既存スクリプトで設定を再生成"
-            if [ -n "$CURRENT" ]; then
+            if printf '%s' "$CURRENT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
               echo "- 差分: https://github.com/kanade0404/skills/compare/${CURRENT}...${TAG}"
               cur_major="${CURRENT#v}"; cur_major="${cur_major%%.*}"
               new_major="${TAG#v}"; new_major="${new_major%%.*}"
@@ -233,6 +236,9 @@ jobs:
               fi
             else
               echo "- リリースタグ: https://github.com/kanade0404/skills/releases/tag/${TAG}"
+              if [ -n "$CURRENT" ]; then
+                echo "- 注記: 現 pin を単一タグとして特定できなかったため compare リンクは省略 (current-ref-command の出力: \`${CURRENT}\`)。pin の食い違いは今回の update で修復されている。"
+              fi
             fi
             if [ -n "$PR_NOTES" ]; then
               echo
@@ -337,6 +343,9 @@ on:
 
 jobs:
   pull:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master
     with:
       app-id: ${{ vars.SKILLS_PULL_APP_ID }}
@@ -392,6 +401,9 @@ on:
 
 jobs:
   pull:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master
     with:
       app-id: ${{ vars.SKILLS_PULL_APP_ID }}

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -82,6 +82,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pull:
@@ -121,7 +122,7 @@ jobs:
       - name: Gate (idempotency / no-op)
         id: gate
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.latest.outputs.tag }}
           CURRENT_REF_COMMAND: ${{ inputs.current-ref-command }}
         run: |
@@ -141,7 +142,14 @@ jobs:
             fi
           fi
           resume=false
-          if gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" >/dev/null 2>&1; then
+          branch_exists=false
+          if out=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" 2>&1); then
+            branch_exists=true
+          elif ! printf '%s' "$out" | grep -q 'HTTP 404'; then
+            echo "::error::branch 存在確認が 404 以外で失敗: ${out}"
+            exit 1
+          fi
+          if [ "$branch_exists" = "true" ]; then
             closed_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state closed --json number --jq length)
             if [ "$closed_prs" != "0" ]; then
               # 人間が close (または merge 後 branch 未削除) した PR を毎日作り直さない。
@@ -376,6 +384,7 @@ name: skills pull
 # pin は rulesync.jsonc / rulesync-claude/rulesync.jsonc の 2 箇所の "ref"。
 # 両ファイルとも JSONC (コメント入り) のため jq でなく sed / grep で扱う。
 # skills 以外の source (planetscale) に ref キーは無い前提 (追加時は sed の対象を見直す)。
+# ref は 2 ファイルの一致を確認し、食い違いは update 実行で自己修復する。
 on:
   schedule:
     - cron: '17 21 * * *' # JST 朝 6:17。正時は GitHub cron が混雑するため回避
@@ -388,7 +397,9 @@ jobs:
       app-id: ${{ vars.SKILLS_PULL_APP_ID }}
       runtime: bun
       current-ref-command: |
-        grep -oE '"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"' rulesync.jsonc | head -n1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+'
+        r1=$(grep -oE '"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"' rulesync.jsonc | head -n1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+        r2=$(grep -oE '"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"' rulesync-claude/rulesync.jsonc | head -n1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+        if [ "$r1" = "$r2" ]; then echo "$r1"; else echo "refs-diverged"; fi
       update-command: |
         sed -i -E 's|"ref": *"v[0-9]+\.[0-9]+\.[0-9]+"|"ref": "'"$SKILLS_TAG"'"|' rulesync.jsonc rulesync-claude/rulesync.jsonc
         bun install --frozen-lockfile
@@ -421,12 +432,12 @@ commit 要約: `ci: skills リリースへの日次 pull 追随 workflow を追�
 
 - [ ] **Step 1: no-op ケース (agegis)**
 
-Run: `gh workflow run skills-pull.yml -R kanade0404/agegis` → `gh run watch -R kanade0404/agegis` で完了確認
+Run: `gh workflow run skills-pull.yml -R kanade0404/agegis` → `gh run watch --exit-status -R kanade0404/agegis` で完了確認
 Expected: run 成功。Gate step のログに「現 pin (v0.8.0) が最新タグと一致、スキップ (no-op)」(agegis は既に最新のため)。PR は作られない
 
 - [ ] **Step 2: PR 作成ケース (dotfiles)**
 
-Run: `gh workflow run skills-pull.yml -R kanade0404/dotfiles` → `gh run watch -R kanade0404/dotfiles`
+Run: `gh workflow run skills-pull.yml -R kanade0404/dotfiles` → `gh run watch --exit-status -R kanade0404/dotfiles`
 Expected: run 成功。`chore/skills-v0.8.0` ブランチで PR が 1 件でき、body に compare リンク (`compare/v0.6.0...v0.8.0`) とパッチ削除可否のチェックリストがある。author は `skills-release-pull[bot]`。**PR 上で dotfiles の CI が起動している** (App token の狙いどおり)
 
 - [ ] **Step 3: 冪等ケース (dotfiles 再実行)**

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -111,7 +111,7 @@ jobs:
           # tags API は semver 順を保証しないため全件を semver ソートして最大を採る。
           # プレリリース (v1.0.0-rc1 等ハイフン付き) は除外。
           tag=$(gh api --paginate repos/kanade0404/skills/tags --jq '.[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
           [ -n "$tag" ] || { echo "::error::kanade0404/skills に v* タグが見つからない"; exit 1; }
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -124,10 +124,6 @@ jobs:
         run: |
           set -euo pipefail
           branch="chore/skills-${TAG}"
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            echo "branch $branch が既に存在するためスキップ (冪等)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
           open_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq length)
           if [ "$open_prs" != "0" ]; then
             echo "branch $branch の open PR が既にあるためスキップ (冪等)"
@@ -141,25 +137,34 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
             fi
           fi
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+          resume=false
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            # 前回 run が「push 成功 → PR 作成前に失敗」した形跡。既存 branch から PR 作成のみ再試行する
+            echo "branch $branch は存在するが open PR が無いため、PR 作成のみ再実行する (自動復旧)"
+            resume=true
+          fi
+          {
+            echo "resume=$resume"
+            echo "current=$current"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup node
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: Enable corepack
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'node' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
         run: corepack enable
 
       - name: Setup bun
-        if: ${{ steps.gate.outputs.skip == 'false' && inputs.runtime == 'bun' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'bun' }}
         uses: oven-sh/setup-bun@v2
 
       - name: Run update command
-        if: ${{ steps.gate.outputs.skip == 'false' }}
+        if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' }}
         env:
           SKILLS_TAG: ${{ steps.latest.outputs.tag }}
           UPDATE_COMMAND: ${{ inputs.update-command }}
@@ -179,19 +184,22 @@ jobs:
           PR_NOTES: ${{ inputs.pr-notes }}
           APP_SLUG: ${{ steps.app.outputs.app-slug }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          RESUME: ${{ steps.gate.outputs.resume }}
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
-          fi
           branch="chore/skills-${TAG}"
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-          git switch -c "$branch"
-          # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
-          git add -A
-          git commit -m "chore: kanade0404/skills ${TAG} へ追随"
-          git push origin "$branch"
+          if [ "$RESUME" != "true" ]; then
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "update 後の差分が無いため PR を作らない (no-op)"; exit 0
+            fi
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+            git switch -c "$branch"
+            # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
+            git add -A
+            git commit -m "chore: kanade0404/skills ${TAG} へ追随"
+            git push origin "$branch"
+          fi
           {
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"
             echo

--- a/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
+++ b/docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md
@@ -80,6 +80,9 @@ on:
         description: 'PR 作成用 GitHub App の private key (PEM)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   pull:
     runs-on: ubuntu-latest
@@ -93,14 +96,14 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.app-private-key }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          token: ${{ steps.app.outputs.token }}
+          persist-credentials: false
 
       - name: Resolve latest skills tag
         id: latest
@@ -138,9 +141,16 @@ jobs:
             fi
           fi
           resume=false
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+          if gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" >/dev/null 2>&1; then
+            closed_prs=$(gh pr list -R "$GITHUB_REPOSITORY" --head "$branch" --state closed --json number --jq length)
+            if [ "$closed_prs" != "0" ]; then
+              # 人間が close (または merge 後 branch 未削除) した PR を毎日作り直さない。
+              # 意図的に再実行したい場合は branch を削除する。
+              echo "branch $branch には closed/merged PR の履歴があるためスキップ (PR は再作成しない)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
             # 前回 run が「push 成功 → PR 作成前に失敗」した形跡。既存 branch から PR 作成のみ再試行する
-            echo "branch $branch は存在するが open PR が無いため、PR 作成のみ再実行する (自動復旧)"
+            echo "branch $branch は存在するが PR 履歴が無いため、PR 作成のみ再実行する (自動復旧)"
             resume=true
           fi
           {
@@ -151,7 +161,7 @@ jobs:
 
       - name: Setup node
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'node' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 'lts/*'
 
@@ -161,7 +171,7 @@ jobs:
 
       - name: Setup bun
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' && inputs.runtime == 'bun' }}
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Run update command
         if: ${{ steps.gate.outputs.skip == 'false' && steps.gate.outputs.resume == 'false' }}
@@ -198,7 +208,7 @@ jobs:
             # 生成物のパスは consumer ごとに異なるため全差分を commit 対象にする
             git add -A
             git commit -m "chore: kanade0404/skills ${TAG} へ追随"
-            git push origin "$branch"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${branch}"
           fi
           {
             echo "kanade0404/skills のリリース **${TAG}** への追随 (pull workflow による自動生成 PR)。"

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -70,9 +70,10 @@ kanade0404/agegis          kanade0404/dotfiles
      現 consumer では使わないが、pin を持たない将来の consumer 向けの安全弁として残す
      (update が実質空振りだった場合に空 PR を作らない防御を兼ねる)。
 4. **resume 判定**: open PR は無いが同ブランチ `chore/skills-<tag>` が既に存在する場合、
-   「前回 run が push 成功 → PR 作成前に失敗」した形跡とみなし resume モードに入る。
-   resume 中は更新実行 (次項) を丸ごとスキップし、既存ブランチから PR 作成のみを再実行する
-   (自動復旧)。
+   まず closed/merged PR の履歴を確認し、あればスキップする (却下された PR を再作成しない。
+   再実行したい場合は branch を削除する)。履歴が無ければ「前回 run が push 成功 → PR 作成前
+   に失敗」した形跡とみなし resume モードに入る (更新実行をスキップし、既存ブランチから
+   PR 作成のみを再実行する自動復旧)。
 5. **更新実行**: resume でない場合のみ、input の `update-command` を環境変数
    `SKILLS_TAG=<新タグ>` 付きで実行。pin 書き換え・rulesync fetch・generate は全て
    consumer 側リポ既存のスクリプトに委譲し、生成物を手編集しない
@@ -148,7 +149,8 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
   → 最新タグ解決 (skills は public、読み取りに認証不要)
   → chore/skills-<tag> ブランチの open PR 既存 → 終了 (冪等)
   → 現 pin と比較 (current-ref-command がある場合) ─ 同じ → 終了 (no-op)
-  → chore/skills-<tag> ブランチが open PR 無しで既存 → resume (PR 作成のみ再実行、自動復旧)
+  → chore/skills-<tag> ブランチが存在し closed/merged PR 履歴あり → 終了 (再作成しない)
+  → 同ブランチが存在し PR 履歴なし → resume (PR 作成のみ再実行、自動復旧)
   → (resume でなければ) update-command 実行 (pin 更新 + rulesync fetch + generate)
   → git diff 空 (current-ref-command 無しの場合の no-op) → 終了
   → PR 作成 (GitHub App installation token) → consumer CI 起動 → 人間が review / merge
@@ -164,7 +166,8 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
 - タグが日次間隔より速く連続した場合: 古いタグの open PR が残っていても、新タグは
   別ブランチ名なので新 PR が立つ。古い PR の close は人間の判断に委ねる。
 - 「push 成功 → PR 作成前に失敗」の部分失敗は、次回 run が既存 branch から PR 作成のみを
-  再実行して自動復旧する。
+  再実行して自動復旧する。自動復旧は「PR 履歴の無い branch」に限る。人間が PR を close した
+  branch は再作成せずスキップし、意図的な再実行は branch 削除で行う。
 
 ## テスト / 検証
 

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -1,0 +1,149 @@
+# consumer pull 型リリース追随 (Devin push 廃止) — 設計
+
+日付: 2026-07-05
+状態: 承認待ち
+
+## 背景 / 問題
+
+現行の release propagate は push 型: skills のタグ push を契機に
+`.github/workflows/release-propagate.yml` が Devin API (v3) に session を作成し、
+consumer リポ (agegis / dotfiles) への追随 PR 作成を Devin に委任している
+(playbook: `.github/devin/consumer-update.md`)。
+
+この構成は **Devin のクレジットが切れると propagate が全停止する** 単一依存を持つ。
+また実作業の大半 (pin 書き換え → rulesync fetch/generate → PR 作成) は機械的で、
+AI エージェントを常用する必然性がない。
+
+## 決定
+
+push 型 (skills → Devin → consumer) を廃止し、**pull 型** に置き換える:
+各 consumer リポが自分の cron workflow で skills の新タグを検知し、
+自リポに追随 PR を作る。実行は AI を使わない決定的スクリプト。
+
+これにより Devin credit 依存は「fallback が要る問題」ではなく「構成から消える問題」になる。
+
+### 検討した代替案と却下理由
+
+| 案 | 却下理由 |
+|---|---|
+| Devin 失敗時に Claude Code Action へ自動 fallback | 実行主体が変わるだけで credit/rate limit 依存は残る。コスト増。 |
+| Devin 失敗時に issue 起票して人間へ | 自動化が途切れる。作業自体は機械的なので人手に落とす理由がない。 |
+| Renovate custom manager + 再生成 workflow | bump と rulesync 再生成が 2 段構えになり複雑。hosted Renovate は任意コマンドを実行できない。 |
+| repository_dispatch (skills → consumer) | 実行は consumer 側になるが cross-repo PAT の管理が残り、純粋な pull でない。遅延要件 (日次で十分) に対して過剰。 |
+| workflow を各 consumer にコピー配置 | 2 リポで重複し修正が 2 度手間。skills は rulesync 配布元でもあり、共通 workflow の配布元を兼ねるのが自然。 |
+
+## アーキテクチャ
+
+```
+kanade0404/skills
+├── .github/workflows/consumer-pull.yml   # 新設: reusable workflow (workflow_call)
+├── .github/workflows/release-propagate.yml   # 削除
+└── .github/devin/consumer-update.md           # 削除
+
+kanade0404/agegis          kanade0404/dotfiles
+└── .github/workflows/      └── .github/workflows/
+    skills-pull.yml             skills-pull.yml
+    (cron + dispatch の薄い wrapper。uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master)
+```
+
+## コンポーネント
+
+### 1. reusable workflow `consumer-pull.yml` (skills リポ、新設)
+
+`on: workflow_call`。1 job で以下を順に行う:
+
+1. **最新タグ解決**: `gh api repos/kanade0404/skills/tags` から `v*` (semver) の最新を選ぶ。
+   GitHub Release の作成には依存しない (このリポのリリースは git タグのみ)。
+2. **冪等チェック**: ブランチ `chore/skills-<tag>` が既に存在する、または同ブランチの
+   open PR がある場合はスキップ終了 (多重 PR 防止)。
+3. **no-op 判定 (2 方式)**:
+   - `current-ref-command` (optional input) がある場合: それを実行して現 pin を stdout で
+     受け取り、最新タグと一致すれば成功終了 (agegis はこちら。pin が `package.json` に
+     明示されている)。
+   - 無い場合: 判定を後段に回し、update 実行後に `git diff` が空なら成功終了
+     (dotfiles はこちら。declarative source 方式で「現在の pin」を持たないため、
+     実際に更新を走らせて差分の有無で判定する)。
+4. **更新実行**: input の `update-command` を環境変数 `SKILLS_TAG=<新タグ>` 付きで実行。
+   pin 書き換え・rulesync fetch・generate は全て consumer 側リポ既存のスクリプトに委譲し、
+   生成物を手編集しない (現 playbook の不変条件を引き継ぐ)。
+6. **PR 作成**: `chore/skills-<tag>` ブランチに commit し、PR を 1 件作成。body には
+   - 何を・なぜ (新タグへの追随)・再生成したもの
+   - diff リンク `https://github.com/kanade0404/skills/compare/<旧>...<新>`
+   - input `pr-notes` の内容 (「要人間確認」チェックリスト。機械判断できない項目を残す)
+
+**interface (inputs / secrets):**
+
+| 名前 | 種別 | 内容 |
+|---|---|---|
+| `current-ref-command` | input (optional) | 現在の pin を stdout に出すシェルコマンド。無指定時は update 後の差分有無で no-op 判定 |
+| `update-command` | input (required) | `SKILLS_TAG` を受けて pin 更新 + fetch + generate を行うコマンド |
+| `pr-notes` | input (optional) | PR body に追記する markdown (人間確認チェックリスト等) |
+| `setup-node` | input (optional, default true) | `actions/setup-node` を実行するか (両 consumer とも npm script 前提) |
+| `pr-token` | secret (required) | PR 作成・push 用の repo 限定 fine-grained PAT |
+
+**PAT を要求する理由**: `GITHUB_TOKEN` で作成した PR には CI が自動起動しない
+(GitHub の再帰防止仕様)。consumer 側は「CI green を確認して merge」の運用なので、
+CI が走るトークンで PR を作る必要がある。PAT は各 consumer リポに repo 限定・
+contents/pull-requests write の最小権限で置く。
+
+### 2. consumer 側 wrapper `skills-pull.yml` (agegis / dotfiles、各 1 本)
+
+- trigger: `schedule` (日次 cron) + `workflow_dispatch` (リリース直後に即時反映したい時)
+- 本体は `uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master` に
+  自リポ固有の inputs を渡すだけ。
+  - agegis: pin は `package.json` の `rulesync:fetch` script 内 `kanade0404/skills@<ref>`。
+    update は fetch script の ref 書き換え + `rulesync:fetch` + generate 系 script。
+  - dotfiles: `rulesync.jsonc` の declarative source 方式。
+    `rulesync:skills:update` / `rulesync:skills:claude:update` を実行。
+    `pr-notes` に `scripts/patch-rulesync-skill-frontmatter.ts` の削除可否確認
+    (skills v0.5.0 以降不要の可能性) をチェックリストとして渡す。
+- reusable workflow の参照は `@master` 固定。skills 自体のタグは skill 配布の
+  バージョニングであり、workflow の互換管理には使わない (自己所有リポ間なので許容)。
+
+### 3. skills 側の削除・文書更新
+
+- `.github/workflows/release-propagate.yml` を削除。
+- `.github/devin/consumer-update.md` を削除。playbook の内容は
+  reusable workflow のロジック + 各 consumer の `pr-notes` に移す。
+- `RELEASING.md` の手順 4「consumer に告知」を
+  「consumer 側 cron が日次で追随 PR を作る。急ぐ場合は consumer 側で
+  `skills-pull.yml` を workflow_dispatch する」に更新。
+- secrets `DEVIN_API_KEY` / `DEVIN_ORG_ID` は不要になる (削除は人間が GitHub 設定で行う)。
+
+## データフロー
+
+```
+(日次 cron / 手動 dispatch @ consumer)
+  → 最新タグ解決 (skills は public、読み取りに認証不要)
+  → chore/skills-<tag> ブランチ / open PR 既存 → 終了 (冪等)
+  → 現 pin と比較 (current-ref-command がある場合) ─ 同じ → 終了 (no-op)
+  → update-command 実行 (pin 更新 + rulesync fetch + generate)
+  → git diff 空 (current-ref-command 無しの場合の no-op) → 終了
+  → PR 作成 (PAT) → consumer CI 起動 → 人間が review / merge
+```
+
+## エラーハンドリング
+
+- workflow 失敗はそのまま red run として consumer リポに残る (GitHub の通知に乗る)。
+  追加の通知チャネルは作らない (YAGNI)。
+- update-command が非ゼロ終了 → PR を作らず fail。翌日の cron が再試行する。
+- 生成差分が空 (pin だけ変わって生成物が同一) の場合も pin 変更自体が commit 対象なので
+  PR は作る。
+- タグが日次間隔より速く連続した場合: 古いタグの open PR が残っていても、新タグは
+  別ブランチ名なので新 PR が立つ。古い PR の close は人間の判断に委ねる。
+
+## テスト / 検証
+
+- ドライラン: consumer 側で `workflow_dispatch` を実行し、(a) no-op 時に PR が
+  立たないこと、(b) pin が古い状態で正しい PR が 1 件立つこと、(c) 再実行で
+  重複 PR が立たないこと (冪等) を確認する。
+- skills 側は workflow lint (actionlint 等、手元実行) のみ。build/test 基盤は無い。
+
+## スコープ外
+
+- consumer リポ (agegis / dotfiles) への wrapper 追加と PAT 設定は各リポでの作業。
+  本リポの変更とは別 PR (実装計画には含めるが、この repo の PR には入らない)。
+- dotfiles のパッチスクリプト削除そのものは、初回 pull PR のチェックリストで
+  人間が判断する一回性のタスク。
+- 即時性 (タグ push 後数分での追随) が将来必要になったら repository_dispatch の
+  追加を検討する。今回は日次 + 手動 dispatch で足りる。

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -108,10 +108,11 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
 - PR author は `<app名>[bot]` になり、自動化 PR と一目で区別できる。
 - App の description に用途 (skills release pull 追随) を明記する
   (将来の「この App 何だっけ」防止)。
-- workflow 本体は `permissions: contents: read` を明示し、外部 action は full commit SHA に
-  pin する。checkout は `persist-credentials: false` とし、App token は push / PR 作成の
-  瞬間のみ供給する (untrusted な依存インストールや update-command 実行中に token を
-  git config に残さない)。
+- workflow 本体は `permissions: contents: read + pull-requests: read` を明示し、外部 action は
+  full commit SHA に pin する。checkout は `persist-credentials: false` とし、App token は
+  push / PR 作成の瞬間のみ供給する (untrusted な依存インストールや update-command 実行中に
+  token を git config に残さない)。Gate の読み取り API と consumer コマンド実行には read-only
+  の `github.token` のみを使い、App token は Create PR step (push / PR 作成) にしか渡さない。
 
 ### 2. consumer 側 wrapper `skills-pull.yml` (agegis / dotfiles、各 1 本)
 

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -37,8 +37,8 @@ push 型 (skills → Devin → consumer) を廃止し、**pull 型** に置き�
 ```
 kanade0404/skills
 ├── .github/workflows/consumer-pull.yml   # 新設: reusable workflow (workflow_call)
-├── .github/workflows/release-propagate.yml   # 削除
-└── .github/devin/consumer-update.md           # 削除
+├── .github/workflows/release-propagate.yml   # Task 7 (検証後) で削除予定
+└── .github/devin/consumer-update.md           # Task 7 (検証後) で削除予定
 
 kanade0404/agegis          kanade0404/dotfiles
 └── .github/workflows/      └── .github/workflows/

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -52,8 +52,12 @@ kanade0404/agegis          kanade0404/dotfiles
 
 `on: workflow_call`。1 job で以下を順に行う:
 
-1. **最新タグ解決**: `gh api repos/kanade0404/skills/tags` から `v*` (semver) の最新を選ぶ。
+1. **最新タグ解決**: `gh api repos/kanade0404/skills/tags` で `v*` タグ全件を取得し、
+   **semver ソートの最大値**を採用する (tags API は commit 順で semver 順を保証しないため
+   API の並び順に依存しない)。プレリリース形式 (`v1.0.0-rc1` 等) は除外。
    GitHub Release の作成には依存しない (このリポのリリースは git タグのみ)。
+   MAJOR bump も自動で PR を立てる — breaking の防波堤は「人間が merge する」ゲートに
+   既にあり、PR body に MAJOR 警告 (削除/リネームを compare リンクで確認せよ) を自動で載せる。
 2. **冪等チェック**: ブランチ `chore/skills-<tag>` が既に存在する、または同ブランチの
    open PR がある場合はスキップ終了 (多重 PR 防止)。
 3. **no-op 判定 (2 方式)**:
@@ -79,16 +83,28 @@ kanade0404/agegis          kanade0404/dotfiles
 | `update-command` | input (required) | `SKILLS_TAG` を受けて pin 更新 + fetch + generate を行うコマンド |
 | `pr-notes` | input (optional) | PR body に追記する markdown (人間確認チェックリスト等) |
 | `setup-node` | input (optional, default true) | `actions/setup-node` を実行するか (両 consumer とも npm script 前提) |
-| `pr-token` | secret (required) | PR 作成・push 用の repo 限定 fine-grained PAT |
+| `app-id` | input (required) | PR 作成用 GitHub App の App ID |
+| `app-private-key` | secret (required) | 同 App の private key (PEM) |
 
-**PAT を要求する理由**: `GITHUB_TOKEN` で作成した PR には CI が自動起動しない
-(GitHub の再帰防止仕様)。consumer 側は「CI green を確認して merge」の運用なので、
-CI が走るトークンで PR を作る必要がある。PAT は各 consumer リポに repo 限定・
-contents/pull-requests write の最小権限で置く。
+**GITHUB_TOKEN でなく GitHub App token を使う理由**: `GITHUB_TOKEN` で作成した PR には
+CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「CI green を確認して merge」の
+運用なので、CI が走るトークンで PR を作る必要がある。fine-grained PAT は有効期限必須
+(最長 1 年) で年次更新チョアと失効リスクを抱えるため、**無期限の GitHub App** を採用する:
+
+- App は個人アカウント配下に 1 つ作成し、権限は Contents / Pull requests の
+  Read & Write のみ。インストール先は agegis / dotfiles に限定する。
+- token 発行 (`actions/create-github-app-token`、1 時間有効の installation token) は
+  reusable workflow 側に埋め込み、consumer は `APP_ID` / `APP_PRIVATE_KEY` を
+  渡すだけにする。
+- PR author は `<app名>[bot]` になり、自動化 PR と一目で区別できる。
+- App の description に用途 (skills release pull 追随) を明記する
+  (将来の「この App 何だっけ」防止)。
 
 ### 2. consumer 側 wrapper `skills-pull.yml` (agegis / dotfiles、各 1 本)
 
-- trigger: `schedule` (日次 cron) + `workflow_dispatch` (リリース直後に即時反映したい時)
+- trigger: `schedule` (日次 cron `17 21 * * *` UTC = JST 朝 6:17。正時は GitHub の cron
+  混雑で遅延・スキップが起きやすいため半端な分を使う。時刻自体に意味はなく変更自由) +
+  `workflow_dispatch` (リリース直後に即時反映したい時)
 - 本体は `uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master` に
   自リポ固有の inputs を渡すだけ。
   - agegis: pin は `package.json` の `rulesync:fetch` script 内 `kanade0404/skills@<ref>`。
@@ -119,7 +135,7 @@ contents/pull-requests write の最小権限で置く。
   → 現 pin と比較 (current-ref-command がある場合) ─ 同じ → 終了 (no-op)
   → update-command 実行 (pin 更新 + rulesync fetch + generate)
   → git diff 空 (current-ref-command 無しの場合の no-op) → 終了
-  → PR 作成 (PAT) → consumer CI 起動 → 人間が review / merge
+  → PR 作成 (GitHub App installation token) → consumer CI 起動 → 人間が review / merge
 ```
 
 ## エラーハンドリング
@@ -139,9 +155,23 @@ contents/pull-requests write の最小権限で置く。
   重複 PR が立たないこと (冪等) を確認する。
 - skills 側は workflow lint (actionlint 等、手元実行) のみ。build/test 基盤は無い。
 
+## 移行手順 (段階移行)
+
+一気に切り替えず、consumer 側の動作確認が取れるまで既存の Devin 経路を残す:
+
+1. skills リポに `consumer-pull.yml` (reusable workflow) を追加する PR。
+   この時点で `release-propagate.yml` は削除しない (共存に害はない)。
+2. agegis / dotfiles に wrapper (`skills-pull.yml`) を追加し、GitHub App の作成・
+   インストール・secrets 設定を行い、workflow_dispatch でドライラン検証
+   (no-op / PR 作成 / 冪等スキップの 3 ケース)。
+3. 検証が通ったら skills 側で `release-propagate.yml` / `.github/devin/consumer-update.md`
+   を削除し RELEASING.md を更新する PR。secrets `DEVIN_API_KEY` / `DEVIN_ORG_ID` の
+   削除もこの時点で行う。
+
 ## スコープ外
 
-- consumer リポ (agegis / dotfiles) への wrapper 追加と PAT 設定は各リポでの作業。
+- consumer リポ (agegis / dotfiles) への wrapper 追加、GitHub App の作成・インストール・
+  secrets (`APP_ID` / `APP_PRIVATE_KEY`) 設定は各リポ / アカウント設定での作業。
   本リポの変更とは別 PR (実装計画には含めるが、この repo の PR には入らない)。
 - dotfiles のパッチスクリプト削除そのものは、初回 pull PR のチェックリストで
   人間が判断する一回性のタスク。

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -107,6 +107,10 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
 - PR author は `<app名>[bot]` になり、自動化 PR と一目で区別できる。
 - App の description に用途 (skills release pull 追随) を明記する
   (将来の「この App 何だっけ」防止)。
+- workflow 本体は `permissions: contents: read` を明示し、外部 action は full commit SHA に
+  pin する。checkout は `persist-credentials: false` とし、App token は push / PR 作成の
+  瞬間のみ供給する (untrusted な依存インストールや update-command 実行中に token を
+  git config に残さない)。
 
 ### 2. consumer 側 wrapper `skills-pull.yml` (agegis / dotfiles、各 1 本)
 

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -58,8 +58,8 @@ kanade0404/agegis          kanade0404/dotfiles
    GitHub Release の作成には依存しない (このリポのリリースは git タグのみ)。
    MAJOR bump も自動で PR を立てる — breaking の防波堤は「人間が merge する」ゲートに
    既にあり、PR body に MAJOR 警告 (削除/リネームを compare リンクで確認せよ) を自動で載せる。
-2. **冪等チェック**: ブランチ `chore/skills-<tag>` が既に存在する、または同ブランチの
-   open PR がある場合はスキップ終了 (多重 PR 防止)。
+2. **冪等チェック**: ブランチ `chore/skills-<tag>` の open PR が既にある場合はスキップ終了
+   (多重 PR 防止)。
 3. **no-op 判定 (2 方式)**:
    - `current-ref-command` (optional input) がある場合: それを実行して現 pin を stdout で
      受け取り、最新タグと一致すれば成功終了。
@@ -69,10 +69,16 @@ kanade0404/agegis          kanade0404/dotfiles
    - 無い場合: 判定を後段に回し、update 実行後に `git diff` が空なら成功終了。
      現 consumer では使わないが、pin を持たない将来の consumer 向けの安全弁として残す
      (update が実質空振りだった場合に空 PR を作らない防御を兼ねる)。
-4. **更新実行**: input の `update-command` を環境変数 `SKILLS_TAG=<新タグ>` 付きで実行。
-   pin 書き換え・rulesync fetch・generate は全て consumer 側リポ既存のスクリプトに委譲し、
-   生成物を手編集しない (現 playbook の不変条件を引き継ぐ)。
-6. **PR 作成**: `chore/skills-<tag>` ブランチに commit し、PR を 1 件作成。body には
+4. **resume 判定**: open PR は無いが同ブランチ `chore/skills-<tag>` が既に存在する場合、
+   「前回 run が push 成功 → PR 作成前に失敗」した形跡とみなし resume モードに入る。
+   resume 中は更新実行 (次項) を丸ごとスキップし、既存ブランチから PR 作成のみを再実行する
+   (自動復旧)。
+5. **更新実行**: resume でない場合のみ、input の `update-command` を環境変数
+   `SKILLS_TAG=<新タグ>` 付きで実行。pin 書き換え・rulesync fetch・generate は全て
+   consumer 側リポ既存のスクリプトに委譲し、生成物を手編集しない
+   (現 playbook の不変条件を引き継ぐ)。
+6. **PR 作成**: resume でない場合は `chore/skills-<tag>` ブランチに commit・push してから、
+   resume の場合は既存ブランチのまま、PR を 1 件作成。body には
    - 何を・なぜ (新タグへの追随)・再生成したもの
    - diff リンク `https://github.com/kanade0404/skills/compare/<旧>...<新>`
    - input `pr-notes` の内容 (「要人間確認」チェックリスト。機械判断できない項目を残す)
@@ -136,9 +142,10 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
 ```
 (日次 cron / 手動 dispatch @ consumer)
   → 最新タグ解決 (skills は public、読み取りに認証不要)
-  → chore/skills-<tag> ブランチ / open PR 既存 → 終了 (冪等)
+  → chore/skills-<tag> ブランチの open PR 既存 → 終了 (冪等)
   → 現 pin と比較 (current-ref-command がある場合) ─ 同じ → 終了 (no-op)
-  → update-command 実行 (pin 更新 + rulesync fetch + generate)
+  → chore/skills-<tag> ブランチが open PR 無しで既存 → resume (PR 作成のみ再実行、自動復旧)
+  → (resume でなければ) update-command 実行 (pin 更新 + rulesync fetch + generate)
   → git diff 空 (current-ref-command 無しの場合の no-op) → 終了
   → PR 作成 (GitHub App installation token) → consumer CI 起動 → 人間が review / merge
 ```
@@ -152,6 +159,8 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
   PR は作る。
 - タグが日次間隔より速く連続した場合: 古いタグの open PR が残っていても、新タグは
   別ブランチ名なので新 PR が立つ。古い PR の close は人間の判断に委ねる。
+- 「push 成功 → PR 作成前に失敗」の部分失敗は、次回 run が既存 branch から PR 作成のみを
+  再実行して自動復旧する。
 
 ## テスト / 検証
 

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -62,11 +62,13 @@ kanade0404/agegis          kanade0404/dotfiles
    open PR がある場合はスキップ終了 (多重 PR 防止)。
 3. **no-op 判定 (2 方式)**:
    - `current-ref-command` (optional input) がある場合: それを実行して現 pin を stdout で
-     受け取り、最新タグと一致すれば成功終了 (agegis はこちら。pin が `package.json` に
-     明示されている)。
-   - 無い場合: 判定を後段に回し、update 実行後に `git diff` が空なら成功終了
-     (dotfiles はこちら。declarative source 方式で「現在の pin」を持たないため、
-     実際に更新を走らせて差分の有無で判定する)。
+     受け取り、最新タグと一致すれば成功終了。
+     **実機確認の結果、両 consumer ともこちらを使える**: agegis は `package.json` の
+     `rulesync:fetch` script に `@vX.Y.Z`、dotfiles は `rulesync.jsonc` と
+     `rulesync-claude/rulesync.jsonc` の 2 箇所に `"ref": "vX.Y.Z"` を明示している。
+   - 無い場合: 判定を後段に回し、update 実行後に `git diff` が空なら成功終了。
+     現 consumer では使わないが、pin を持たない将来の consumer 向けの安全弁として残す
+     (update が実質空振りだった場合に空 PR を作らない防御を兼ねる)。
 4. **更新実行**: input の `update-command` を環境変数 `SKILLS_TAG=<新タグ>` 付きで実行。
    pin 書き換え・rulesync fetch・generate は全て consumer 側リポ既存のスクリプトに委譲し、
    生成物を手編集しない (現 playbook の不変条件を引き継ぐ)。
@@ -82,7 +84,7 @@ kanade0404/agegis          kanade0404/dotfiles
 | `current-ref-command` | input (optional) | 現在の pin を stdout に出すシェルコマンド。無指定時は update 後の差分有無で no-op 判定 |
 | `update-command` | input (required) | `SKILLS_TAG` を受けて pin 更新 + fetch + generate を行うコマンド |
 | `pr-notes` | input (optional) | PR body に追記する markdown (人間確認チェックリスト等) |
-| `setup-node` | input (optional, default true) | `actions/setup-node` を実行するか (両 consumer とも npm script 前提) |
+| `runtime` | input (optional, default `node`) | `node` (setup-node lts + corepack enable。agegis は pnpm) / `bun` (setup-bun。dotfiles) / `none` |
 | `app-id` | input (required) | PR 作成用 GitHub App の App ID |
 | `app-private-key` | secret (required) | 同 App の private key (PEM) |
 
@@ -107,10 +109,13 @@ CI が自動起動しない (GitHub の再帰防止仕様)。consumer 側は「C
   `workflow_dispatch` (リリース直後に即時反映したい時)
 - 本体は `uses: kanade0404/skills/.github/workflows/consumer-pull.yml@master` に
   自リポ固有の inputs を渡すだけ。
-  - agegis: pin は `package.json` の `rulesync:fetch` script 内 `kanade0404/skills@<ref>`。
-    update は fetch script の ref 書き換え + `rulesync:fetch` + generate 系 script。
-  - dotfiles: `rulesync.jsonc` の declarative source 方式。
-    `rulesync:skills:update` / `rulesync:skills:claude:update` を実行。
+  - agegis (pnpm): pin は `package.json` の `rulesync:fetch` script 内
+    `kanade0404/skills@vX.Y.Z`。update は sed で pin 書き換え (jq だと整形差分が出る) +
+    `pnpm run rulesync:fetch` + `pnpm run rulesync:generate`。
+  - dotfiles (bun): pin は `rulesync.jsonc` と `rulesync-claude/rulesync.jsonc` の
+    2 箇所の `"ref": "vX.Y.Z"`。JSONC (コメント入り) のため書き換えは sed、
+    読み取りは grep で行い jq に依存しない。update は両ファイルの ref 書き換え +
+    `bun run rulesync:skills:update` + `bun run rulesync:skills:claude:update`。
     `pr-notes` に `scripts/patch-rulesync-skill-frontmatter.ts` の削除可否確認
     (skills v0.5.0 以降不要の可能性) をチェックリストとして渡す。
 - reusable workflow の参照は `@master` 固定。skills 自体のタグは skill 配布の

--- a/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md
@@ -1,7 +1,7 @@
 # consumer pull 型リリース追随 (Devin push 廃止) — 設計
 
 日付: 2026-07-05
-状態: 承認待ち
+状態: 承認済み (ADR 0001 として決定を記録: docs/adr/0001-consumer-pull-release-propagation.md)
 
 ## 背景 / 問題
 


### PR DESCRIPTION
## 概要

release 追随を Devin API push 型から **consumer pull 型**に転換する第 1 段 (段階移行の skills 側追加分)。Devin credit 枯渇で propagate が全停止する単一依存を、consumer 側 cron の決定的スクリプトに置き換えて構成から消す。

- 設計 spec: `docs/superpowers/specs/2026-07-05-consumer-pull-propagation-design.md`
- 決定記録: `docs/adr/0001-consumer-pull-release-propagation.md` (却下した代替案含む)
- 実装計画: `docs/superpowers/plans/2026-07-19-consumer-pull-propagation.md`
- 実装: `.github/workflows/consumer-pull.yml` — consumer (agegis / dotfiles) が `@master` で呼ぶ reusable workflow (workflow_call)。最新タグ解決 (semver 最大値) → 冪等ゲート (open PR / no-op / resume 自動復旧) → consumer 固有 update コマンド実行 → GitHub App token で PR 作成

## この PR でやらないこと (段階移行)

- **`release-propagate.yml` / `.github/devin/consumer-update.md` は削除しない**。consumer 側 wrapper + GitHub App の検証 (計画 Task 3-6) が通った後の別 PR で削除する。この PR は consumer が呼ぶまで inert。

## 検証

- actionlint clean (shellcheck 込み)
- タグ解決ロジックの単体実行で `v0.8.0` を確認
- タスクレビュー + 最終 whole-branch レビュー実施済み。指摘 (dead guard / 部分失敗時の PR 取りこぼし / strict mode 非伝播) は修正済み。fast-follow 候補 (closed PR resurrection 対策、persist-credentials 縮小) は計画の ledger に記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `skills` の新タグを定期（cron）・手動で検知し、必要に応じて追随PRを自動作成。
  - SemVer（プレリリース除外）で最大タグを解決し、比較リンク・メジャー更新警告・要確認チェックリストをPR本文に自動追記。
  - 冪等対応（既存オープンPR/同一ピンでの no-op）と、PR作成失敗からの復旧（再実行で継続）を強化。
- **ドキュメント**
  - push型からconsumer pull型への移行方針・設計・手順を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->