### PR TITLE
Retro fixes: F9 gate-heartbeat denominator, F10 transcript attribution, F11 defer regex, F17 review-response-gate

### DIFF
--- a/.agents/skills/retro/scripts/retro_scan.py
+++ b/.agents/skills/retro/scripts/retro_scan.py
@@ -641,28 +641,38 @@ def scan_prs(pr_numbers, repo_arg):
 # reference the PR (by number/URL) or its head branch, or the run aborts.
 def verify_transcript_attribution(files, pr_numbers, branches):
     """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
-    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
+    right boundary so "#1050" is not evidence for PR 105) or one of
+    `branches.values()`
     (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
-    needles = set()
-    for n in pr_numbers:
-        needles.add(f"#{n}")
-        needles.add(f"/pull/{n}")
-    for b in branches.values():
-        if b:
-            needles.add(b)
-    if not needles:
-        return
+    # PR #115 review (Devin + CodeRabbit): plain substring needles ("#105",
+    # "/pull/105") also matched inside a longer number, so a transcript that
+    # only ever mentions #1050 satisfied the check for PR 105 — exactly the
+    # misattribution this gate exists to stop. The numeric forms therefore
+    # require a non-digit right boundary ("#" / "/pull/" already supplies the
+    # left one). Branch names stay plain substrings: they are free text, not
+    # numeric prefixes of each other.
+    pr_patterns = [
+        re.compile(rf"(?:#|/pull/){n}(?!\d)")
+        for n in sorted({int(x) for x in pr_numbers})
+    ]
+    branch_needles = {b for b in branches.values() if b}
     for f in files:
         try:
+            # Streamed line by line rather than read() in full: transcripts are
+            # JSONL and can be very large, and no needle contains a newline, so
+            # a per-line scan is equivalent (CodeRabbit, PR #115).
             with open(f, encoding="utf-8", errors="replace") as fh:
-                content = fh.read()
+                for line in fh:
+                    if any(p.search(line) for p in pr_patterns):
+                        return
+                    if any(b in line for b in branch_needles):
+                        return
         except OSError:
             continue
-        if any(needle in content for needle in needles):
-            return
     pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
     branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
     sys.exit(

--- a/.agents/skills/retro/scripts/retro_scan.py
+++ b/.agents/skills/retro/scripts/retro_scan.py
@@ -649,7 +649,8 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
     right boundary so "#1050" is not evidence for PR 105) or one of
     `branches.values()`
-    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    (the PRs' head branch names, from scan_prs(), matched literally between
+    ref-name boundaries). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
@@ -658,13 +659,22 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # only ever mentions #1050 satisfied the check for PR 105 — exactly the
     # misattribution this gate exists to stop. The numeric forms therefore
     # require a non-digit right boundary ("#" / "/pull/" already supplies the
-    # left one). Branch names stay plain substrings: they are free text, not
-    # numeric prefixes of each other.
+    # left one). Branch names get the same treatment (CodeRabbit, second
+    # round): "feature/fixes" is not evidence for head branch "feature/fix",
+    # and "hotfix" is not evidence for "fix". They are matched literally
+    # (re.escape — a branch name is free text, not a pattern) between ref-name
+    # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
+    # different branch, while the left boundary allows "/" so a remote-prefixed
+    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
+    # because it is far more often sentence punctuation than part of a ref.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
-    branch_needles = {b for b in branches.values() if b}
+    branch_patterns = [
+        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        for b in sorted({b for b in branches.values() if b})
+    ]
     for f in files:
         try:
             # Streamed line by line rather than read() in full: transcripts are
@@ -674,7 +684,7 @@ def verify_transcript_attribution(files, pr_numbers, branches):
                 for line in fh:
                     if any(p.search(line) for p in pr_patterns):
                         return
-                    if any(b in line for b in branch_needles):
+                    if any(p.search(line) for p in branch_patterns):
                         return
         except OSError:
             continue

--- a/.agents/skills/retro/scripts/retro_scan.py
+++ b/.agents/skills/retro/scripts/retro_scan.py
@@ -665,14 +665,21 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # (re.escape — a branch name is free text, not a pattern) between ref-name
     # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
     # different branch, while the left boundary allows "/" so a remote-prefixed
-    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
-    # because it is far more often sentence punctuation than part of a ref.
+    # mention ("origin/feature/fix") still counts. "." is a legal ref character
+    # but in a transcript it is usually sentence punctuation, so it ends the
+    # ref only when what sits on the far side of it is not ref-name material:
+    # "on feature/fix." counts, "feature/fix.next" and "feature.fix" (both
+    # different branches) do not.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
     branch_patterns = [
-        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        re.compile(
+            rf"(?<![0-9A-Za-z_-])(?<![0-9A-Za-z_-]\.)"
+            rf"{re.escape(b)}"
+            rf"(?![0-9A-Za-z_/-])(?!\.[0-9A-Za-z_/-])"
+        )
         for b in sorted({b for b in branches.values() if b})
     ]
     for f in files:

--- a/.agents/skills/retro/scripts/retro_scan.py
+++ b/.agents/skills/retro/scripts/retro_scan.py
@@ -408,7 +408,25 @@ def render_table(rows):
 _FIXED_RE = re.compile(r"fixed\s+in\s+`?[0-9a-f]{7,40}\b", re.I)
 _PUSHBACK_RE = re.compile(
     r"maintainer\s*判断|self-resolve\s*しません|pushback", re.I)
-_ISSUE_REF_RE = re.compile(r"/issues/\d+|\bissues?\s+#\d+", re.I)
+# F11: the original pattern required the literal word "issue(s)" immediately
+# before "#NNN", so defer replies written as "Tracked in #114" / "Deferred to
+# #113" (no "issue" word, no /issues/ URL) matched nothing and the thread fell
+# through to UNTERMINATED even though it had a real terminal defer reply.
+# Widened to also match "#NNN" co-occurring with a defer/reference context
+# word (tracked/deferred/follow-up/see/ref/→) within a short window directly
+# before it — proximity-bound so a stray "#123" elsewhere in the reply (a
+# cross-referenced PR number, a code-comment ticket number) does not
+# false-positive just because the reply separately contains defer wording
+# (_DEFER_RE is checked independently over the whole reply by classify_thread;
+# only this proximity requirement is what keeps overmatching bounded).
+_ISSUE_REF_RE = re.compile(
+    r"/issues/\d+"
+    r"|\bissues?\s+#\d+"
+    r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
+    r"[^\n#]{0,20}#\d+"
+    r"|→\s*#\d+",
+    re.I,
+)
 _DEFER_RE = re.compile(r"defer|follow[- ]?up|後続|別途|追跡|track", re.I)
 # Tradeoff: a fix reply that merely cross-references another thread
 # (#discussion_r...) is misread as DUPLICATE — accepted for this pre-read;
@@ -461,6 +479,7 @@ _THREADS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
+      headRefName
       reviewThreads(first: 50, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
@@ -537,14 +556,19 @@ def _graphql(query, fields):
 
 
 def fetch_review_threads(owner, name, number):
-    """All review threads of one PR, comments fully paginated per thread."""
+    """All review threads of one PR (comments fully paginated per thread),
+    plus the PR's head branch name — used by verify_transcript_attribution()
+    to confirm a transcript actually belongs to this PR's session."""
     threads, cursor = [], None
+    head_ref_name = None
     for _ in range(_MAX_PAGES):
         data = _graphql(_THREADS_QUERY, {"owner": owner, "name": name,
                                          "number": number, "cursor": cursor})
         pr = (data.get("repository") or {}).get("pullRequest")
         if pr is None:
             sys.exit(f"PR #{number} not found in {owner}/{name}")
+        if head_ref_name is None:
+            head_ref_name = pr.get("headRefName")
         conn = pr["reviewThreads"]
         for node in conn["nodes"]:
             bodies = [c.get("body") for c in node["comments"]["nodes"]]
@@ -568,7 +592,7 @@ def fetch_review_threads(owner, name, number):
                             "resolved": bool(node["isResolved"]),
                             "bodies": bodies})
         if not conn["pageInfo"]["hasNextPage"]:
-            return threads
+            return threads, head_ref_name
         cursor = conn["pageInfo"]["endCursor"]
     sys.exit(f"PR #{number}: thread pagination exceeded {_MAX_PAGES} pages")
 
@@ -587,9 +611,12 @@ def scan_prs(pr_numbers, repo_arg):
     repo = resolve_repo(repo_arg)
     owner, name = repo.split("/", 1)
     prs = {}
+    branches = {}
     for number in sorted(set(pr_numbers)):
         threads = []
-        for node in fetch_review_threads(owner, name, number):
+        nodes, head_ref_name = fetch_review_threads(owner, name, number)
+        branches[str(number)] = head_ref_name
+        for node in nodes:
             # path is API-derived but still sanitized before the output fork —
             # same contract as summary (--json must not pass ANSI/C0 through).
             path = strip_controls(node["path"])
@@ -602,7 +629,50 @@ def scan_prs(pr_numbers, repo_arg):
                 "resolved": node["resolved"],
             })
         prs[str(number)] = threads
-    return {"repo": repo, "prs": prs}
+    return {"repo": repo, "prs": prs, "branches": branches}
+
+
+# F10: PR-scoped analysis previously trusted whatever transcript(s) were
+# selected (often via the --latest fallback) without ever checking that the
+# transcript actually belongs to the session that produced the PR under
+# review — this caused a real misattribution where retro analyzed an
+# unrelated session. verify_transcript_attribution() is the fail-closed check:
+# when --pr is combined with a transcript scan, at least one scanned file must
+# reference the PR (by number/URL) or its head branch, or the run aborts.
+def verify_transcript_attribution(files, pr_numbers, branches):
+    """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
+    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    empty (transcript-only scans are unaffected)."""
+    if not pr_numbers:
+        return
+    needles = set()
+    for n in pr_numbers:
+        needles.add(f"#{n}")
+        needles.add(f"/pull/{n}")
+    for b in branches.values():
+        if b:
+            needles.add(b)
+    if not needles:
+        return
+    for f in files:
+        try:
+            with open(f, encoding="utf-8", errors="replace") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        if any(needle in content for needle in needles):
+            return
+    pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
+    branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
+    sys.exit(
+        f"TRANSCRIPT_MISMATCH: none of the {len(files)} scanned transcript(s) "
+        f"mention PR {pr_list} (checked for the PR number/URL and head "
+        f"branch(es) {branch_list}) — the selected transcript(s) likely do "
+        "not belong to the session that produced this PR. Pass the correct "
+        "--transcript explicitly instead of relying on --latest, or drop "
+        "--pr if this scan is not meant to be PR-scoped."
+    )
 
 
 def render_pr_report(data):
@@ -734,6 +804,9 @@ def main():
     # GraphQL calls spend API rate limit (r3695744834).
     if args.pr:
         pr_data = scan_prs(args.pr, args.repo)
+        # F10: fail closed before the (expensive) duckdb scan runs if none of
+        # the selected transcripts actually belong to the PR(s) under review.
+        verify_transcript_attribution(files, args.pr, pr_data["branches"])
 
     try:
         import duckdb

