### PR TITLE
Vendor eli5 skill from anthropics/claude-plugins-community

### DIFF
--- a/.agents/skills/eli5/LICENSE
+++ b/.agents/skills/eli5/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thariq Shihipar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/eli5/PROVENANCE.md
+++ b/.agents/skills/eli5/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 `LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
 is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
 ```
 

--- a/.agents/skills/eli5/PROVENANCE.md
+++ b/.agents/skills/eli5/PROVENANCE.md
@@ -1,0 +1,52 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` / `README.md` ("サードパーティ skill は
+vendor しない。明示的に copy-in した例外は、該当 skill ディレクトリ内に出典と
+ライセンスを残す"). It was copied — not fetched at runtime — deliberately, to
+avoid executing upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/anthropics/claude-plugins-community
+- **Upstream path**: `eli5/skills/eli5`
+- **Author**: Thariq Shihipar
+- **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
+  `.claude-plugin/plugin.json`, which is not itself vendored here)
+- **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
+- **Retrieved**: 2026-08-22
+
+In the **source-of-truth** directory `skills/eli5/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
+is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
+
+```
+https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/eli5/` only. This repo also
+commits **rulesync-generated** mirrors under `.claude/skills/` and
+`.agents/skills/` (see `scripts/rulesync-sync.mjs`; regenerate, don't
+hand-edit). Those are derived artifacts and rulesync transforms frontmatter
+per target. Verify the mirrors with `node scripts/rulesync-sync.mjs --check`,
+not by diffing against upstream.
+
+## Behavior note
+
+`SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
+template variable from the upstream plugin's original packaging (it ships as
+a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
+Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
+harness where supported, and otherwise reads as the literal topic prompt text
+typed after `/eli5`.
+
+## Updating
+
+Re-run the copy against a newer upstream commit and update the pinned commit /
+retrieval date above.

--- a/.agents/skills/eli5/PROVENANCE.md
+++ b/.agents/skills/eli5/PROVENANCE.md
@@ -12,7 +12,11 @@ avoid executing upstream tooling (supply-chain hardening).
 - **Upstream path**: `eli5/skills/eli5`
 - **Author**: Thariq Shihipar
 - **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
-  `.claude-plugin/plugin.json`, which is not itself vendored here)
+  `.claude-plugin/plugin.json`, which is not itself vendored here). The upstream
+  repo ships no standalone LICENSE file for this plugin (only the `"license":
+  "MIT"` SPDX identifier), so there is no upstream copyright year to match —
+  `LICENSE` here uses the retrieval year below and the author name from
+  `plugin.json`.
 - **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
 - **Retrieved**: 2026-08-22
 

--- a/.agents/skills/eli5/PROVENANCE.md
+++ b/.agents/skills/eli5/PROVENANCE.md
@@ -46,11 +46,16 @@ not by diffing against upstream.
 `SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
 template variable from the upstream plugin's original packaging (it ships as
 a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
-Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
-harness where supported, and otherwise reads as the literal topic prompt text
-typed after `/eli5`.
+Kept verbatim for fidelity. Claude Code substitutes `$ARGUMENTS` with the
+text typed after `/eli5 <topic>`; a harness without that substitution has no
+topic fallback and leaves the literal `$ARGUMENTS` token in place.
 
 ## Updating
 
-Re-run the copy against a newer upstream commit and update the pinned commit /
-retrieval date above.
+Re-run the copy against a newer upstream commit, then:
+
+1. Update the pinned commit, retrieval date, and the audit URL above (the
+   commit hash is embedded in it too).
+2. Run `node scripts/rulesync-sync.mjs` to regenerate the `.claude/skills/`
+   and `.agents/skills/` mirrors.
+3. Run `node scripts/rulesync-sync.mjs --check` to verify they're in sync.

--- a/.agents/skills/eli5/SKILL.md
+++ b/.agents/skills/eli5/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: eli5
+description: >-
+  Explain a topic like I'm a 5 year old. Use when the user types /eli5 <topic>
+  or asks for a dead-simple picture explainer of how something works.
+---
+# eli5
+
+Explain like I'm someone who knows nothing about this topic, using a HTML artifact with big pictures and few words.
+
+Topic: $ARGUMENTS

--- a/.claude/skills/eli5/LICENSE
+++ b/.claude/skills/eli5/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thariq Shihipar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/eli5/PROVENANCE.md
+++ b/.claude/skills/eli5/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 `LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
 is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
 ```
 

