### PR TITLE
Add SessionStart hook for direnv/nix devshell setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,18 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-setup.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
 # Load the nix devshell defined in flake.nix. Requires nix (flakes enabled)
-# and direnv; nix-direnv is recommended for evaluation
-  caching.
+# and direnv; nix-direnv is recommended for evaluation caching.
 if has nix; then
   use flake
 else

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+# Load the nix devshell defined in flake.nix. Requires nix (flakes enabled)
+# and direnv; nix-direnv is recommended for evaluation
+  caching.
+if has nix; then
+  use flake
+else
+  log_error "nix not found; devshell not loaded (see https://nixos.org/download)"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pycache__/
 # This repo intentionally commits its generated Codex skills under .agents/
 # (dogfooding). Override a personal global ~/.gitignore that ignores .agents/.
 !.agents/
+
+# direnv's local evaluation cache for .envrc (machine-local, not distributed)
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785602060,
+        "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a5cbcfe954791221bfffe2307f7d1a1bf61a871e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
             packages = [
               python
               pkgs.uv
+              pkgs.nodejs_24
+              pkgs.jq
             ];
           };
         });

--- a/hooks-local/README.md
+++ b/hooks-local/README.md
@@ -17,9 +17,18 @@ Claude Code の `.claude/settings.json` の `hooks` キーにそのまま代入�
 
 - `.claude/settings.json` を直接編集しても `scripts/rulesync-sync.mjs` の再実行で
   上書きされて消えるため、変更はこのファイル側で行う。
-- 現在の内容: pr-monitor の state ファイル (`.claude/.pr-monitor/*`) への
-  Write/Edit/MultiEdit 直書きを PreToolUse hook で拒否し、
-  `prm state-init`/`prm state-merge` (read-modify-write) に誘導するガード。
+- 現在の内容:
+  - pr-monitor の state ファイル (`.claude/.pr-monitor/*`) への
+    Write/Edit/MultiEdit 直書きを PreToolUse hook で拒否し、
+    `prm state-init`/`prm state-merge` (read-modify-write) に誘導するガード。
+  - SessionStart hook: `scripts/session-setup.sh` を起動し、この checkout の
+    nix devshell (`flake.nix`) をバックグラウンドで build する
+    (direnv/nix が無い環境では警告を出すだけで exit 0、セッション開始をブロックしない)。
+    `direnv allow` は既定では実行しない — このリポジトリは任意の PR ブランチを
+    worktree に checkout する自動フローがあり、無条件 allow は direnv の
+    trust-on-first-use を無効化するため。環境変数 `SKILLS_DIRENV_AUTO_ALLOW=1` を
+    設定したセッションでのみ自動 allow する (未設定なら手動で
+    `direnv allow <root>` を促す警告を出す)。
 
 ## `claude-code-env.json`
 