--- a/.agents/skills/retro/scripts/retro_scan.py
+++ b/.agents/skills/retro/scripts/retro_scan.py
@@ -423,7 +423,12 @@ _ISSUE_REF_RE = re.compile(
     r"/issues/\d+"
     r"|\bissues?\s+#\d+"
     r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
-    r"[^\n#]{0,20}#\d+"
+    # The gap may not contain an explicit "PR" label right before the number:
+    # "Tracked in PR #114" / "see PR #123" cross-reference a pull request, not
+    # a follow-up issue, and counting them let a defer reply claim a tracking
+    # issue that does not exist (PR #115 review, Devin). Bare "#NNN" after the
+    # context word — the form F11 widened this regex for — still matches.
+    r"(?:(?![Pp][Rr]\s*#)[^\n#]){0,20}#\d+"
     r"|→\s*#\d+",
     re.I,
 )

--- a/.claude/skills/retro/scripts/retro_scan.py
+++ b/.claude/skills/retro/scripts/retro_scan.py
@@ -641,28 +641,38 @@ def scan_prs(pr_numbers, repo_arg):
 # reference the PR (by number/URL) or its head branch, or the run aborts.
 def verify_transcript_attribution(files, pr_numbers, branches):
     """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
-    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
+    right boundary so "#1050" is not evidence for PR 105) or one of
+    `branches.values()`
     (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
-    needles = set()
-    for n in pr_numbers:
-        needles.add(f"#{n}")
-        needles.add(f"/pull/{n}")
-    for b in branches.values():
-        if b:
-            needles.add(b)
-    if not needles:
-        return
+    # PR #115 review (Devin + CodeRabbit): plain substring needles ("#105",
+    # "/pull/105") also matched inside a longer number, so a transcript that
+    # only ever mentions #1050 satisfied the check for PR 105 — exactly the
+    # misattribution this gate exists to stop. The numeric forms therefore
+    # require a non-digit right boundary ("#" / "/pull/" already supplies the
+    # left one). Branch names stay plain substrings: they are free text, not
+    # numeric prefixes of each other.
+    pr_patterns = [
+        re.compile(rf"(?:#|/pull/){n}(?!\d)")
+        for n in sorted({int(x) for x in pr_numbers})
+    ]
+    branch_needles = {b for b in branches.values() if b}
     for f in files:
         try:
+            # Streamed line by line rather than read() in full: transcripts are
+            # JSONL and can be very large, and no needle contains a newline, so
+            # a per-line scan is equivalent (CodeRabbit, PR #115).
             with open(f, encoding="utf-8", errors="replace") as fh:
-                content = fh.read()
+                for line in fh:
+                    if any(p.search(line) for p in pr_patterns):
+                        return
+                    if any(b in line for b in branch_needles):
+                        return
         except OSError:
             continue
-        if any(needle in content for needle in needles):
-            return
     pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
     branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
     sys.exit(

--- a/.claude/skills/retro/scripts/retro_scan.py
+++ b/.claude/skills/retro/scripts/retro_scan.py
@@ -649,7 +649,8 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
     right boundary so "#1050" is not evidence for PR 105) or one of
     `branches.values()`
-    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    (the PRs' head branch names, from scan_prs(), matched literally between
+    ref-name boundaries). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
@@ -658,13 +659,22 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # only ever mentions #1050 satisfied the check for PR 105 — exactly the
     # misattribution this gate exists to stop. The numeric forms therefore
     # require a non-digit right boundary ("#" / "/pull/" already supplies the
-    # left one). Branch names stay plain substrings: they are free text, not
-    # numeric prefixes of each other.
+    # left one). Branch names get the same treatment (CodeRabbit, second
+    # round): "feature/fixes" is not evidence for head branch "feature/fix",
+    # and "hotfix" is not evidence for "fix". They are matched literally
+    # (re.escape — a branch name is free text, not a pattern) between ref-name
+    # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
+    # different branch, while the left boundary allows "/" so a remote-prefixed
+    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
+    # because it is far more often sentence punctuation than part of a ref.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
-    branch_needles = {b for b in branches.values() if b}
+    branch_patterns = [
+        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        for b in sorted({b for b in branches.values() if b})
+    ]
     for f in files:
         try:
             # Streamed line by line rather than read() in full: transcripts are
@@ -674,7 +684,7 @@ def verify_transcript_attribution(files, pr_numbers, branches):
                 for line in fh:
                     if any(p.search(line) for p in pr_patterns):
                         return
-                    if any(b in line for b in branch_needles):
+                    if any(p.search(line) for p in branch_patterns):
                         return
         except OSError:
             continue

--- a/.claude/skills/retro/scripts/retro_scan.py
+++ b/.claude/skills/retro/scripts/retro_scan.py
@@ -665,14 +665,21 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # (re.escape — a branch name is free text, not a pattern) between ref-name
     # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
     # different branch, while the left boundary allows "/" so a remote-prefixed
-    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
-    # because it is far more often sentence punctuation than part of a ref.
+    # mention ("origin/feature/fix") still counts. "." is a legal ref character
+    # but in a transcript it is usually sentence punctuation, so it ends the
+    # ref only when what sits on the far side of it is not ref-name material:
+    # "on feature/fix." counts, "feature/fix.next" and "feature.fix" (both
+    # different branches) do not.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
     branch_patterns = [
-        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        re.compile(
+            rf"(?<![0-9A-Za-z_-])(?<![0-9A-Za-z_-]\.)"
+            rf"{re.escape(b)}"
+            rf"(?![0-9A-Za-z_/-])(?!\.[0-9A-Za-z_/-])"
+        )
         for b in sorted({b for b in branches.values() if b})
     ]
     for f in files:

--- a/.claude/skills/retro/scripts/retro_scan.py
+++ b/.claude/skills/retro/scripts/retro_scan.py
@@ -408,7 +408,25 @@ def render_table(rows):
 _FIXED_RE = re.compile(r"fixed\s+in\s+`?[0-9a-f]{7,40}\b", re.I)
 _PUSHBACK_RE = re.compile(
     r"maintainer\s*判断|self-resolve\s*しません|pushback", re.I)
-_ISSUE_REF_RE = re.compile(r"/issues/\d+|\bissues?\s+#\d+", re.I)
+# F11: the original pattern required the literal word "issue(s)" immediately
+# before "#NNN", so defer replies written as "Tracked in #114" / "Deferred to
+# #113" (no "issue" word, no /issues/ URL) matched nothing and the thread fell
+# through to UNTERMINATED even though it had a real terminal defer reply.
+# Widened to also match "#NNN" co-occurring with a defer/reference context
+# word (tracked/deferred/follow-up/see/ref/→) within a short window directly
+# before it — proximity-bound so a stray "#123" elsewhere in the reply (a
+# cross-referenced PR number, a code-comment ticket number) does not
+# false-positive just because the reply separately contains defer wording
+# (_DEFER_RE is checked independently over the whole reply by classify_thread;
+# only this proximity requirement is what keeps overmatching bounded).
+_ISSUE_REF_RE = re.compile(
+    r"/issues/\d+"
+    r"|\bissues?\s+#\d+"
+    r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
+    r"[^\n#]{0,20}#\d+"
+    r"|→\s*#\d+",
+    re.I,
+)
 _DEFER_RE = re.compile(r"defer|follow[- ]?up|後続|別途|追跡|track", re.I)
 # Tradeoff: a fix reply that merely cross-references another thread
 # (#discussion_r...) is misread as DUPLICATE — accepted for this pre-read;
@@ -461,6 +479,7 @@ _THREADS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
+      headRefName
       reviewThreads(first: 50, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
@@ -537,14 +556,19 @@ def _graphql(query, fields):
 
 
 def fetch_review_threads(owner, name, number):
-    """All review threads of one PR, comments fully paginated per thread."""
+    """All review threads of one PR (comments fully paginated per thread),
+    plus the PR's head branch name — used by verify_transcript_attribution()
+    to confirm a transcript actually belongs to this PR's session."""
     threads, cursor = [], None
+    head_ref_name = None
     for _ in range(_MAX_PAGES):
         data = _graphql(_THREADS_QUERY, {"owner": owner, "name": name,
                                          "number": number, "cursor": cursor})
         pr = (data.get("repository") or {}).get("pullRequest")
         if pr is None:
             sys.exit(f"PR #{number} not found in {owner}/{name}")
+        if head_ref_name is None:
+            head_ref_name = pr.get("headRefName")
         conn = pr["reviewThreads"]
         for node in conn["nodes"]:
             bodies = [c.get("body") for c in node["comments"]["nodes"]]
@@ -568,7 +592,7 @@ def fetch_review_threads(owner, name, number):
                             "resolved": bool(node["isResolved"]),
                             "bodies": bodies})
         if not conn["pageInfo"]["hasNextPage"]:
-            return threads
+            return threads, head_ref_name
         cursor = conn["pageInfo"]["endCursor"]
     sys.exit(f"PR #{number}: thread pagination exceeded {_MAX_PAGES} pages")
 
@@ -587,9 +611,12 @@ def scan_prs(pr_numbers, repo_arg):
     repo = resolve_repo(repo_arg)
     owner, name = repo.split("/", 1)
     prs = {}
+    branches = {}
     for number in sorted(set(pr_numbers)):
         threads = []
-        for node in fetch_review_threads(owner, name, number):
+        nodes, head_ref_name = fetch_review_threads(owner, name, number)
+        branches[str(number)] = head_ref_name
+        for node in nodes:
             # path is API-derived but still sanitized before the output fork —
             # same contract as summary (--json must not pass ANSI/C0 through).
             path = strip_controls(node["path"])
@@ -602,7 +629,50 @@ def scan_prs(pr_numbers, repo_arg):
                 "resolved": node["resolved"],
             })
         prs[str(number)] = threads
-    return {"repo": repo, "prs": prs}
+    return {"repo": repo, "prs": prs, "branches": branches}
+
+
+# F10: PR-scoped analysis previously trusted whatever transcript(s) were
+# selected (often via the --latest fallback) without ever checking that the
+# transcript actually belongs to the session that produced the PR under
+# review — this caused a real misattribution where retro analyzed an
+# unrelated session. verify_transcript_attribution() is the fail-closed check:
+# when --pr is combined with a transcript scan, at least one scanned file must
+# reference the PR (by number/URL) or its head branch, or the run aborts.
+def verify_transcript_attribution(files, pr_numbers, branches):
+    """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
+    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    empty (transcript-only scans are unaffected)."""
+    if not pr_numbers:
+        return
+    needles = set()
+    for n in pr_numbers:
+        needles.add(f"#{n}")
+        needles.add(f"/pull/{n}")
+    for b in branches.values():
+        if b:
+            needles.add(b)
+    if not needles:
+        return
+    for f in files:
+        try:
+            with open(f, encoding="utf-8", errors="replace") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        if any(needle in content for needle in needles):
+            return
+    pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
+    branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
+    sys.exit(
+        f"TRANSCRIPT_MISMATCH: none of the {len(files)} scanned transcript(s) "
+        f"mention PR {pr_list} (checked for the PR number/URL and head "
+        f"branch(es) {branch_list}) — the selected transcript(s) likely do "
+        "not belong to the session that produced this PR. Pass the correct "
+        "--transcript explicitly instead of relying on --latest, or drop "
+        "--pr if this scan is not meant to be PR-scoped."
+    )
 
 
 def render_pr_report(data):
