### PR TITLE
fix(commit): make trigger act-based and concise

### DIFF
--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: git commit を「観測 → ガード → 明示パス staging → ファイル経由メッセージ → 検証」の固定順で作る skill。`git add -A` / `git add .` / heredoc を使わないため、permission / hook で汎用コマンドが拒否される環境でもブロックされずに完走する。「commit して」「コミット作って」「この変更コミットしといて」「stage して commit」「きりのいいところで commit 切って」「一区切りだから記録して」のような要請、および tdd / tidy-first / shipping の各サイクル終端の commit 作成で必ず起動すること。commit までが責務 — push・PR 作成は `shipping`(検証ループ付き)または `commit-commands:commit-push-pr` に、リリースタグは RELEASING.md の手順に、structural / behavioral の分割判断は `tidy-first` に渡す。履歴書き換え (amend / rebase / squash / reset / revert) と commit 取り消しは範囲外 — 新規 commit を作る要請だけを扱う。
+description: git commit を新規作成する全ての場面で、コマンドを打つ前に必ず起動する。トリガは「commit を作る」という行為そのもの — ユーザーの依頼、上流 skill (tdd / tidy-first / shipping) のサイクル終端、エージェント自身の判断による commit (CI 修正 commit・区切り commit 等) のいずれも同じ。「観測 → ガード → 明示パス staging → ファイル経由メッセージ → 検証」の固定手順で、permission / hook が汎用コマンドを拒否する環境でも一発で通る commit を作る。commit 作成までが責務 — push・PR 作成・リリースタグ・履歴書き換え (amend / rebase / squash / reset / revert) は範囲外。
 claudecode:
   allowed-tools:
     - Read
@@ -26,9 +26,9 @@ claudecode:
 
 ## いつ使うか / 使わない場面
 
-**使う**: コミット作成の要請すべて。「commit して」「コミットしといて」「この変更で commit
-作って」「stage して commit」「きりのいいところで commit 切って」。tdd の GREEN 直後、
-tidy-first の tidying 単位、shipping Phase 3 など上流 skill からの commit 局面も同じ。
+**使う**: git commit を新規作成する全ての場面。ユーザーの依頼、上流 skill からの局面
+(tdd の GREEN 直後、tidy-first の tidying 単位、shipping Phase 3)、エージェント自身の
+判断による commit (CI 修正 commit・区切り commit) のいずれかを問わない。
 
 **使わない** (成果物で線を引く):
 


### PR DESCRIPTION
## 概要

`commit` skill の description トリガを「行為ベース」に一般化し、全体を短縮する。

## 背景 (retro finding)

kanade0404/resume の CI 対応セッションの retro で、同一セッション内で `commit` skill が1回目は起動され、2回目 (ci-self-heal 中のエージェント自身の判断による修正 commit) は起動されない不整合が観測された。原因は description のトリガが以下のみで構成されていたこと:

- ユーザーの発話フレーズの列挙 (「commit して」「コミット作って」等)
- 上流 skill (tdd / tidy-first / shipping) のサイクル終端

「エージェント自身が git commit を打つと判断した場面」がどのトリガにも該当せず、2回目の不発は description 通りの挙動だった。

## 変更

- description のトリガを「git commit を新規作成する行為そのもの」に一般化(ユーザー依頼・上流 skill 終端・エージェント自身の判断のいずれも同じ扱い)
- 発話フレーズの列挙を削除して description を短縮
- 本文「いつ使うか」の「使う」節を同じ基準に揃える
- スコープ境界 (push / PR / タグ / 履歴書き換えは範囲外) は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP4jndXmvdKv2UQepXwPMf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コミット作成手順の適用範囲と責務を明確化しました。
  * コミット作成時の標準手順（確認、保護、ステージング、メッセージ作成、検証）をより具体的に記載しました。
  * コミットを作成する場面と、対象外となる操作を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->