--- a/.claude/skills/eli5/PROVENANCE.md
+++ b/.claude/skills/eli5/PROVENANCE.md
@@ -1,0 +1,52 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` / `README.md` ("サードパーティ skill は
+vendor しない。明示的に copy-in した例外は、該当 skill ディレクトリ内に出典と
+ライセンスを残す"). It was copied — not fetched at runtime — deliberately, to
+avoid executing upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/anthropics/claude-plugins-community
+- **Upstream path**: `eli5/skills/eli5`
+- **Author**: Thariq Shihipar
+- **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
+  `.claude-plugin/plugin.json`, which is not itself vendored here)
+- **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
+- **Retrieved**: 2026-08-22
+
+In the **source-of-truth** directory `skills/eli5/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
+is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
+
+```
+https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/eli5/` only. This repo also
+commits **rulesync-generated** mirrors under `.claude/skills/` and
+`.agents/skills/` (see `scripts/rulesync-sync.mjs`; regenerate, don't
+hand-edit). Those are derived artifacts and rulesync transforms frontmatter
+per target. Verify the mirrors with `node scripts/rulesync-sync.mjs --check`,
+not by diffing against upstream.
+
+## Behavior note
+
+`SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
+template variable from the upstream plugin's original packaging (it ships as
+a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
+Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
+harness where supported, and otherwise reads as the literal topic prompt text
+typed after `/eli5`.
+
+## Updating
+
+Re-run the copy against a newer upstream commit and update the pinned commit /
+retrieval date above.

--- a/.claude/skills/eli5/PROVENANCE.md
+++ b/.claude/skills/eli5/PROVENANCE.md
@@ -12,7 +12,11 @@ avoid executing upstream tooling (supply-chain hardening).
 - **Upstream path**: `eli5/skills/eli5`
 - **Author**: Thariq Shihipar
 - **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
-  `.claude-plugin/plugin.json`, which is not itself vendored here)
+  `.claude-plugin/plugin.json`, which is not itself vendored here). The upstream
+  repo ships no standalone LICENSE file for this plugin (only the `"license":
+  "MIT"` SPDX identifier), so there is no upstream copyright year to match —
+  `LICENSE` here uses the retrieval year below and the author name from
+  `plugin.json`.
 - **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
 - **Retrieved**: 2026-08-22
 

--- a/.claude/skills/eli5/PROVENANCE.md
+++ b/.claude/skills/eli5/PROVENANCE.md
@@ -46,11 +46,16 @@ not by diffing against upstream.
 `SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
 template variable from the upstream plugin's original packaging (it ships as
 a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
-Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
-harness where supported, and otherwise reads as the literal topic prompt text
-typed after `/eli5`.
+Kept verbatim for fidelity. Claude Code substitutes `$ARGUMENTS` with the
+text typed after `/eli5 <topic>`; a harness without that substitution has no
+topic fallback and leaves the literal `$ARGUMENTS` token in place.
 
 ## Updating
 
-Re-run the copy against a newer upstream commit and update the pinned commit /
-retrieval date above.
+Re-run the copy against a newer upstream commit, then:
+
+1. Update the pinned commit, retrieval date, and the audit URL above (the
+   commit hash is embedded in it too).
+2. Run `node scripts/rulesync-sync.mjs` to regenerate the `.claude/skills/`
+   and `.agents/skills/` mirrors.
+3. Run `node scripts/rulesync-sync.mjs --check` to verify they're in sync.

--- a/.claude/skills/eli5/SKILL.md
+++ b/.claude/skills/eli5/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: eli5
+description: >-
+  Explain a topic like I'm a 5 year old. Use when the user types /eli5 <topic>
+  or asks for a dead-simple picture explainer of how something works.
+---
+# eli5
+
+Explain like I'm someone who knows nothing about this topic, using a HTML artifact with big pictures and few words.
+
+Topic: $ARGUMENTS

--- a/skills/eli5/LICENSE
+++ b/skills/eli5/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thariq Shihipar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/eli5/PROVENANCE.md
+++ b/skills/eli5/PROVENANCE.md
@@ -24,7 +24,7 @@ byte-for-byte copy of the upstream at that commit:
 `LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
 is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
 
-```
+```text
 https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
 ```
 