@@ -734,6 +804,9 @@ def main():
     # GraphQL calls spend API rate limit (r3695744834).
     if args.pr:
         pr_data = scan_prs(args.pr, args.repo)
+        # F10: fail closed before the (expensive) duckdb scan runs if none of
+        # the selected transcripts actually belong to the PR(s) under review.
+        verify_transcript_attribution(files, args.pr, pr_data["branches"])
 
     try:
         import duckdb

--- a/.claude/skills/retro/scripts/retro_scan.py
+++ b/.claude/skills/retro/scripts/retro_scan.py
@@ -423,7 +423,12 @@ _ISSUE_REF_RE = re.compile(
     r"/issues/\d+"
     r"|\bissues?\s+#\d+"
     r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
-    r"[^\n#]{0,20}#\d+"
+    # The gap may not contain an explicit "PR" label right before the number:
+    # "Tracked in PR #114" / "see PR #123" cross-reference a pull request, not
+    # a follow-up issue, and counting them let a defer reply claim a tracking
+    # issue that does not exist (PR #115 review, Devin). Bare "#NNN" after the
+    # context word — the form F11 widened this regex for — still matches.
+    r"(?:(?![Pp][Rr]\s*#)[^\n#]){0,20}#\d+"
     r"|→\s*#\d+",
     re.I,
 )

--- a/.github/workflows/gate-heartbeat.yml
+++ b/.github/workflows/gate-heartbeat.yml
@@ -130,8 +130,15 @@ jobs:
                 and ((.repo // null) == $repo)
               ))) as $win
             | {
-                merged_prs: ($win | map(select(.event=="pr_closed" and .outcome=="merged")) | length),
-                attempted_prs: ($win | map(select(.event=="pr_closed")) | length),
+                # PR #115 review (CodeRabbit): loop-metrics writes one
+                # pr_closed record per close event, so a PR that is reopened
+                # and closed again (or a re-run of the emitting workflow)
+                # contributes several records for the same PR. Both PR counts
+                # are therefore taken over distinct .pr values — a record
+                # without .pr collapses into a single "unknown" bucket rather
+                # than inflating the denominator that gates the alert.
+                merged_prs: ($win | map(select(.event=="pr_closed" and .outcome=="merged") | .pr) | unique | length),
+                attempted_prs: ($win | map(select(.event=="pr_closed") | .pr) | unique | length),
                 gate_events: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate")) | length),
                 gate_blocks: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate" and .result_subtype=="block")) | length)
               }

--- a/.github/workflows/gate-heartbeat.yml
+++ b/.github/workflows/gate-heartbeat.yml
@@ -38,10 +38,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WINDOW_DAYS: ${{ inputs.window_days || '14' }}
-      # 閾値の根拠: merged PR が 1 件だけだと「たまたまテスト差分を含まない変更
-      # だった」可能性が残り誤検知になりやすい。2 件以上 merge されてなお gate
-      # イベントが 0 件なら偶然では説明しづらく、不発を疑うのに十分な件数と判断した。
-      MIN_MERGED_PRS: '2'
+      # 閾値の根拠: PR (merge/close いずれの決着でも) が 1 件だけだと「たまたま
+      # テスト差分を含まない変更だった」可能性が残り誤検知になりやすい。2 件以上
+      # 決着してなお gate イベントが 0 件なら偶然では説明しづらく、不発を疑うのに
+      # 十分な件数と判断した。
+      #
+      # F9: 分母は「merge に成功した PR (merged_prs)」ではなく「決着した PR 全体
+      # (attempted_prs = merged + closed-without-merge)」にする。merged_prs だけを
+      # 分母にすると、CI/レビューが詰まって merge が 0 件の失敗窓 — 最も観測が
+      # 必要な状況 — でこの条件が真にならず、sensor 自体が沈黙してしまう
+      # (merged_prs=0 の時点で `merged_prs >= MIN` が常に偽になるため)。
+      # attempted_prs は既にこのワークフローが loop-metrics.yml 由来の pr_closed
+      # イベント (outcome が merged/closed のどちらでも emit される) から集計できる
+      # 値を使うだけで、新しいイベント種別は追加しない。
+      MIN_ATTEMPTED_PRS: '2'
       LOOP_OPS_REPO: kanade0404/loop-ops
       ISSUE_TITLE: '[gate-heartbeat] test-mutation-gate が沈黙しています'
     steps:
@@ -121,17 +131,23 @@ jobs:
               ))) as $win
             | {
                 merged_prs: ($win | map(select(.event=="pr_closed" and .outcome=="merged")) | length),
+                attempted_prs: ($win | map(select(.event=="pr_closed")) | length),
                 gate_events: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate")) | length),
                 gate_blocks: ($win | map(select(.event=="agent_run" and .phase=="test-mutation-gate" and .result_subtype=="block")) | length)
               }
           ')
 
           merged_prs=$(echo "$RESULT" | jq '.merged_prs')
+          attempted_prs=$(echo "$RESULT" | jq '.attempted_prs')
           gate_events=$(echo "$RESULT" | jq '.gate_events')
           gate_blocks=$(echo "$RESULT" | jq '.gate_blocks')
 
           is_alert=false
-          if [ "$merged_prs" -ge "$MIN_MERGED_PRS" ] && [ "$gate_events" -eq 0 ]; then
+          # F9: attempted_prs (merged + closed-without-merge) is the
+          # denominator, not merged_prs alone — a failure window where
+          # nothing merges (merged_prs=0) is exactly the window that most
+          # needs this sensor to still fire.
+          if [ "$attempted_prs" -ge "$MIN_ATTEMPTED_PRS" ] && [ "$gate_events" -eq 0 ]; then
             is_alert=true
           fi
 
@@ -144,10 +160,11 @@ jobs:
             echo "## gate-heartbeat 集計結果"
             echo ""
             echo "- window: 直近 ${WINDOW_DAYS} 日 (対象月: ${CUR_MONTH} + ${PREV_MONTH})"
-            echo "- 閾値: merged_prs >= ${MIN_MERGED_PRS} かつ gate_events == 0 でアラート"
+            echo "- 閾値: attempted_prs >= ${MIN_ATTEMPTED_PRS} かつ gate_events == 0 でアラート"
             echo ""
             echo "| 指標 | 値 |"
             echo "|---|---|"
+            echo "| attempted_prs (merged + closed-without-merge) | ${attempted_prs} |"
             echo "| merged_prs | ${merged_prs} |"
             echo "| gate_events (test-mutation-gate) | ${gate_events} |"
             echo "| gate_blocks | ${gate_blocks} |"