--- a/hooks-local/claude-code-hooks.json
+++ b/hooks-local/claude-code-hooks.json
@@ -1,4 +1,16 @@
 {
+  "SessionStart": [
+    {
+      "matcher": "startup|resume|clear",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-setup.sh",
+          "timeout": 60
+        }
+      ]
+    }
+  ],
   "PreToolUse": [
     {
       "matcher": "Write|Edit|MultiEdit",

--- a/scripts/rulesync-sync.mjs
+++ b/scripts/rulesync-sync.mjs
@@ -54,10 +54,25 @@ const MIRRORED_DIRS = ['.claude/skills', '.claude/rules', '.agents/skills'];
 // placeholder-only (README without frontmatter) and would fail rulesync parsing.
 // rules/ は配布用 (consumer が fetch で丸ごと受け取る)、rules-local/ はこの repo
 // 専用 (root rule 等。配布 feature には含まれない) — 自前生成では両方を staging する。
+// Python bytecode caches (skills/*/scripts/__pycache__/*.pyc) are gitignored
+// but reappear on disk whenever `uv run python3 -m unittest discover -s tests`
+// imports a skill's Python script (e.g. skills/retro/scripts/retro_scan.py).
+// They must never enter the generate pipeline: staged into `.rulesync/skills`
+// here, `rulesync generate` would mirror them into `.claude/skills/` and
+// `.agents/skills/`, and a fresh checkout without that local cache would then
+// have `--check` report the mirrored path as missing/stale. Filtering them
+// out at this single staging entry point — the only place top-level `skills/`
+// content enters the pipeline — keeps them out of `genOut` entirely, so both
+// `diffTree` (walks `genOut`) and the write-mode `cpSync` overlay never see
+// them either.
+const isPycacheEntry = (name) => name === '__pycache__' || name.endsWith('.pyc');
 const stage = join(ROOT, '.rulesync');
 rmSync(stage, { recursive: true, force: true });
 mkdirSync(stage, { recursive: true });
-cpSync(join(ROOT, 'skills'), join(stage, 'skills'), { recursive: true });
+cpSync(join(ROOT, 'skills'), join(stage, 'skills'), {
+  recursive: true,
+  filter: (src) => !isPycacheEntry(basename(src)),
+});
 copyFileSync(join(ROOT, 'permissions.json'), join(stage, 'permissions.json'));
 mkdirSync(join(stage, 'rules'), { recursive: true });
 // rulesync は nested rule (rules/**/*.md) を扱えるため再帰的に staging する
@@ -320,6 +335,14 @@ function findStaleFiles(generatedRoot, targetRoot) {
   const stale = [];
   const walk = (absDir, relDir) => {
     for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      // Pre-existing `__pycache__`/`*.pyc` copies from before the staging
+      // filter above existed (or from a stray local run) never appear in
+      // `generatedRoot` now, which would otherwise make every one of them
+      // "stale" forever with no way to clear them (they're gitignored, not
+      // committed, and this script has no delete-on-check mode). They're
+      // harmless build byproducts, not generated content this script owns —
+      // skip them entirely rather than flag or recurse into them.
+      if (isPycacheEntry(entry.name)) continue;
       const relPath = join(relDir, entry.name);
       const absPath = join(absDir, entry.name);
       const genPath = join(generatedRoot, relPath);

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -27,6 +27,15 @@
 # the log path it prints if the devshell later seems broken/missing.
 set -u
 
+# This script machine-parses `direnv status --json` output with grep/sed
+# below (see root_is_direnv_allowed). Inherited terminal color/decoration
+# settings (e.g. CLICOLOR_FORCE=1) can inject ANSI escapes into that output
+# even when piped, silently breaking the grep/sed parsing — disable them at
+# the entry point rather than relying on the environment being clean.
+export NO_COLOR=1
+export CLICOLOR_FORCE=0
+unset GH_FORCE_TTY
+
 root=$(cd "$(dirname "$0")/.." && pwd)
 
 warn() { printf 'session-setup: %s\n' "$*" >&2; }

--- a/scripts/session-setup.sh
+++ b/scripts/session-setup.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure this checkout's nix devshell (flake.nix) is
+# authorized with direnv and built. Must never block or fail the session:
+# the (possibly slow) first build runs in the background, and every failure
+# path exits 0 with a warning on stderr.
+#
+# `direnv allow` is opt-in (SKILLS_DIRENV_AUTO_ALLOW=1), not automatic: this
+# repository has an automated flow that checks out arbitrary PR branches
+# into worktrees, and unconditionally allowing would defeat direnv's
+# trust-on-first-use model for whatever .envrc happens to be checked out.
+#
+# The background devshell build below is gated the same way: `nix develop`
+# executes the flake's shellHook unconditionally (direnv is not involved at
+# all for that invocation), so triggering it every SessionStart whenever nix
+# happens to be on PATH would run untrusted shellHook code for whatever
+# branch is checked out into this worktree, regardless of the direnv-allow
+# gate above. The build only runs when EITHER (a) SKILLS_DIRENV_AUTO_ALLOW=1
+# (the same opt-in as `direnv allow` above), OR (b) $root's own .envrc has
+# already been `direnv allow`-ed previously (by a human, outside this hook)
+# — in that case direnv's normal operation would build the flake on its own
+# the next time a shell enters $root anyway, so building it here does not
+# create new exposure. If neither holds, no build is started.
+#
+# Note: the devshell build below runs detached (nohup + disown). If it
+# fails after this hook has already exited, there is no later notification
+# for that failure — the warning below is the only signal you get; check
+# the log path it prints if the devshell later seems broken/missing.
+set -u
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+
+warn() { printf 'session-setup: %s\n' "$*" >&2; }
+
+# root_is_direnv_allowed: true iff "$1"'s own .envrc has already been
+# `direnv allow`-ed. We must not shell out to jq — jq typically lives inside
+# the not-yet-built devshell, so it may not be on PATH yet, which is exactly
+# the situation this function runs in. `direnv status --json` is parsed with
+# grep/sed instead: its foundRC object is a flat, one-key-per-line pretty
+# printed block (`"foundRC": {`, `"allowed": N`, `"path": "..."`, `}`), a
+# stable characteristic of Go's json.MarshalIndent across direnv versions,
+# so grep -A2 right after the "foundRC": { line reliably captures both
+# fields without needing a real JSON parser. `direnv status` always reports
+# on the *current* directory, so we cd into "$1" in a subshell first.
+root_is_direnv_allowed() {
+  local target="$1/.envrc" json block allowed_line path_line path_val
+  json=$(cd "$1" 2>/dev/null && direnv status --json 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  block=$(printf '%s\n' "$json" | grep -A2 '"foundRC": {') || return 1
+  [ -n "$block" ] || return 1
+  allowed_line=$(printf '%s\n' "$block" | grep '"allowed"') || return 1
+  path_line=$(printf '%s\n' "$block" | grep '"path"') || return 1
+  path_val=$(printf '%s\n' "$path_line" | sed -E 's/.*"path"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  [ "$path_val" = "$target" ] || return 1
+  printf '%s\n' "$allowed_line" | grep -Eq '"allowed"[[:space:]]*:[[:space:]]*0[,]?[[:space:]]*$'
+}
+
+if ! command -v nix >/dev/null 2>&1; then
+  warn "nix not found; skipping devshell setup (see https://nixos.org/download)"
+  exit 0
+fi
+
+# build_authorized gates the background `nix develop` build below (see the
+# header comment for the threat this closes). It is deliberately computed
+# independently of direnv's presence: SKILLS_DIRENV_AUTO_ALLOW=1 authorizes
+# the build on its own even if direnv itself is missing.
+build_authorized=0
+if [ "${SKILLS_DIRENV_AUTO_ALLOW:-}" = "1" ]; then
+  build_authorized=1
+fi
+
+if command -v direnv >/dev/null 2>&1; then
+  if [ "${SKILLS_DIRENV_AUTO_ALLOW:-}" = "1" ]; then
+    direnv allow "$root" || warn "direnv allow failed for $root"
+  else
+    warn "direnv found but not auto-allowed; set SKILLS_DIRENV_AUTO_ALLOW=1 to auto-allow, or run 'direnv allow $root' manually"
+    if root_is_direnv_allowed "$root"; then
+      build_authorized=1
+    fi
+  fi
+else
+  warn "direnv not found; enter the devshell manually with 'nix develop'"
+fi
+
+if [ "$build_authorized" != 1 ]; then
+  warn "skipping background devshell build for $root (not authorized): run 'direnv allow $root' manually, or set SKILLS_DIRENV_AUTO_ALLOW=1 to auto-allow and build automatically on future sessions"
+  exit 0
+fi
+
+# Build/install the devshell in the background so session start is not
+# blocked by a cold nix build. Logged under .direnv/ (gitignored, per-repo)
+# rather than a fixed path under $TMPDIR, which would be predictable and
+# shared/clobbered across concurrent sessions (CWE-377).
+log_dir="$root/.direnv"
+mkdir -p "$log_dir" 2>/dev/null || true
+log="$log_dir/session-setup.log"
+nohup nix develop --extra-experimental-features 'nix-command flakes' \
+  "$root#default" --command true >"$log" 2>&1 &
+disown 2>/dev/null || true
+warn "devshell build started in background (log: $log; failures after this point are not re-notified, check the log)"
+exit 0

--- a/tests/session-setup-test.sh
+++ b/tests/session-setup-test.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This suite machine-parses stub logs and command output (grep) throughout.
+# Disable inherited terminal color/decoration settings at the entry point so
+# a colorized environment can't corrupt what's being asserted on, matching
+# the same discipline applied inside scripts/session-setup.sh itself.
+export NO_COLOR=1
+export CLICOLOR_FORCE=0
+unset GH_FORCE_TTY
+
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 SCRIPT="$ROOT_DIR/scripts/session-setup.sh"
 

--- a/tests/session-setup-test.sh
+++ b/tests/session-setup-test.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/session-setup.sh"
+
+# Minimal system PATH that (on this dev machine) does not contain nix or
+# direnv, so tests can control their presence/absence deterministically via
+# a stub bin directory prepended in front of it.
+BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+# poll_for_pattern waits (up to ~2s) for "$file" to contain "$pattern",
+# returning success as soon as it appears. The build the script under test
+# starts is detached (nohup + disown), so its stub-log line is written
+# asynchronously — checking $file immediately after the script under test
+# returns is a race. Callers that assert *absence* wait out the full budget
+# before concluding the pattern never appeared.
+poll_for_pattern() {
+  local file=$1
+  local pattern=$2
+  local attempts=${3:-40}
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if [[ -f "$file" ]] && grep -q "$pattern" "$file"; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  [[ -f "$file" ]] && grep -q "$pattern" "$file"
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local message=$3
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$message: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+# write_stub creates an executable no-op command at "$dir/$name" that
+# records every invocation (name + args) as a line in "$STUB_LOG".
+write_stub() {
+  local dir=$1
+  local name=$2
+  cat >"$dir/$name" <<'EOF'
+#!/bin/sh
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$STUB_LOG"
+exit 0
+EOF
+  chmod +x "$dir/$name"
+}
+
+# write_direnv_status_stub creates an executable "direnv" stub that, like
+# write_stub, logs every invocation, but additionally answers
+# `direnv status --json` with a canned response describing whether
+# "$envrc_path" is allowed (0) or not (1) — mirroring the real `direnv
+# status --json` shape (state.foundRC.{allowed,path}) so the gate logic
+# under test can be exercised without a real direnv install.
+write_direnv_status_stub() {
+  local dir=$1
+  local allowed=$2
+  local envrc_path=$3
+  cat >"$dir/direnv" <<EOF
+#!/bin/sh
+printf '%s %s\n' "\$(basename "\$0")" "\$*" >>"\$STUB_LOG"
+if [ "\$1" = "status" ] && [ "\$2" = "--json" ]; then
+  cat <<JSON
+{
+  "config": {},
+  "state": {
+    "foundRC": {
+      "allowed": ${allowed},
+      "path": "${envrc_path}"
+    },
+    "loadedRC": null
+  }
+}
+JSON
+fi
+exit 0
+EOF
+  chmod +x "$dir/direnv"
+}
+
+# make_script_copy copies session-setup.sh under a fresh tmp "repo" so each
+# test gets its own $root (the script derives root from its own location)
+# and never touches this checkout's real .direnv/ directory.
+make_script_copy() {
+  local tmpdir=$1
+  mkdir -p "$tmpdir/scripts"
+  cp "$SCRIPT" "$tmpdir/scripts/session-setup.sh"
+  chmod +x "$tmpdir/scripts/session-setup.sh"
+}
+
+test_exits_zero_and_warns_when_nix_is_missing() {
+  local tmpdir rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+
+  set +e
+  PATH="$BASE_PATH" bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code when nix is missing"
+  if ! grep -q "nix not found" "$tmpdir/err"; then
+    echo "expected stderr to warn that nix was not found" >&2
+    exit 1
+  fi
+}
+
+test_exits_zero_when_direnv_is_missing() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  STUB_LOG="$tmpdir/stub.log" write_stub "$stubbin" nix
+
+  set +e
+  STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code when direnv is missing"
+  if ! grep -q "direnv not found" "$tmpdir/err"; then
+    echo "expected stderr to warn that direnv was not found" >&2
+    exit 1
+  fi
+}
+
+test_direnv_allow_not_called_without_auto_allow_env() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  write_stub "$stubbin" nix
+  write_stub "$stubbin" direnv
+
+  set +e
+  env -u SKILLS_DIRENV_AUTO_ALLOW \
+    STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code without SKILLS_DIRENV_AUTO_ALLOW"
+  if [[ -f "$tmpdir/stub.log" ]] && grep -q "^direnv allow" "$tmpdir/stub.log"; then
+    echo "expected 'direnv allow' NOT to be called without SKILLS_DIRENV_AUTO_ALLOW=1" >&2
+    exit 1
+  fi
+  if ! grep -q "SKILLS_DIRENV_AUTO_ALLOW" "$tmpdir/err"; then
+    echo "expected stderr to mention SKILLS_DIRENV_AUTO_ALLOW as the opt-in knob" >&2
+    exit 1
+  fi
+}
+
+test_direnv_allow_called_with_auto_allow_env() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  write_stub "$stubbin" nix
+  write_stub "$stubbin" direnv
+
+  set +e
+  SKILLS_DIRENV_AUTO_ALLOW=1 \
+    STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code with SKILLS_DIRENV_AUTO_ALLOW=1"
+  if ! grep -q "^direnv allow" "$tmpdir/stub.log"; then
+    echo "expected 'direnv allow' to be called when SKILLS_DIRENV_AUTO_ALLOW=1" >&2
+    exit 1
+  fi
+  if [[ ! -f "$tmpdir/.direnv/session-setup.log" ]]; then
+    echo "expected background build log at \$root/.direnv/session-setup.log" >&2
+    exit 1
+  fi
+}
+
+test_build_not_started_when_gate_off_and_root_not_allowed() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  write_stub "$stubbin" nix
+  # root's own .envrc is NOT allowed (allowed: 1 == direnv's "not allowed").
+  write_direnv_status_stub "$stubbin" 1 "$tmpdir/.envrc"
+
+  set +e
+  env -u SKILLS_DIRENV_AUTO_ALLOW \
+    STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code when gate is off and root is not direnv-allowed"
+  if poll_for_pattern "$tmpdir/stub.log" "^nix develop"; then
+    echo "expected 'nix develop' NOT to be called when gate is off and root is not direnv-allowed" >&2
+    exit 1
+  fi
+}
+
+test_build_started_when_root_already_direnv_allowed_without_auto_allow_env() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  write_stub "$stubbin" nix
+  # root's own .envrc IS already allowed (allowed: 0 == direnv's "allowed"),
+  # e.g. because a human previously ran `direnv allow` manually.
+  write_direnv_status_stub "$stubbin" 0 "$tmpdir/.envrc"
+
+  set +e
+  env -u SKILLS_DIRENV_AUTO_ALLOW \
+    STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code when root is already direnv-allowed"
+  if ! poll_for_pattern "$tmpdir/stub.log" "^nix develop"; then
+    echo "expected 'nix develop' to be called when root is already direnv-allowed, even without SKILLS_DIRENV_AUTO_ALLOW" >&2
+    exit 1
+  fi
+  if [[ ! -f "$tmpdir/.direnv/session-setup.log" ]]; then
+    echo "expected background build log at \$root/.direnv/session-setup.log" >&2
+    exit 1
+  fi
+}
+
+test_build_started_with_auto_allow_env_even_when_root_not_allowed() {
+  local tmpdir stubbin rc
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  make_script_copy "$tmpdir"
+  stubbin="$tmpdir/stubbin"
+  mkdir -p "$stubbin"
+  write_stub "$stubbin" nix
+  # root's own .envrc is NOT (yet) allowed; SKILLS_DIRENV_AUTO_ALLOW=1 must
+  # be sufficient on its own to authorize the build.
+  write_direnv_status_stub "$stubbin" 1 "$tmpdir/.envrc"
+
+  set +e
+  SKILLS_DIRENV_AUTO_ALLOW=1 \
+    STUB_LOG="$tmpdir/stub.log" PATH="$stubbin:$BASE_PATH" \
+    bash "$tmpdir/scripts/session-setup.sh" >"$tmpdir/out" 2>"$tmpdir/err"
+  rc=$?
+  set -e
+
+  assert_eq "0" "$rc" "exit code with SKILLS_DIRENV_AUTO_ALLOW=1 and root not yet allowed"
+  if ! poll_for_pattern "$tmpdir/stub.log" "^nix develop"; then
+    echo "expected 'nix develop' to be called when SKILLS_DIRENV_AUTO_ALLOW=1, regardless of prior direnv-allow state" >&2
+    exit 1
+  fi
+}
+
+test_exits_zero_and_warns_when_nix_is_missing
+test_exits_zero_when_direnv_is_missing
+test_direnv_allow_not_called_without_auto_allow_env
+test_direnv_allow_called_with_auto_allow_env
+test_build_not_started_when_gate_off_and_root_not_allowed
+test_build_started_when_root_already_direnv_allowed_without_auto_allow_env
+test_build_started_with_auto_allow_env_even_when_root_not_allowed
+
+echo "session-setup-test.sh: all tests passed"

--- a/tests/test_session_setup_sh.py
+++ b/tests/test_session_setup_sh.py
@@ -1,0 +1,45 @@
+"""CI wiring for tests/session-setup-test.sh.
+
+session-setup-test.sh is a hermetic bash suite (7 tests) covering the
+SessionStart hook's build-authorization gate (scripts/session-setup.sh):
+nix/direnv presence detection, SKILLS_DIRENV_AUTO_ALLOW opt-in, and the
+direnv-allowed-root gate. It never touches real nix/direnv — each test
+prepends a stub bin directory (fake `nix` / `direnv`) in front of a minimal
+system PATH, so it is safe to run unattended on CI (ubuntu-latest, no nix or
+direnv installed).
+
+CI (.github/workflows/trigger-evals.yml) runs `python3 -m unittest discover
+-s tests`, which only discovers `test_*.py` — a bare `.sh` script is invisible
+to it, so the suite previously only ran when someone remembered to invoke it
+by hand. This wrapper runs it as a subprocess so unittest discovery wires it
+into CI automatically.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SUITE = REPO_ROOT / "tests" / "session-setup-test.sh"
+
+
+class SessionSetupShTest(unittest.TestCase):
+    def test_session_setup_test_sh_suite_passes(self) -> None:
+        result = subprocess.run(
+            ["bash", str(SUITE)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"tests/session-setup-test.sh failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a `SessionStart` hook (`startup|resume|clear`) that runs
`scripts/session-setup.sh`, warming this repo's nix devshell
(`flake.nix`, now including `nodejs_24` and `jq`) via direnv so a new
Claude Code session in this repo doesn't need a manual
`direnv allow` + `nix develop`. Also fixes an unrelated flakiness bug
in `scripts/rulesync-sync.mjs` where test-run bytecode caches could
get staged into the rulesync pipeline and make `--check` report false
staleness.

## Why

Sessions in this repo (including PR-branch worktrees) currently start
without the devshell loaded, so `uv`, `node`, etc. aren't guaranteed
to be on `PATH` until someone manually runs `direnv allow` and
`nix develop`. A `SessionStart` hook removes that manual step for the
common case while keeping execution opt-in for untrusted checkouts
(see design decision below).

Separately, `uv run python3 -m unittest discover -s tests` regenerates
gitignored `__pycache__` directories under `skills/*/scripts/`. Those
were getting copied into the `.rulesync` staging tree and then mirrored
into `.claude/skills/` / `.agents/skills/` by `rulesync generate`,
so a fresh checkout without the local cache would see the mirrored
path as stale under `--check`. Filtered out at the single staging
entry point.

## Design decision: opt-in gate instead of unconditional `direnv allow` / `nix develop`

`scripts/session-setup.sh` does **not** run `direnv allow` or
`nix develop` unconditionally. It only proceeds if either:

- `SKILLS_DIRENV_AUTO_ALLOW=1` is set, or
- the repo root has already been `direnv allow`-ed by a human.

Otherwise it warns and exits `0` without blocking session start.

This repo's workflows routinely check out arbitrary PR branches into
worktrees. Unconditionally running `direnv allow` (or `nix develop`)
on session start would auto-execute an untrusted `flake.nix` from
whatever branch happens to be checked out, defeating direnv's
trust-on-first-use model. Requiring one of the two opt-in signals
keeps the hook inert until a human (or an explicitly configured CI
job) has vetted the flake for that checkout.

## Verification

From the prior verify-done gate on this branch:
- `tests/session-setup-test.sh`: 7/7 passing (hermetic bash tests
  covering the gating logic and the no-nix/no-direnv fallback path).
- `uv run python3 -m unittest discover -s tests`: 99/99 passing
  (includes `tests/test_session_setup_sh.py`, the unittest wrapper
  around the shell suite).
- `node scripts/rulesync-sync.mjs --check`: exit 0 (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 開発環境の起動・再開・クリア時に、必要な環境準備を自動化しました。
  * Nix と direnv が利用可能な場合、開発環境をバックグラウンドで構築し、状況をログに記録します。
  * 環境が利用できない場合も警告のみで処理を継続します。
  * 設定に応じて、direnv の許可処理を自動化できます。

* **改善**
  * Python のキャッシュファイルがスキルのステージング対象に含まれないようにしました。
  * 開発環境に Node.js と jq を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->