--- a/skills/eli5/PROVENANCE.md
+++ b/skills/eli5/PROVENANCE.md
@@ -1,0 +1,52 @@
+# Provenance
+
+This skill is a **vendored copy** of a third-party skill, brought in under the
+copy-in exception in the repo `CLAUDE.md` / `README.md` ("サードパーティ skill は
+vendor しない。明示的に copy-in した例外は、該当 skill ディレクトリ内に出典と
+ライセンスを残す"). It was copied — not fetched at runtime — deliberately, to
+avoid executing upstream tooling (supply-chain hardening).
+
+## Source
+
+- **Upstream repo**: https://github.com/anthropics/claude-plugins-community
+- **Upstream path**: `eli5/skills/eli5`
+- **Author**: Thariq Shihipar
+- **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
+  `.claude-plugin/plugin.json`, which is not itself vendored here)
+- **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
+- **Retrieved**: 2026-08-22
+
+In the **source-of-truth** directory `skills/eli5/`, the following file is a
+byte-for-byte copy of the upstream at that commit:
+
+- `SKILL.md`
+
+`LICENSE` and this `PROVENANCE.md` are added by the vendoring; everything else
+is untouched. To audit, diff `SKILL.md` against the pinned upstream URL:
+
+```
+https://raw.githubusercontent.com/anthropics/claude-plugins-community/f4c9452f5ca091f1be7064d9faab1b001ea21645/eli5/skills/eli5/SKILL.md
+```
+
+### Generated mirrors are not byte-for-byte
+
+The byte-for-byte claim above is about `skills/eli5/` only. This repo also
+commits **rulesync-generated** mirrors under `.claude/skills/` and
+`.agents/skills/` (see `scripts/rulesync-sync.mjs`; regenerate, don't
+hand-edit). Those are derived artifacts and rulesync transforms frontmatter
+per target. Verify the mirrors with `node scripts/rulesync-sync.mjs --check`,
+not by diffing against upstream.
+
+## Behavior note
+
+`SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
+template variable from the upstream plugin's original packaging (it ships as
+a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
+Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
+harness where supported, and otherwise reads as the literal topic prompt text
+typed after `/eli5`.
+
+## Updating
+
+Re-run the copy against a newer upstream commit and update the pinned commit /
+retrieval date above.

--- a/skills/eli5/PROVENANCE.md
+++ b/skills/eli5/PROVENANCE.md
@@ -12,7 +12,11 @@ avoid executing upstream tooling (supply-chain hardening).
 - **Upstream path**: `eli5/skills/eli5`
 - **Author**: Thariq Shihipar
 - **License**: MIT (see [LICENSE](./LICENSE); declared in the upstream plugin's
-  `.claude-plugin/plugin.json`, which is not itself vendored here)
+  `.claude-plugin/plugin.json`, which is not itself vendored here). The upstream
+  repo ships no standalone LICENSE file for this plugin (only the `"license":
+  "MIT"` SPDX identifier), so there is no upstream copyright year to match —
+  `LICENSE` here uses the retrieval year below and the author name from
+  `plugin.json`.
 - **Commit pinned**: `f4c9452f5ca091f1be7064d9faab1b001ea21645` (`main`)
 - **Retrieved**: 2026-08-22
 

--- a/skills/eli5/PROVENANCE.md
+++ b/skills/eli5/PROVENANCE.md
@@ -46,11 +46,16 @@ not by diffing against upstream.
 `SKILL.md`'s body ends with `Topic: $ARGUMENTS` — a slash-command style
 template variable from the upstream plugin's original packaging (it ships as
 a plugin whose `eli5` skill doubles as the `/eli5 <topic>` command target).
-Kept verbatim for fidelity; `$ARGUMENTS` is substituted by the invoking
-harness where supported, and otherwise reads as the literal topic prompt text
-typed after `/eli5`.
+Kept verbatim for fidelity. Claude Code substitutes `$ARGUMENTS` with the
+text typed after `/eli5 <topic>`; a harness without that substitution has no
+topic fallback and leaves the literal `$ARGUMENTS` token in place.
 
 ## Updating
 
-Re-run the copy against a newer upstream commit and update the pinned commit /
-retrieval date above.
+Re-run the copy against a newer upstream commit, then:
+
+1. Update the pinned commit, retrieval date, and the audit URL above (the
+   commit hash is embedded in it too).
+2. Run `node scripts/rulesync-sync.mjs` to regenerate the `.claude/skills/`
+   and `.agents/skills/` mirrors.
+3. Run `node scripts/rulesync-sync.mjs --check` to verify they're in sync.

--- a/skills/eli5/SKILL.md
+++ b/skills/eli5/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: eli5
+description: Explain a topic like I'm a 5 year old. Use when the user types /eli5 <topic> or asks for a dead-simple picture explainer of how something works.
+---
+
+# eli5
+
+Explain like I'm someone who knows nothing about this topic, using a HTML artifact with big pictures and few words.
+
+Topic: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds `skills/eli5/` — a byte-for-byte vendored copy of the `eli5` skill from [`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community/blob/main/eli5/skills/eli5/SKILL.md) (`/eli5 <topic>`: explain a topic as a dead-simple HTML picture explainer)
- This repo's README documents a default of **not** vendoring third-party skills (consumers should `rulesync fetch` upstream directly), with an explicit copy-in exception when source + license are retained in the skill directory. Since this was requested by name, it's treated as that explicit exception: `skills/eli5/SKILL.md` is pinned to upstream commit `f4c9452`, with `LICENSE` (MIT, per the upstream plugin's declared license) and `PROVENANCE.md` documenting source/audit instructions, following the same pattern as `skills/setup-matt-pocock-skills/`
- Regenerated the rulesync mirrors (`.claude/skills/eli5/`, `.agents/skills/eli5/`) via `node scripts/rulesync-sync.mjs`; `--check` passes

## Test plan

- [x] `node scripts/rulesync-sync.mjs --check` → `up to date`
- [x] Diffed `skills/eli5/SKILL.md` against the pinned upstream raw URL → identical


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmvaiS15z5rMyBquVQufM1)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - トピックを初心者向けに、HTML形式の大きな図と簡潔な文章で説明する「eli5」スキルを追加しました。
  - `/eli5 <トピック>`形式の依頼や、簡単な図解説明に対応します。

- **ドキュメント**
  - スキルの出典、ライセンス、取得情報、検証方法、更新手順を記録しました。
  - MITライセンス全文を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->