@@ -165,6 +182,7 @@ jobs:
 
           {
             echo "merged_prs=${merged_prs}"
+            echo "attempted_prs=${attempted_prs}"
             echo "gate_events=${gate_events}"
             echo "gate_blocks=${gate_blocks}"
             echo "is_alert=${is_alert}"
@@ -178,6 +196,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           MERGED_PRS: ${{ steps.aggregate.outputs.merged_prs }}
+          ATTEMPTED_PRS: ${{ steps.aggregate.outputs.attempted_prs }}
           GATE_EVENTS: ${{ steps.aggregate.outputs.gate_events }}
           GATE_BLOCKS: ${{ steps.aggregate.outputs.gate_blocks }}
           CUR_MONTH: ${{ steps.aggregate.outputs.cur_month }}
@@ -196,12 +215,16 @@ jobs:
             echo ""
             echo "| 指標 | 値 |"
             echo "|---|---|"
+            echo "| attempted_prs (merged + closed-without-merge) | ${ATTEMPTED_PRS} |"
             echo "| merged_prs | ${MERGED_PRS} |"
             echo "| gate_events (test-mutation-gate) | ${GATE_EVENTS} |"
             echo "| gate_blocks | ${GATE_BLOCKS} |"
             echo ""
-            echo "merged PR が ${MIN_MERGED_PRS} 件以上あるのに、test-mutation-gate の agent_run"
-            echo "イベントが loop-ops (kanade0404/loop-ops) に 1 件も届いていません。"
+            echo "決着した PR (merge 成功 + merge されずに close) が ${MIN_ATTEMPTED_PRS} 件以上"
+            echo "あるのに、test-mutation-gate の agent_run イベントが loop-ops"
+            echo "(kanade0404/loop-ops) に 1 件も届いていません。merged_prs が 0 件でも"
+            echo "attempted_prs だけで閾値を満たしていればアラートします — merge が 0 件の"
+            echo "失敗窓こそ、この sensor が沈黙してはいけない状況だからです。"
             echo ""
             echo "## 考えられる原因"
             echo ""
@@ -212,8 +235,9 @@ jobs:
             echo ""
             echo "## 確認手順"
             echo ""
-            echo "1. 該当期間 (直近 ${WINDOW_DAYS} 日) に merge された PR に、実際にテストファイルの"
-            echo "   diff が含まれているか確認する (\`gh pr list --repo kanade0404/skills --state merged --search \"merged:>=<date>\"\`"
+            echo "1. 該当期間 (直近 ${WINDOW_DAYS} 日) に決着した PR (merge 成功 + merge されずに"
+            echo "   close されたもの) に、実際にテストファイルの diff が含まれているか確認する"
+            echo "   (\`gh pr list --repo kanade0404/skills --state closed --search \"closed:>=<date>\"\`"
             echo "   などで対象 PR を洗い出し、\`gh pr diff <number> --name-only\` でテストファイルの"
             echo "   有無を見る)。テスト変更を含む PR が無ければ gate 不発は正常。"
             echo "2. 開発マシン側の \`.cache/test-mutation-gate/gate-events.jsonl\` を確認し、"

--- a/.github/workflows/review-response-gate.yml
+++ b/.github/workflows/review-response-gate.yml
@@ -43,6 +43,19 @@ on:
   # レビューコメントで再評価される。required check として運用する場合、この
   # ラグは許容する前提 (merge 前に最新の再評価が走っていることは
   # branch protection 側の「最新コミットに対する green」要求で担保される)。
+  #
+  # ただし「最後の 1 件を resolve して閉じた」直後は、新しい push も新しい
+  # レビューコメントも発生しないまま fail が残りうる (PR #115 review, Devin)。
+  # その場合の逃げ道として workflow_dispatch を用意する:
+  #   gh workflow run review-response-gate.yml -f pr=<PR番号>
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: >-
+          再評価する PR 番号 (thread を resolve しただけでは自動再走しないため
+          の手動トリガー)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -56,7 +69,15 @@ jobs:
       - name: Fail on unresolved bot review threads with zero replies
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+          # このジョブは checkout しない (gh api だけで完結する設計) ため、
+          # runner の workspace は git リポジトリではない。`gh repo view` は
+          # 引数も GH_REPO も無いとカレントディレクトリの git remote から
+          # リポジトリを解決するので、そこで
+          # `fatal: not a git repository` で落ちる (PR #115 review,
+          # CodeRabbit — 実際にこの PR の初回実行がこれで fail した)。
+          # owner/name は Actions が必ず提供する github.repository から取る。
+          REPO: ${{ github.repository }}
         run: |
           # shellcheck disable=SC2016
           # (jq programs below use jq's own `$var` / `\(...)` interpolation,
@@ -74,8 +95,12 @@ jobs:
             exit 1
           fi
 
-          owner=$(gh repo view --json owner --jq '.owner.login')
-          name=$(gh repo view --json name --jq '.name')
+          if [ -z "${REPO:-}" ] || [ "${REPO#*/}" = "$REPO" ]; then
+            echo "::error::REPO must be owner/name (got '${REPO:-}')"
+            exit 1
+          fi
+          owner="${REPO%%/*}"
+          name="${REPO##*/}"
 
           # Full cursor-paginated fetch of review threads. comments(first: 100)
           # is enough to decide "has any reply" (root + >=1 more) without
@@ -131,6 +156,15 @@ jobs:
           # Bot detection mirrors skills/pr-review-respond/scripts/fetch_threads.sh's
           # vendor() convention (login prefix/substring), plus the GraphQL Actor
           # __typename == "Bot" signal as the primary check.
+          #
+          # PR #115 review (Devin): "has a second comment" is too weak as the
+          # response test — a reviewer bot's own follow-up (or another review
+          # bot chiming in) cleared the gate while the finding stayed
+          # unanswered by the PR side. A reply only counts when it comes from
+          # the PR side: a human, or the author's own automation
+          # (github-actions[bot] / claude[bot], which is how a headless
+          # pr-review-respond run posts). Review bots (CodeRabbit / Devin /
+          # Copilot, and any other Bot actor) do not count as responders.
           failing=$(jq -c '
             def is_bot(a):
               (a.__typename == "Bot")
@@ -140,11 +174,15 @@ jobs:
                     or ($l | startswith("devin")) or ($l | contains("devin-ai"))
                     or ($l | startswith("copilot")) or ($l | contains("copilot-pull-request-reviewer"))
                     or ($l | startswith("github-actions")));
+            def is_author_agent(a):
+              (a.login // "" | ascii_downcase) as $l
+              | ($l | startswith("github-actions")) or ($l | startswith("claude"));
+            def is_responder(a): (is_bot(a) | not) or is_author_agent(a);
             [ .[]
               | select(.isResolved == false)
               | select((.comments.nodes | length) > 0)
               | select(is_bot(.comments.nodes[0].author))
-              | select((.comments.nodes | length) == 1)
+              | select([.comments.nodes[1:][] | select(is_responder(.author))] | length == 0)
               | {
                   path: (.path // "(no path)"),
                   author: (.comments.nodes[0].author.login // "(unknown)"),

--- a/.github/workflows/review-response-gate.yml
+++ b/.github/workflows/review-response-gate.yml
@@ -1,0 +1,177 @@
+# F17 (retro finding): PR #105 で Devin bot の BUG 指摘 4 件が返信 0 のまま
+# マージされた — pr-review-respond skill が起動されなかった/未完走のセッションが
+# あっても、それを検知して止める仕組みが無かった。この workflow は「bot 起因の
+# unresolved review thread に 1 件もリプライが無い」状態を fail させる required
+# check 候補で、pr-review-respond の実行漏れを機械的にブロックする最終防衛線。
+#
+# 判定方針:
+#   - resolved なスレッドは対象外 (対応済みとみなす)。
+#   - bot 起因 (CodeRabbit / Devin / Copilot 等) の unresolved スレッドのうち、
+#     リプライ (root コメント以外のコメント) が 1 件も無いものが 1 件でもあれば
+#     fail する。
+#   - リプライさえあれば内容は問わない — pushback (根拠付き反論で self-resolve
+#     しない、#111 のような意図的残置) も応答として有効。返信の妥当性判定は
+#     pr-review-respond / 人間レビュアーの役割であり、この gate は「無視されて
+#     いないか」だけを機械的に見る。
+#   - bot 判定は GraphQL Actor の __typename == "Bot" を主信号にしつつ、login
+#     パターン (coderabbit* / devin* / devin-ai / copilot* / *[bot] /
+#     github-actions*) も見る — pr-review-respond/pr-monitor の vendor 判定
+#     (skills/pr-review-respond/scripts/fetch_threads.sh) と同じ発想。
+#
+# なぜ actions/checkout が不要か: gh api だけで完結する自己完結設計 (gate-heartbeat.yml
+# と同じ判断) — このリポジトリのコードやスクリプトには依存しない。
+#
+# branch protection への required check 登録は行わない (人間の操作) — この
+# workflow を作るところまでが本 PR のスコープ。required check にするには GitHub
+# の Settings > Branches > Branch protection rules で対象ブランチのルールを開き、
+# "Require status checks to pass before merging" に `review-response-gate` を
+# 追加する (このジョブの `name:` と一致させてある)。
+name: review-response-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  # 注: GitHub のクラシック repository webhook には thread の resolve/unresolve
+  # を配信する `pull_request_review_thread` イベントがあるが、GitHub Actions の
+  # `on:` トリガーとしてはサポートされていない (2026-08 時点。actionlint も
+  # 未知イベントとして拒否する)。そのため「UI 上で resolve しただけ」の変化は
+  # このワークフローを即座には再起動しない — 次の push (synchronize) か新規
+  # レビューコメントで再評価される。required check として運用する場合、この
+  # ラグは許容する前提 (merge 前に最新の再評価が走っていることは
+  # branch protection 側の「最新コミットに対する green」要求で担保される)。
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: review-response-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on unresolved bot review threads with zero replies
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # shellcheck disable=SC2016
+          # (jq programs below use jq's own `$var` / `\(...)` interpolation,
+          # not shell expansion — this directive suppresses shellcheck's false
+          # positive on single-quoted `$l` inside the jq filter.)
+          set -euo pipefail
+
+          export NO_COLOR=1
+          export CLICOLOR_FORCE=0
+          unset GH_FORCE_TTY 2>/dev/null || true
+          export GH_PAGER=cat
+
+          if [ -z "${PR_NUMBER:-}" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::error::could not determine PR number from event payload"
+            exit 1
+          fi
+
+          owner=$(gh repo view --json owner --jq '.owner.login')
+          name=$(gh repo view --json name --jq '.name')
+
+          # Full cursor-paginated fetch of review threads. comments(first: 100)
+          # is enough to decide "has any reply" (root + >=1 more) without
+          # needing per-thread comment pagination — a thread with >100
+          # comments trivially already has replies.
+          threads_json='[]'
+          cursor=""
+          while :; do
+            args=(-f owner="$owner" -f name="$name" -F number="$PR_NUMBER")
+            if [ -n "$cursor" ]; then
+              args+=(-f cursor="$cursor")
+            fi
+            # shellcheck disable=SC2016
+            # The GraphQL document below uses GraphQL's own $owner/$name/
+            # $number/$cursor variable syntax inside a single-quoted string —
+            # deliberately not shell-expanded (values are bound via the -f/-F
+            # flags above).
+            resp=$(gh api graphql "${args[@]}" -f query='
+              query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 50, after: $cursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        isResolved
+                        path
+                        comments(first: 100) {
+                          pageInfo { hasNextPage }
+                          nodes {
+                            databaseId
+                            url
+                            author { login __typename }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }')
+            pr_node=$(jq -c '.data.repository.pullRequest' <<<"$resp")
+            if [ "$pr_node" = "null" ]; then
+              echo "::error::PR #$PR_NUMBER not found in $owner/$name"
+              exit 1
+            fi
+            threads_json=$(jq -c --argjson r "$resp" \
+              '. + $r.data.repository.pullRequest.reviewThreads.nodes' <<<"$threads_json")
+            hasNext=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$resp")
+            cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<<"$resp")
+            [ "$hasNext" = "true" ] || break
+          done
+
+          # Bot detection mirrors skills/pr-review-respond/scripts/fetch_threads.sh's
+          # vendor() convention (login prefix/substring), plus the GraphQL Actor
+          # __typename == "Bot" signal as the primary check.
+          failing=$(jq -c '
+            def is_bot(a):
+              (a.__typename == "Bot")
+              or ((a.login // "" | ascii_downcase) as $l
+                  | ($l | endswith("[bot]"))
+                    or ($l | startswith("coderabbit"))
+                    or ($l | startswith("devin")) or ($l | contains("devin-ai"))
+                    or ($l | startswith("copilot")) or ($l | contains("copilot-pull-request-reviewer"))
+                    or ($l | startswith("github-actions")));
+            [ .[]
+              | select(.isResolved == false)
+              | select((.comments.nodes | length) > 0)
+              | select(is_bot(.comments.nodes[0].author))
+              | select((.comments.nodes | length) == 1)
+              | {
+                  path: (.path // "(no path)"),
+                  author: (.comments.nodes[0].author.login // "(unknown)"),
+                  url: .comments.nodes[0].url
+                }
+            ]
+          ' <<<"$threads_json")
+
+          count=$(jq 'length' <<<"$failing")
+
+          {
+            echo "## review-response-gate"
+            echo ""
+            echo "bot 起因の unresolved review thread のうち、リプライが 1 件も無いもの: ${count} 件"
+            echo ""
+            if [ "$count" -gt 0 ]; then
+              echo "| author | path | url |"
+              echo "|---|---|---|"
+              jq -r '.[] | "| \(.author) | \(.path) | \(.url) |"' <<<"$failing"
+            else
+              echo "OK: bot 指摘で未応答のまま放置されているスレッドはありません。"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$count" -gt 0 ]; then
+            echo "::error::${count} unresolved bot review thread(s) have zero replies — respond (fix, defer, or reasoned pushback) before merging. See the job summary for the list, or run pr-review-respond."
+            exit 1
+          fi
+
+          echo "OK: no unresolved bot review thread is unanswered."

--- a/.github/workflows/review-response-gate.yml
+++ b/.github/workflows/review-response-gate.yml
@@ -46,16 +46,19 @@ on:
   #
   # ただし「最後の 1 件を resolve して閉じた」直後は、新しい push も新しい
   # レビューコメントも発生しないまま fail が残りうる (PR #115 review, Devin)。
-  # その場合の逃げ道として workflow_dispatch を用意する:
-  #   gh workflow run review-response-gate.yml -f pr=<PR番号>
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: >-
-          再評価する PR 番号 (thread を resolve しただけでは自動再走しないため
-          の手動トリガー)
-        required: true
-        type: string
+  # その場合の再走は、この check を作った run 自体を再実行する:
+  #   gh run rerun <run-id>          # または PR の Checks タブの "Re-run jobs"
+  # 元の pull_request イベントの payload ごと再生されるため、PR に紐づいた
+  # 同じ check run が更新される。workflow_dispatch は使わない — dispatch した
+  # run は PR の status check rollup に載らず、required check の fail を
+  # 解消できないため (PR #115 review, CodeRabbit)。
+
+# 同一 PR に対して synchronize とレビューコメント系イベントが重なると run が
+# 多重に走り、古い run が後から完了して新しい評価結果を上書きしうる
+# (PR #115 review, CodeRabbit)。PR 単位で直列化し、古い run は打ち切る。
+concurrency:
+  group: review-response-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -69,7 +72,7 @@ jobs:
       - name: Fail on unresolved bot review threads with zero replies
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           # このジョブは checkout しない (gh api だけで完結する設計) ため、
           # runner の workspace は git リポジトリではない。`gh repo view` は
           # 引数も GH_REPO も無いとカレントディレクトリの git remote から

--- a/skills/retro/scripts/retro_scan.py
+++ b/skills/retro/scripts/retro_scan.py
@@ -641,28 +641,38 @@ def scan_prs(pr_numbers, repo_arg):
 # reference the PR (by number/URL) or its head branch, or the run aborts.
 def verify_transcript_attribution(files, pr_numbers, branches):
     """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
-    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
+    right boundary so "#1050" is not evidence for PR 105) or one of
+    `branches.values()`
     (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
-    needles = set()
-    for n in pr_numbers:
-        needles.add(f"#{n}")
-        needles.add(f"/pull/{n}")
-    for b in branches.values():
-        if b:
-            needles.add(b)
-    if not needles:
-        return
+    # PR #115 review (Devin + CodeRabbit): plain substring needles ("#105",
+    # "/pull/105") also matched inside a longer number, so a transcript that
+    # only ever mentions #1050 satisfied the check for PR 105 — exactly the
+    # misattribution this gate exists to stop. The numeric forms therefore
+    # require a non-digit right boundary ("#" / "/pull/" already supplies the
+    # left one). Branch names stay plain substrings: they are free text, not
+    # numeric prefixes of each other.
+    pr_patterns = [
+        re.compile(rf"(?:#|/pull/){n}(?!\d)")
+        for n in sorted({int(x) for x in pr_numbers})
+    ]
+    branch_needles = {b for b in branches.values() if b}
     for f in files:
         try:
+            # Streamed line by line rather than read() in full: transcripts are
+            # JSONL and can be very large, and no needle contains a newline, so
+            # a per-line scan is equivalent (CodeRabbit, PR #115).
             with open(f, encoding="utf-8", errors="replace") as fh:
-                content = fh.read()
+                for line in fh:
+                    if any(p.search(line) for p in pr_patterns):
+                        return
+                    if any(b in line for b in branch_needles):
+                        return
         except OSError:
             continue
-        if any(needle in content for needle in needles):
-            return
     pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
     branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
     sys.exit(

--- a/skills/retro/scripts/retro_scan.py
+++ b/skills/retro/scripts/retro_scan.py
@@ -649,7 +649,8 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     one of `pr_numbers` (as "#N" or ".../pull/N", matched with a non-digit
     right boundary so "#1050" is not evidence for PR 105) or one of
     `branches.values()`
-    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    (the PRs' head branch names, from scan_prs(), matched literally between
+    ref-name boundaries). No-op when pr_numbers is
     empty (transcript-only scans are unaffected)."""
     if not pr_numbers:
         return
@@ -658,13 +659,22 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # only ever mentions #1050 satisfied the check for PR 105 — exactly the
     # misattribution this gate exists to stop. The numeric forms therefore
     # require a non-digit right boundary ("#" / "/pull/" already supplies the
-    # left one). Branch names stay plain substrings: they are free text, not
-    # numeric prefixes of each other.
+    # left one). Branch names get the same treatment (CodeRabbit, second
+    # round): "feature/fixes" is not evidence for head branch "feature/fix",
+    # and "hotfix" is not evidence for "fix". They are matched literally
+    # (re.escape — a branch name is free text, not a pattern) between ref-name
+    # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
+    # different branch, while the left boundary allows "/" so a remote-prefixed
+    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
+    # because it is far more often sentence punctuation than part of a ref.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
-    branch_needles = {b for b in branches.values() if b}
+    branch_patterns = [
+        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        for b in sorted({b for b in branches.values() if b})
+    ]
     for f in files:
         try:
             # Streamed line by line rather than read() in full: transcripts are
@@ -674,7 +684,7 @@ def verify_transcript_attribution(files, pr_numbers, branches):
                 for line in fh:
                     if any(p.search(line) for p in pr_patterns):
                         return
-                    if any(b in line for b in branch_needles):
+                    if any(p.search(line) for p in branch_patterns):
                         return
         except OSError:
             continue

--- a/skills/retro/scripts/retro_scan.py
+++ b/skills/retro/scripts/retro_scan.py
@@ -665,14 +665,21 @@ def verify_transcript_attribution(files, pr_numbers, branches):
     # (re.escape — a branch name is free text, not a pattern) between ref-name
     # boundaries: the right boundary also excludes "/" so "feature/fix/2" is a
     # different branch, while the left boundary allows "/" so a remote-prefixed
-    # mention ("origin/feature/fix") still counts. "." is allowed on both sides
-    # because it is far more often sentence punctuation than part of a ref.
+    # mention ("origin/feature/fix") still counts. "." is a legal ref character
+    # but in a transcript it is usually sentence punctuation, so it ends the
+    # ref only when what sits on the far side of it is not ref-name material:
+    # "on feature/fix." counts, "feature/fix.next" and "feature.fix" (both
+    # different branches) do not.
     pr_patterns = [
         re.compile(rf"(?:#|/pull/){n}(?!\d)")
         for n in sorted({int(x) for x in pr_numbers})
     ]
     branch_patterns = [
-        re.compile(rf"(?<![0-9A-Za-z_-]){re.escape(b)}(?![0-9A-Za-z_/-])")
+        re.compile(
+            rf"(?<![0-9A-Za-z_-])(?<![0-9A-Za-z_-]\.)"
+            rf"{re.escape(b)}"
+            rf"(?![0-9A-Za-z_/-])(?!\.[0-9A-Za-z_/-])"
+        )
         for b in sorted({b for b in branches.values() if b})
     ]
     for f in files:

--- a/skills/retro/scripts/retro_scan.py
+++ b/skills/retro/scripts/retro_scan.py
@@ -408,7 +408,25 @@ def render_table(rows):
 _FIXED_RE = re.compile(r"fixed\s+in\s+`?[0-9a-f]{7,40}\b", re.I)
 _PUSHBACK_RE = re.compile(
     r"maintainer\s*判断|self-resolve\s*しません|pushback", re.I)
-_ISSUE_REF_RE = re.compile(r"/issues/\d+|\bissues?\s+#\d+", re.I)
+# F11: the original pattern required the literal word "issue(s)" immediately
+# before "#NNN", so defer replies written as "Tracked in #114" / "Deferred to
+# #113" (no "issue" word, no /issues/ URL) matched nothing and the thread fell
+# through to UNTERMINATED even though it had a real terminal defer reply.
+# Widened to also match "#NNN" co-occurring with a defer/reference context
+# word (tracked/deferred/follow-up/see/ref/→) within a short window directly
+# before it — proximity-bound so a stray "#123" elsewhere in the reply (a
+# cross-referenced PR number, a code-comment ticket number) does not
+# false-positive just because the reply separately contains defer wording
+# (_DEFER_RE is checked independently over the whole reply by classify_thread;
+# only this proximity requirement is what keeps overmatching bounded).
+_ISSUE_REF_RE = re.compile(
+    r"/issues/\d+"
+    r"|\bissues?\s+#\d+"
+    r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
+    r"[^\n#]{0,20}#\d+"
+    r"|→\s*#\d+",
+    re.I,
+)
 _DEFER_RE = re.compile(r"defer|follow[- ]?up|後続|別途|追跡|track", re.I)
 # Tradeoff: a fix reply that merely cross-references another thread
 # (#discussion_r...) is misread as DUPLICATE — accepted for this pre-read;
@@ -461,6 +479,7 @@ _THREADS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
+      headRefName
       reviewThreads(first: 50, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
@@ -537,14 +556,19 @@ def _graphql(query, fields):
 
 
 def fetch_review_threads(owner, name, number):
-    """All review threads of one PR, comments fully paginated per thread."""
+    """All review threads of one PR (comments fully paginated per thread),
+    plus the PR's head branch name — used by verify_transcript_attribution()
+    to confirm a transcript actually belongs to this PR's session."""
     threads, cursor = [], None
+    head_ref_name = None
     for _ in range(_MAX_PAGES):
         data = _graphql(_THREADS_QUERY, {"owner": owner, "name": name,
                                          "number": number, "cursor": cursor})
         pr = (data.get("repository") or {}).get("pullRequest")
         if pr is None:
             sys.exit(f"PR #{number} not found in {owner}/{name}")
+        if head_ref_name is None:
+            head_ref_name = pr.get("headRefName")
         conn = pr["reviewThreads"]
         for node in conn["nodes"]:
             bodies = [c.get("body") for c in node["comments"]["nodes"]]
@@ -568,7 +592,7 @@ def fetch_review_threads(owner, name, number):
                             "resolved": bool(node["isResolved"]),
                             "bodies": bodies})
         if not conn["pageInfo"]["hasNextPage"]:
-            return threads
+            return threads, head_ref_name
         cursor = conn["pageInfo"]["endCursor"]
     sys.exit(f"PR #{number}: thread pagination exceeded {_MAX_PAGES} pages")
 
@@ -587,9 +611,12 @@ def scan_prs(pr_numbers, repo_arg):
     repo = resolve_repo(repo_arg)
     owner, name = repo.split("/", 1)
     prs = {}
+    branches = {}
     for number in sorted(set(pr_numbers)):
         threads = []
-        for node in fetch_review_threads(owner, name, number):
+        nodes, head_ref_name = fetch_review_threads(owner, name, number)
+        branches[str(number)] = head_ref_name
+        for node in nodes:
             # path is API-derived but still sanitized before the output fork —
             # same contract as summary (--json must not pass ANSI/C0 through).
             path = strip_controls(node["path"])
@@ -602,7 +629,50 @@ def scan_prs(pr_numbers, repo_arg):
                 "resolved": node["resolved"],
             })
         prs[str(number)] = threads
-    return {"repo": repo, "prs": prs}
+    return {"repo": repo, "prs": prs, "branches": branches}
+
+
+# F10: PR-scoped analysis previously trusted whatever transcript(s) were
+# selected (often via the --latest fallback) without ever checking that the
+# transcript actually belongs to the session that produced the PR under
+# review — this caused a real misattribution where retro analyzed an
+# unrelated session. verify_transcript_attribution() is the fail-closed check:
+# when --pr is combined with a transcript scan, at least one scanned file must
+# reference the PR (by number/URL) or its head branch, or the run aborts.
+def verify_transcript_attribution(files, pr_numbers, branches):
+    """Exit with TRANSCRIPT_MISMATCH unless at least one of `files` mentions
+    one of `pr_numbers` (as "#N" or ".../pull/N") or one of `branches.values()`
+    (the PRs' head branch names, from scan_prs()). No-op when pr_numbers is
+    empty (transcript-only scans are unaffected)."""
+    if not pr_numbers:
+        return
+    needles = set()
+    for n in pr_numbers:
+        needles.add(f"#{n}")
+        needles.add(f"/pull/{n}")
+    for b in branches.values():
+        if b:
+            needles.add(b)
+    if not needles:
+        return
+    for f in files:
+        try:
+            with open(f, encoding="utf-8", errors="replace") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        if any(needle in content for needle in needles):
+            return
+    pr_list = ", ".join(f"#{n}" for n in sorted(set(pr_numbers)))
+    branch_list = ", ".join(sorted({b for b in branches.values() if b})) or "(none)"
+    sys.exit(
+        f"TRANSCRIPT_MISMATCH: none of the {len(files)} scanned transcript(s) "
+        f"mention PR {pr_list} (checked for the PR number/URL and head "
+        f"branch(es) {branch_list}) — the selected transcript(s) likely do "
+        "not belong to the session that produced this PR. Pass the correct "
+        "--transcript explicitly instead of relying on --latest, or drop "
+        "--pr if this scan is not meant to be PR-scoped."
+    )
 
 
 def render_pr_report(data):
@@ -734,6 +804,9 @@ def main():
     # GraphQL calls spend API rate limit (r3695744834).
     if args.pr:
         pr_data = scan_prs(args.pr, args.repo)
+        # F10: fail closed before the (expensive) duckdb scan runs if none of
+        # the selected transcripts actually belong to the PR(s) under review.
+        verify_transcript_attribution(files, args.pr, pr_data["branches"])
 
     try:
         import duckdb

--- a/skills/retro/scripts/retro_scan.py
+++ b/skills/retro/scripts/retro_scan.py
@@ -423,7 +423,12 @@ _ISSUE_REF_RE = re.compile(
     r"/issues/\d+"
     r"|\bissues?\s+#\d+"
     r"|\b(?:track(?:ed|ing)?|defer(?:red|ring)?|follow[- ]?up|see|ref(?:erence)?d?)\b"
-    r"[^\n#]{0,20}#\d+"
+    # The gap may not contain an explicit "PR" label right before the number:
+    # "Tracked in PR #114" / "see PR #123" cross-reference a pull request, not
+    # a follow-up issue, and counting them let a defer reply claim a tracking
+    # issue that does not exist (PR #115 review, Devin). Bare "#NNN" after the
+    # context word — the form F11 widened this regex for — still matches.
+    r"(?:(?![Pp][Rr]\s*#)[^\n#]){0,20}#\d+"
     r"|→\s*#\d+",
     re.I,
 )

--- a/tests/test_retro_pr_classification.py
+++ b/tests/test_retro_pr_classification.py
@@ -165,6 +165,57 @@ class TestBoundaries(unittest.TestCase):
         self.assertEqual(
             classify([FINDING, "後続で検討します"]), "UNTERMINATED")
 
+    def test_tracked_in_bare_issue_number_is_defer(self) -> None:
+        # F11: "Tracked in #114" は issue URL でも "issue #N" でもない —
+        # 従来の _ISSUE_REF_RE は "issue" という語を要求しており、この形の defer
+        # 表記を拾えず UNTERMINATED に誤判定していた
+        self.assertEqual(
+            classify([FINDING, "Tracked in #114"]), "VALID_DEFER")
+
+    def test_deferred_to_bare_issue_number_is_defer(self) -> None:
+        self.assertEqual(
+            classify([FINDING, "Deferred to #113"]), "VALID_DEFER")
+
+    def test_arrow_bare_issue_number_with_defer_wording_is_defer(self) -> None:
+        self.assertEqual(
+            classify([FINDING, "後続対応します → #120"]), "VALID_DEFER")
+
+    def test_bare_hash_number_without_context_word_is_not_defer(self) -> None:
+        # 過剰マッチガード: 返信中に defer 語 (後続) があっても、#NNN の直前に
+        # 文脈語 (tracked/deferred/issue/→ 等) が無ければ issue 参照とみなさない
+        # (コード中の #123 コメントや無関係な PR 参照を defer と誤認しない)
+        self.assertEqual(
+            classify([FINDING, "後続で検討します。関連 PR #123 を見てください"]),
+            "UNTERMINATED",
+        )
+
+
+class TestIssueRefRegex(unittest.TestCase):
+    """F11: _ISSUE_REF_RE 単体の境界確認 (classify_thread 経由だと _DEFER_RE との
+    共起判定に埋もれるため、regex 自体の挙動を直接固定する)。"""
+
+    def test_matches_tracked_in_bare_number(self) -> None:
+        self.assertIsNotNone(retro_scan._ISSUE_REF_RE.search("Tracked in #114"))
+
+    def test_matches_deferred_to_bare_number(self) -> None:
+        self.assertIsNotNone(retro_scan._ISSUE_REF_RE.search("Deferred to #113"))
+
+    def test_matches_arrow_bare_number(self) -> None:
+        self.assertIsNotNone(retro_scan._ISSUE_REF_RE.search("→ #120"))
+
+    def test_matches_issue_word_plus_number(self) -> None:
+        self.assertIsNotNone(retro_scan._ISSUE_REF_RE.search("issue #7"))
+
+    def test_matches_issues_url(self) -> None:
+        self.assertIsNotNone(
+            retro_scan._ISSUE_REF_RE.search("https://github.com/o/r/issues/9"))
+
+    def test_does_not_match_bare_number_without_context(self) -> None:
+        self.assertIsNone(retro_scan._ISSUE_REF_RE.search("関連 PR #123 を見てください"))
+
+    def test_does_not_match_hex_color_like_token(self) -> None:
+        self.assertIsNone(retro_scan._ISSUE_REF_RE.search("background: #123456;"))
+
 
 class TestClassInventory(unittest.TestCase):
     def test_thread_classes_cover_the_six_terminals(self) -> None:

--- a/tests/test_retro_pr_classification.py
+++ b/tests/test_retro_pr_classification.py
@@ -190,6 +190,16 @@ class TestBoundaries(unittest.TestCase):
         )
 
 
+    def test_labeled_pr_reference_with_defer_wording_is_not_defer(self) -> None:
+        # PR #115 review (Devin): "Tracked in PR #114" carries defer wording and
+        # a #NNN, but names a PR — there is no follow-up issue, so the thread is
+        # not terminated as VALID_DEFER.
+        self.assertEqual(
+            classify([FINDING, "Tracked in PR #114"]), "UNTERMINATED")
+        self.assertEqual(
+            classify([FINDING, "defer this; see PR #123"]), "UNTERMINATED")
+
+
 class TestIssueRefRegex(unittest.TestCase):
     """F11: _ISSUE_REF_RE 単体の境界確認 (classify_thread 経由だと _DEFER_RE との
     共起判定に埋もれるため、regex 自体の挙動を直接固定する)。"""
@@ -215,6 +225,24 @@ class TestIssueRefRegex(unittest.TestCase):
 
     def test_does_not_match_hex_color_like_token(self) -> None:
         self.assertIsNone(retro_scan._ISSUE_REF_RE.search("background: #123456;"))
+
+    def test_does_not_match_explicitly_labeled_pr_reference(self) -> None:
+        # PR #115 review (Devin): a context word followed by an explicit "PR"
+        # label is a pull-request cross-reference, not a follow-up issue —
+        # counting it made replies claim a deferral target that never exists.
+        for text in ("Tracked in PR #114",
+                     "defer this; see PR #123",
+                     "follow-up は pr#99 側で扱う",
+                     "Deferred — see PR  #7"):
+            with self.subTest(text=text):
+                self.assertIsNone(retro_scan._ISSUE_REF_RE.search(text))
+
+    def test_still_matches_bare_number_after_context_word(self) -> None:
+        # The PR-label exclusion must not swallow the bare-number defer forms
+        # F11 widened the regex for in the first place.
+        for text in ("Tracked in #114", "see #120", "follow-up: #7"):
+            with self.subTest(text=text):
+                self.assertIsNotNone(retro_scan._ISSUE_REF_RE.search(text))
 
 
 class TestClassInventory(unittest.TestCase):

--- a/tests/test_retro_scan.py
+++ b/tests/test_retro_scan.py
@@ -318,6 +318,47 @@ class TestTranscriptAttributionVerification(unittest.TestCase):
                     retro_scan.verify_transcript_attribution(
                         [f], [105], {"105": None})
 
+    def test_rejects_branch_name_that_is_only_a_prefix_of_another(self) -> None:
+        # PR #115 review (CodeRabbit): a plain substring test accepted
+        # "feature/fixes" as evidence for head branch "feature/fix".
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl",
+                             '{"text":"git switch feature/fixes"}\n')
+            with self.assertRaises(SystemExit) as ctx:
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": "feature/fix"})
+            self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
+
+    def test_rejects_branch_name_that_is_only_a_suffix_of_another(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl",
+                             '{"text":"git switch hotfix"}\n')
+            with self.assertRaises(SystemExit):
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": "fix"})
+
+    def test_accepts_branch_name_at_a_ref_boundary(self) -> None:
+        # Quoting, surrounding punctuation, a remote prefix and end-of-line are
+        # all still genuine mentions of the branch.
+        for text in ('{"text":"git switch -c feature/fix"}\n',
+                     '{"text":"pushed origin/feature/fix"}\n',
+                     '{"text":"on feature/fix."}\n',
+                     '{"text":"branch=feature/fix'):
+            with self.subTest(text=text):
+                with tempfile.TemporaryDirectory() as tmp:
+                    f = self._write(Path(tmp) / "s.jsonl", text)
+                    retro_scan.verify_transcript_attribution(
+                        [f], [105], {"105": "feature/fix"})
+
+    def test_branch_name_is_matched_literally_not_as_regex(self) -> None:
+        # A branch name is free text; regex metacharacters in it must not be
+        # interpreted (". " is not a wildcard).
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl", '{"text":"fix/aXb"}\n')
+            with self.assertRaises(SystemExit):
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": "fix/a.b"})
+
     def test_rejects_pr_number_preceded_by_digits(self) -> None:
         # "#2105" is PR 2105, not PR 105 — the left side needs a boundary too.
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_retro_scan.py
+++ b/tests/test_retro_scan.py
@@ -292,6 +292,40 @@ class TestTranscriptAttributionVerification(unittest.TestCase):
             self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
             self.assertIn("#105", str(ctx.exception.code))
 
+    def test_rejects_longer_pr_number_that_only_shares_a_prefix(self) -> None:
+        # A transcript that mentions #1050 / /pull/1050 must NOT satisfy the
+        # attribution check for PR 105: substring matching let an unrelated
+        # session's transcript pass (PR #115 review, Devin + CodeRabbit).
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(
+                Path(tmp) / "s.jsonl",
+                '{"text":"opened PR #1050 https://github.com/o/r/pull/1050"}\n')
+            with self.assertRaises(SystemExit) as ctx:
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": None})
+            self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
+
+    def test_accepts_pr_number_followed_by_non_digit(self) -> None:
+        # The boundary is "not another digit" — punctuation, whitespace and
+        # end-of-file all still count as a genuine reference.
+        for text in ('{"text":"#105"}\n',
+                     '{"text":"see #105, then merge"}\n',
+                     '{"text":"https://github.com/o/r/pull/105#issuecomment-1"}\n',
+                     '{"text":"https://github.com/o/r/pull/105"}'):
+            with self.subTest(text=text):
+                with tempfile.TemporaryDirectory() as tmp:
+                    f = self._write(Path(tmp) / "s.jsonl", text)
+                    retro_scan.verify_transcript_attribution(
+                        [f], [105], {"105": None})
+
+    def test_rejects_pr_number_preceded_by_digits(self) -> None:
+        # "#2105" is PR 2105, not PR 105 — the left side needs a boundary too.
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl", '{"text":"see #2105"}\n')
+            with self.assertRaises(SystemExit):
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": None})
+
     def test_unreadable_file_is_skipped_not_fatal(self) -> None:
         # A missing/unreadable file must not itself raise — it's treated like
         # a non-matching file, and the overall mismatch (if any) still exits

--- a/tests/test_retro_scan.py
+++ b/tests/test_retro_scan.py
@@ -381,9 +381,21 @@ class TestPrScanOrdering(unittest.TestCase):
 
     def test_matching_transcript_passes_verification(self) -> None:
         # A transcript that does reference the PR must clear verification and
-        # reach the duckdb stage (the bundled stub module has no `connect`,
-        # so an AttributeError there is evidence execution got past the
-        # TRANSCRIPT_MISMATCH check rather than being blocked by it).
+        # reach the duckdb stage. Evidence is taken from an explicitly injected
+        # duckdb module whose connect() raises a sentinel, plus a spy on
+        # verify_transcript_attribution: the previous version inferred "we got
+        # past verification" from an AttributeError raised by the bundled stub,
+        # but sys.modules.setdefault() does not replace a real duckdb, so that
+        # assertion silently depended on duckdb being absent from the
+        # environment (PR #115 review, CodeRabbit).
+        sentinel = RuntimeError("reached the duckdb stage")
+
+        def boom(*args, **kwargs):
+            raise sentinel
+
+        fake_duckdb = types.ModuleType("duckdb")
+        fake_duckdb.connect = boom
+
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "session.jsonl"
             transcript.write_text('{"text":"opened PR #105"}\n', encoding="utf-8")
@@ -393,10 +405,21 @@ class TestPrScanOrdering(unittest.TestCase):
                         "branches": {"105": None}}
 
             argv = ["retro_scan.py", "--transcript", str(transcript), "--pr", "105"]
-            with mock.patch.object(retro_scan, "scan_prs", fake_scan_prs), \
+            with mock.patch.object(
+                    retro_scan, "verify_transcript_attribution",
+                    wraps=retro_scan.verify_transcript_attribution) as verify, \
+                    mock.patch.dict(sys.modules, {"duckdb": fake_duckdb}), \
+                    mock.patch.object(retro_scan, "scan_prs", fake_scan_prs), \
                     mock.patch.object(sys, "argv", argv):
-                with self.assertRaises(AttributeError):
+                with self.assertRaises(RuntimeError) as ctx:
                     retro_scan.main()
+
+        self.assertIs(ctx.exception, sentinel)
+        verify.assert_called_once()
+        called_files, called_prs, called_branches = verify.call_args.args
+        self.assertEqual([str(transcript)], [str(f) for f in called_files])
+        self.assertEqual([105], list(called_prs))
+        self.assertEqual({"105": None}, called_branches)
 
 
 if __name__ == "__main__":

--- a/tests/test_retro_scan.py
+++ b/tests/test_retro_scan.py
@@ -350,6 +350,21 @@ class TestTranscriptAttributionVerification(unittest.TestCase):
                     retro_scan.verify_transcript_attribution(
                         [f], [105], {"105": "feature/fix"})
 
+    def test_rejects_dotted_branch_extensions(self) -> None:
+        # PR #115 review (Devin + CodeRabbit): "." is a legal ref character, so
+        # treating it as a boundary unconditionally let "feature/fix.next" and
+        # "feature.fix" — different branches — count as evidence. A "." only
+        # ends the ref when what follows it is not itself ref-name material.
+        cases = [("feature/fix", '{"text":"switched to feature/fix.next"}\n'),
+                 ("feature", '{"text":"switched to feature.fix"}\n')]
+        for branch, text in cases:
+            with self.subTest(branch=branch):
+                with tempfile.TemporaryDirectory() as tmp:
+                    f = self._write(Path(tmp) / "s.jsonl", text)
+                    with self.assertRaises(SystemExit):
+                        retro_scan.verify_transcript_attribution(
+                            [f], [105], {"105": branch})
+
     def test_branch_name_is_matched_literally_not_as_regex(self) -> None:
         # A branch name is free text; regex metacharacters in it must not be
         # interpreted (". " is not a wildcard).

--- a/tests/test_retro_scan.py
+++ b/tests/test_retro_scan.py
@@ -241,6 +241,67 @@ class TestSlugCollisionGuard(unittest.TestCase):
             self.assertNotIn(no_cwd, found)
 
 
+class TestTranscriptAttributionVerification(unittest.TestCase):
+    """F10: a PR-scoped scan must confirm the selected transcript(s) actually
+    belong to the PR under review (number/URL or head branch present
+    somewhere in the file) before continuing — a --latest fallback pick can
+    silently be an unrelated session."""
+
+    def _write(self, path: Path, content: str) -> str:
+        path.write_text(content, encoding="utf-8")
+        return str(path)
+
+    def test_noop_when_no_pr_numbers(self) -> None:
+        # Transcript-only scans (no --pr) must not be affected.
+        retro_scan.verify_transcript_attribution(["/does/not/exist.jsonl"], [], {})
+
+    def test_passes_when_pr_number_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl",
+                             '{"text":"opened PR #105 for review"}\n')
+            retro_scan.verify_transcript_attribution([f], [105], {"105": None})
+
+    def test_passes_when_pull_url_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl",
+                             '{"text":"https://github.com/o/r/pull/105"}\n')
+            retro_scan.verify_transcript_attribution([f], [105], {"105": None})
+
+    def test_passes_when_head_branch_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(
+                Path(tmp) / "s.jsonl",
+                '{"text":"git switch -c harness/retro-fixes-f9-f11-f17"}\n')
+            retro_scan.verify_transcript_attribution(
+                [f], [105], {"105": "harness/retro-fixes-f9-f11-f17"})
+
+    def test_passes_when_any_of_multiple_files_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            unrelated = self._write(Path(tmp) / "a.jsonl", '{"text":"unrelated"}\n')
+            matching = self._write(Path(tmp) / "b.jsonl", '{"text":"see #105"}\n')
+            retro_scan.verify_transcript_attribution(
+                [unrelated, matching], [105], {"105": None})
+
+    def test_exits_transcript_mismatch_when_nothing_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = self._write(Path(tmp) / "s.jsonl",
+                             '{"text":"totally unrelated session"}\n')
+            with self.assertRaises(SystemExit) as ctx:
+                retro_scan.verify_transcript_attribution(
+                    [f], [105], {"105": "some-other-branch"})
+            self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
+            self.assertIn("#105", str(ctx.exception.code))
+
+    def test_unreadable_file_is_skipped_not_fatal(self) -> None:
+        # A missing/unreadable file must not itself raise — it's treated like
+        # a non-matching file, and the overall mismatch (if any) still exits
+        # cleanly with TRANSCRIPT_MISMATCH rather than an OSError traceback.
+        with self.assertRaises(SystemExit) as ctx:
+            retro_scan.verify_transcript_attribution(
+                ["/does/not/exist.jsonl"], [105], {"105": None})
+        self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
+
+
 class TestPrScanOrdering(unittest.TestCase):
     """--pr 併用 (非 standalone) 時、transcript 探索の失敗は gh API 呼び出し
     より先に検出する — 引数の誤りで exit する起動が API レート制限を消費
@@ -264,6 +325,44 @@ class TestPrScanOrdering(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 retro_scan.main()
         self.assertEqual(calls, ["discover"])
+
+    def test_mismatched_transcript_exits_before_duckdb_stage(self) -> None:
+        # F10: main() wires --transcript + --pr through
+        # verify_transcript_attribution() before reaching the duckdb import —
+        # a mismatch must abort with TRANSCRIPT_MISMATCH, not silently scan.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "session.jsonl"
+            transcript.write_text('{"text":"unrelated session"}\n', encoding="utf-8")
+
+            def fake_scan_prs(pr_numbers, repo_arg):
+                return {"repo": "o/r", "prs": {"105": []},
+                        "branches": {"105": "some-other-branch"}}
+
+            argv = ["retro_scan.py", "--transcript", str(transcript), "--pr", "105"]
+            with mock.patch.object(retro_scan, "scan_prs", fake_scan_prs), \
+                    mock.patch.object(sys, "argv", argv):
+                with self.assertRaises(SystemExit) as ctx:
+                    retro_scan.main()
+            self.assertIn("TRANSCRIPT_MISMATCH", str(ctx.exception.code))
+
+    def test_matching_transcript_passes_verification(self) -> None:
+        # A transcript that does reference the PR must clear verification and
+        # reach the duckdb stage (the bundled stub module has no `connect`,
+        # so an AttributeError there is evidence execution got past the
+        # TRANSCRIPT_MISMATCH check rather than being blocked by it).
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = Path(tmp) / "session.jsonl"
+            transcript.write_text('{"text":"opened PR #105"}\n', encoding="utf-8")
+
+            def fake_scan_prs(pr_numbers, repo_arg):
+                return {"repo": "o/r", "prs": {"105": []},
+                        "branches": {"105": None}}
+
+            argv = ["retro_scan.py", "--transcript", str(transcript), "--pr", "105"]
+            with mock.patch.object(retro_scan, "scan_prs", fake_scan_prs), \
+                    mock.patch.object(sys, "argv", argv):
+                with self.assertRaises(AttributeError):
+                    retro_scan.main()
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_jq.py
+++ b/tests/test_workflow_jq.py
@@ -1,0 +1,217 @@
+"""Behaviour tests for the jq programs embedded in the gate workflows.
+
+`review-response-gate` and `gate-heartbeat` carry their whole decision in a
+single-quoted jq program inside `run:`. actionlint only checks the YAML/shell
+shape, so the classification itself was unpinned — the two findings fixed in
+PR #115 (a bot's own follow-up counting as a response; `pr_closed` records
+counted instead of distinct PRs) were both invisible to CI.
+
+These tests lift each jq program straight out of the workflow file (so the
+workflow stays the single source of truth) and run it against fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+GATE = REPO_ROOT / ".github" / "workflows" / "review-response-gate.yml"
+HEARTBEAT = REPO_ROOT / ".github" / "workflows" / "gate-heartbeat.yml"
+
+
+def extract_jq(path: pathlib.Path, start_marker: str) -> str:
+    """Return the single-quoted jq program that starts on the line containing
+    `start_marker`. The program ends at the first following line whose first
+    non-blank character is the closing quote (a single quote cannot occur
+    inside a shell single-quoted string, so this is unambiguous)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    starts = [i for i, line in enumerate(lines) if start_marker in line]
+    if len(starts) != 1:
+        raise AssertionError(
+            f"{path.name}: expected exactly one line containing "
+            f"{start_marker!r}, found {len(starts)}")
+    head = lines[starts[0]].split("'", 1)
+    if len(head) != 2:
+        raise AssertionError(f"{path.name}: no opening quote on start line")
+    body = [head[1]] if head[1].strip() else []
+    for line in lines[starts[0] + 1:]:
+        if line.strip().startswith("'"):
+            return "\n".join(body)
+        body.append(line)
+    raise AssertionError(f"{path.name}: unterminated jq program")
+
+
+def run_jq(program: str, *args: str, stdin: str = "") -> str:
+    proc = subprocess.run(["jq", *args, program], input=stdin,
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise AssertionError(f"jq failed: {proc.stderr}")
+    return proc.stdout
+
+
+def bot(login: str) -> dict:
+    return {"login": login, "__typename": "Bot"}
+
+
+def user(login: str) -> dict:
+    return {"login": login, "__typename": "User"}
+
+
+def thread(url: str, resolved: bool, authors: list[dict]) -> dict:
+    return {
+        "id": url,
+        "isResolved": resolved,
+        "path": "some/file.py",
+        "comments": {
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [{"databaseId": i, "url": url, "author": a}
+                      for i, a in enumerate(authors)],
+        },
+    }
+
+
+class ReviewResponseGateFilterTest(unittest.TestCase):
+    """Which threads the gate reports as "unanswered bot finding"."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.program = extract_jq(GATE, "failing=$(jq -c")
+
+    def failing_urls(self, threads: list[dict]) -> set[str]:
+        out = run_jq(self.program, "-c", stdin=json.dumps(threads))
+        return {row["url"] for row in json.loads(out)}
+
+    def test_unanswered_bot_thread_fails(self) -> None:
+        threads = [thread("u1", False, [bot("coderabbitai")])]
+        self.assertEqual({"u1"}, self.failing_urls(threads))
+
+    def test_resolved_thread_is_ignored(self) -> None:
+        threads = [thread("u1", True, [bot("coderabbitai")])]
+        self.assertEqual(set(), self.failing_urls(threads))
+
+    def test_human_originated_thread_is_ignored(self) -> None:
+        threads = [thread("u1", False, [user("kanade0404")])]
+        self.assertEqual(set(), self.failing_urls(threads))
+
+    def test_human_reply_answers_the_finding(self) -> None:
+        threads = [thread("u1", False, [bot("devin-ai-integration"),
+                                        user("kanade0404")])]
+        self.assertEqual(set(), self.failing_urls(threads))
+
+    def test_author_agent_reply_answers_the_finding(self) -> None:
+        # Replies posted by the PR author's own automation (the repo's
+        # workflows run as github-actions[bot]; the Claude app as claude[bot])
+        # are PR-side responses and must clear the gate — otherwise a headless
+        # pr-review-respond run could never turn this check green.
+        for login in ("github-actions[bot]", "claude[bot]"):
+            with self.subTest(login=login):
+                threads = [thread("u1", False, [bot("coderabbitai"),
+                                                bot(login)])]
+                self.assertEqual(set(), self.failing_urls(threads))
+
+    def test_reviewer_own_follow_up_does_not_answer_the_finding(self) -> None:
+        # PR #115 review (Devin): counting *any* second comment let a reviewer
+        # bot answer its own finding, so the gate went green with the finding
+        # still unanswered by the PR side.
+        threads = [thread("u1", False, [bot("devin-ai-integration"),
+                                        bot("devin-ai-integration")])]
+        self.assertEqual({"u1"}, self.failing_urls(threads))
+
+    def test_other_review_bot_reply_does_not_answer_the_finding(self) -> None:
+        threads = [thread("u1", False, [bot("devin-ai-integration"),
+                                        bot("coderabbitai")])]
+        self.assertEqual({"u1"}, self.failing_urls(threads))
+
+    def test_reports_every_unanswered_thread(self) -> None:
+        threads = [
+            thread("u1", False, [bot("coderabbitai")]),
+            thread("u2", False, [bot("copilot-pull-request-reviewer[bot]")]),
+            thread("u3", False, [bot("coderabbitai"), user("kanade0404")]),
+            thread("u4", True, [bot("coderabbitai")]),
+        ]
+        self.assertEqual({"u1", "u2"}, self.failing_urls(threads))
+
+
+class GateHeartbeatMetricsTest(unittest.TestCase):
+    """How the heartbeat counts its alert denominator."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.program = extract_jq(HEARTBEAT, "RESULT=$(jq -n")
+
+    def metrics(self, events: list[dict], repo: str = "o/r") -> dict:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "events.json"
+            path.write_text("\n".join(json.dumps(e) for e in events),
+                            encoding="utf-8")
+            out = run_jq(self.program, "-n",
+                         "--argjson", "window_days", "30",
+                         "--arg", "repo", repo,
+                         "--slurpfile", "events", str(path))
+        return json.loads(out)
+
+    @staticmethod
+    def _ts(days_ago: float) -> str:
+        moment = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def closed(self, pr: int, outcome: str, days_ago: float = 1,
+               repo: str = "o/r") -> dict:
+        return {"v": 1, "ts": self._ts(days_ago), "event": "pr_closed",
+                "repo": repo, "pr": pr, "outcome": outcome}
+
+    def test_counts_distinct_prs_not_records(self) -> None:
+        # PR #115 review (CodeRabbit): loop-metrics emits one pr_closed record
+        # per close event, so a reopened-then-reclosed PR (or a re-run of the
+        # workflow) inflates the denominator that gates the alert.
+        events = [
+            self.closed(42, "merged", days_ago=3),
+            self.closed(42, "closed", days_ago=2),
+            self.closed(42, "merged", days_ago=1),
+            self.closed(43, "closed", days_ago=1),
+        ]
+        result = self.metrics(events)
+        self.assertEqual(2, result["attempted_prs"])
+        self.assertEqual(1, result["merged_prs"])
+
+    def test_counts_each_pr_once_per_window(self) -> None:
+        events = [self.closed(1, "merged"), self.closed(2, "merged"),
+                  self.closed(3, "closed")]
+        result = self.metrics(events)
+        self.assertEqual(3, result["attempted_prs"])
+        self.assertEqual(2, result["merged_prs"])
+
+    def test_other_repositories_are_excluded(self) -> None:
+        events = [self.closed(1, "merged"), self.closed(2, "merged",
+                                                        repo="other/repo")]
+        result = self.metrics(events)
+        self.assertEqual(1, result["attempted_prs"])
+        self.assertEqual(1, result["merged_prs"])
+
+    def test_events_outside_the_window_are_excluded(self) -> None:
+        events = [self.closed(1, "merged", days_ago=45),
+                  self.closed(2, "merged", days_ago=2)]
+        result = self.metrics(events)
+        self.assertEqual(1, result["attempted_prs"])
+
+    def test_gate_events_still_counted_per_record(self) -> None:
+        # gate runs are per-invocation signals, not per-PR: they stay a raw
+        # record count.
+        events = [
+            {"v": 1, "ts": self._ts(1), "event": "agent_run", "repo": "o/r",
+             "phase": "test-mutation-gate", "result_subtype": "pass"},
+            {"v": 1, "ts": self._ts(1), "event": "agent_run", "repo": "o/r",
+             "phase": "test-mutation-gate", "result_subtype": "block"},
+        ]
+        result = self.metrics(events)
+        self.assertEqual(2, result["gate_events"])
+        self.assertEqual(1, result["gate_blocks"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the 4 retro-approved fixes (F9 / F10 / F11 / F17) from the last
session's retrospective.

### F11 -- `retro_scan.py` issue-ref regex under-matched defer replies

`_ISSUE_REF_RE` required the literal word "issue(s)" immediately before
`#NNN`, so defer replies like "Tracked in #114" or "Deferred to #113" (no
"issue" word, no `/issues/` URL) matched nothing, and `classify_thread()`
mis-classified those threads as `UNTERMINATED` instead of `VALID_DEFER`.
Widened the regex to also match `#NNN` co-occurring with a defer/reference
context word (tracked/deferred/follow-up/see/ref/→) within a short window
directly before it -- tight enough that a stray `#123` elsewhere in a reply
doesn't false-positive on its own. RED-first tests in
`tests/test_retro_pr_classification.py`.

### F10 -- `retro_scan.py` never verified PR-scoped transcript attribution

A PR-scoped scan (`--pr` combined with a transcript scan) trusted whatever
transcript was selected -- often via the `--latest` fallback -- without
checking it actually belonged to the session that produced the PR under
review. This caused a real misattribution in the prior session. Added
`verify_transcript_attribution()`: it now fails closed with a
`TRANSCRIPT_MISMATCH` error (before the duckdb stage even runs) unless at
least one scanned transcript mentions the PR number/URL or its head branch
(fetched via a new `headRefName` field on the existing `reviewThreads`
GraphQL query). Tests in `tests/test_retro_scan.py` (unit + `main()`
integration).

### F9 -- `gate-heartbeat.yml` silent on zero-merge failure windows

The alert condition required `merged_prs >= MIN_MERGED_PRS`, so a failure
window where CI/review is stuck and nothing merges -- the situation that
most needs this sensor to fire -- always kept the sensor silent. Changed the
denominator to `attempted_prs` (merged + closed-without-merge), computed
from the same `pr_closed` events the workflow already fetches (both outcomes
are already emitted by `loop-metrics.yml`); no new event type was
introduced. `merged_prs` is still reported for context.

### F17 -- no gate against unanswered bot review threads

On PR #105, 4 Devin bot BUG findings were merged with zero replies -- nothing
structurally prevented it. Added
`.github/workflows/review-response-gate.yml`: a self-contained job (`gh api`
GraphQL only, no checkout) that fails when any **unresolved** review thread
whose root comment is **bot-authored** (CodeRabbit / Devin / Copilot etc.,
via GraphQL `__typename == "Bot"` plus the login-pattern fallback already
used in `skills/pr-review-respond/scripts/fetch_threads.sh`) has **zero
replies**. Any reply counts as answered -- content isn't judged, so reasoned
pushback (e.g. #111's deliberate non-fix) is never blocked.

**To make this a required check**: in GitHub Settings > Branches > branch
protection rules for the target branch, add `review-response-gate` under
"Require status checks to pass before merging". This PR does not touch
branch protection itself.

## Test plan

- [x] `python3 -m unittest discover -s tests -v` -- 159 tests, all green (1
      pre-existing skip, unrelated to this change)
- [x] `node scripts/rulesync-sync.mjs` regenerated the `.claude/` / `.agents/`
      mirrors of `retro_scan.py`; `node scripts/rulesync-sync.mjs --check` now
      reports up to date
- [x] `uv run --with duckdb python3 skills/retro/scripts/retro_scan.py --help`
      smoke-runs cleanly
- [x] `actionlint` clean on both touched/added workflow files
      (`gate-heartbeat.yml`, `review-response-gate.yml`); a pre-existing,
      unrelated shellcheck info in `consumer-update.yml` was left untouched
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbPXmV685LeYFLDSJv444V

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/skills/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 未返信の未解決レビューを自動検出し、通知するチェックを追加しました。
  - トランスクリプトと対象PRの番号、URL、ブランチ情報を照合し、不一致時は処理を停止します。
  - PRの延期・追跡に関する参照表現の認識範囲を拡張しました。
  - マージ済み・クローズ済みを含む完了済みPR全体を基準にアラート判定できるようになりました。

- **テスト**
  - PR参照形式、トランスクリプト照合、レビュー対応チェック、アラート判定の検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->